### PR TITLE
Resolve Issue With Loading Default Resources/Configurations From the Classpath

### DIFF
--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import io.github.linuxforhealth.core.Constants;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -44,12 +46,11 @@ public class FHIRConverterTest {
         + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
 
     HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, true, BundleType.TRANSACTION);
+    String json = ftv.convert(hl7message);
+    verifyResult(json, Constants.DEFAULT_BUNDLE_TYPE);
 
-    System.out.println(json);
+    json = ftv.convert(hl7message, true, BundleType.TRANSACTION);
     verifyResult(json, BundleType.TRANSACTION);
-
-
   }
 
 


### PR DESCRIPTION
This PR resolves an issue where the HL7ToFHIRConverter fails to load/instantiate within an application that utilizes the converter as a dependency.

I tested by building and publishing the converter locally, and then referencing it as a dependency within a test application.
I was able to run the code below without errors.

```
        System.out.println(IOUtils.resourceToString("hl7/message/ADT_A01.yml", StandardCharsets.UTF_8, ClassLoader.getSystemClassLoader()));

        HL7ToFHIRConverter converter = new HL7ToFHIRConverter();
        String fhirMessage = converter.convert(hl7Message);
        System.out.println(fhirMessage);
```