### PR TITLE
Resource Loading Errors on Windows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,16 +11,19 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java: [1.8]
+    name: HL7v2 FHIR Converter CI - OS ${{ matrix.os }} Java Version ${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 .classpath
 .project
 .settings/
+
+# Jetbrains IDEA
+.idea

--- a/src/main/java/io/github/linuxforhealth/hl7/resource/ResourceReader.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/resource/ResourceReader.java
@@ -84,9 +84,9 @@ public class ResourceReader {
         resource = loadClassPathResource(path.toString());
       }
     } catch (IOException ioEx) {
-      String msg = "Error loading resource from " + path.toString();
+      String msg = "Resource path  " + path.toString() + " is not valid";
       logger.error(msg, ioEx);
-      throw new RuntimeException(msg, ioEx);
+      throw new IllegalArgumentException(msg, ioEx);
     }
     return resource;
   }


### PR DESCRIPTION
This PR updates the ResourceReader to utilize InputStreams to resolve issues with loading resources from the classpath on Windows.

Updates include:
- ResourceReader updates to support stream i/o
- Updated GitHub Actions to run tests on Linux and Windows for Java 1.8