### PR TITLE
PR for Issue #90

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -309,7 +309,7 @@ public class SimpleDataValueResolver {
         if (code != null) {
           return code;
         } else {
-          return null;
+          return "unknown";
         }
 
       };

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -122,6 +122,21 @@ public class FHIRConverterTest {
   }
 
   @Test
+  public void test_ORU_r01_without_status() throws IOException {
+    String hl7message = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r" +
+            "PID|1||PATID5421^^^NIST MPI^MR||Wilson^Patrice^Natasha^^^^L||19820304|F||2106-3^White^HL70005|144 East 12th Street^^Los Angeles^CA^90012^^H||^PRN^PH^^^203^2290210|||||||||N^Not Hispanic or Latino^HL70189\r" +
+            "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r" +
+            "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r" +
+            "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r" +
+            "OBX|2|CWE|20575-7^Hepatitis A virus Ab [Presence] in Serum^LN^HAVAB^Hepatitis A antibodies (anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r" +
+            "OBX|3|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
+
+    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+    ftv.convert(hl7message);
+
+  }
+
+  @Test
   public void test_invalid_message_throws_error() throws IOException {
     String hl7message = "some text";
 


### PR DESCRIPTION
Error: "DiagnosticReport.status: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/DiagnosticReport)" shows when running the current FHIR validator on the converted file from attached HL7 message.

Solution: Default to unknown when status is not specified 