### PR TITLE
Issue#110 Handle empty telecom correctly

### DIFF
--- a/TECHNIQUES.md
+++ b/TECHNIQUES.md
@@ -4,14 +4,14 @@
 
 Additional information, techniques, and hints about development of templates, java exits, and other enhancements to the converter.
 
-### Getting Java control via data Types
+## Getting Java control via data Types
 
 The converter extracts information via a template and converts to a data type, such as `STRING` and `BOOLEAN`.  You can take advantage of this and create custom data types which can be called for processing of unique inputs.  Before the input is used, your custom data type processor will be invoked.
 
 As an example, type `RELIGIOUS_AFFILIATION_CC` was added to `SimpleDataTypeMapper.java` and mapped to the data handler method `RELIGIOUS_AFFILIATION_FHIR_CC` in `SimpleDataValueResolver.java`
 
 The template reference passes input PID.17 through custom data type `RELIGIOUS_AFFILIATION_CC`:
-```
+```yaml
 extension_2:
   condition: $valCodeableConcept NOT_NULL
   valueOf: extension/Extension_CodeableConcept
@@ -23,12 +23,12 @@ extension_2:
 ```
 
 The mapping.
-```
+```java
 RELIGIOUS_AFFILIATION_CC(SimpleDataValueResolver.RELIGIOUS_AFFILIATION_FHIR_CC),
 ```
 
 The resolver takes as input a value and returns a `CodeableConcept` object, which can be used in the template yaml.  In the example code, the input value is converted to a string and the HAPI FHIR `V3ReligiousAffiliation.class` is used to lookup the code.  With the code, the V3ReligiousAffiliation is found from the code and is used to create the CodeableConcept.
-```
+```java
     public static final ValueExtractor<Object, CodeableConcept> RELIGIOUS_AFFILIATION_FHIR_CC = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, V3ReligiousAffiliation.class);
@@ -46,7 +46,7 @@ The resolver takes as input a value and returns a `CodeableConcept` object, whic
 
 The lookup of the FHIR code is in file `v2ToFFhirMapping.yml` and it is important to note that the lookup section is the same as the class passed in `getFHIRCode(val, V3ReligiousAffiliation.class)`
 
-```
+```yaml
 V3ReligiousAffiliation:
   # Agnostic -> Agnosticism
   AGN: 1004
@@ -58,14 +58,14 @@ V3ReligiousAffiliation:
   ```
 
 
-### Getting Java control via JEXL calls to classes 
+## Getting Java control via JEXL calls to classes 
 
 Evaluation of JEXL expressions can include the evaluation of a custom method.  You can use this to get control and evaluate an input before returning from the JEXL evaluation.
 
 As an example, address district has specialized rules for when Parish should be used.  The Address template evaluates a JEXL expression that calls to the public `getAddressDistrict` which is in file `Hl7RelatedGeneralUtils.java`, which is mapped to `GeneralUtils`.  Variables are collected and input to method.  
 
 `Address.yml`
-```
+```yaml
 district:
      type: STRING
      valueOf: 'GeneralUtils.getAddressDistrict( patientCounty, addressCountyParish, patient)'
@@ -77,7 +77,7 @@ district:
 ```
 `Hl7RelatedGeneralUtils.getAddressDistrict` 
 
-```    
+```java
 public static String getAddressDistrict(String patientCountyPid12, String addressCountyParishPid119, Object patient) {
         LOGGER.info("getAddressCountyParish for {}", patient);
 
@@ -96,4 +96,37 @@ public static String getAddressDistrict(String patientCountyPid12, String addres
         }
         return returnDistrict;
     }
+```
+## YAML Hints
+
+Hints about the ways syntax and references work in the YAML files
+
+### Condition test variables, not templates
+
+Instead of testing the template field directly in the condition:
+
+```yaml
+telecom_1:
+    condition: PID.14 NOT_NULL    
+    valueOf: datatype/Telecom
+    generateList: true
+    expressionType: resource
+    specs: PID.14
+    constants: 
+       use: "work"
+```
+
+Do this -- create a var for the template field and test the var
+
+```yaml
+telecom_1:
+    condition: $pid14 NOT_NULL    
+    valueOf: datatype/Telecom
+    generateList: true
+    expressionType: resource
+    specs: PID.14
+    vars:
+       pid14: PID.14
+    constants: 
+       use: "work"
 ```

--- a/TECHNIQUES.md
+++ b/TECHNIQUES.md
@@ -103,8 +103,9 @@ Hints about the ways syntax and references work in the YAML files
 
 ### Condition test variables, not templates
 
-Instead of testing the template field directly in the condition:
+Testing the segment fields directly in conditions doesn't work. Instead you must create a var for the template field and test the var.
 
+Not this:
 ```yaml
 telecom_1:
     condition: PID.14 NOT_NULL    
@@ -116,8 +117,7 @@ telecom_1:
        use: "work"
 ```
 
-Do this -- create a var for the template field and test the var
-
+Do this:
 ```yaml
 telecom_1:
     condition: $pid14 NOT_NULL    

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -36,21 +36,27 @@ address:
 
   
 telecom_1:
+    condition: $pid14 NOT_NULL
     valueOf: datatype/Telecom
     generateList: true
     expressionType: resource
     specs: PID.14
+    vars:
+       pid14: PID.14
     constants: 
        use: "work"
 
 # The yaml is processed in reverse order, therefore
-# put the PID.13 last in yaml so it is first to be processed 
+# Put the PID.13 last in yaml so it is first to be processed 
        
 telecom_2:
+    condition: $pid13 NOT_NULL
     valueOf: datatype/Telecom
     generateList: true
     expressionType: resource
     specs: PID.13
+    vars:
+       pid13: PID.13
     constants: 
        use: "home"
 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
@@ -61,5 +61,19 @@ public class Hl7TelecomFHIRConversionTest {
 
   }
 
+  @Test
+
+  public void patient_no_telcom_test() {
+
+    String patientNoPhone =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n"
+    ;
   
+    Patient patient = PatientUtils.createPatientFromHl7Segment(patientNoPhone);
+    assertThat(patient.hasTelecom()).isFalse();
+
+  }
+
+
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
@@ -21,15 +21,11 @@ public class Hl7TelecomFHIRConversionTest {
   @Rule
   public ExpectedException exceptionRule = ExpectedException.none();
 
-
   @Test
-
   public void patient_telcom_test() {
 
-    String patientPhone =
-    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^2~^PRN^CP^^22^555^2221313^^^^^^^^^^^1|^PRN^PH^^^555^1111414^889||||||||||||||||\n"
-    ;
+    String patientPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+        + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^2~^PRN^CP^^22^555^2221313^^^^^^^^^^^1|^PRN^PH^^^555^1111414^889||||||||||||||||\n";
 
     Patient patient = PatientUtils.createPatientFromHl7Segment(patientPhone);
     assertThat(patient.hasTelecom()).isTrue();
@@ -37,7 +33,7 @@ public class Hl7TelecomFHIRConversionTest {
     assertThat(contacts.size()).isEqualTo(3);
 
     // First home contact
-    ContactPoint contact = contacts.get(0); 
+    ContactPoint contact = contacts.get(0);
     assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.HOME);
     assertThat(contact.getValue()).hasToString("+22 555 111 1313");
     assertThat(contact.hasRank()).isTrue();
@@ -45,7 +41,7 @@ public class Hl7TelecomFHIRConversionTest {
     assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
 
     // Second home contact
-    contact = contacts.get(1); 
+    contact = contacts.get(1);
     assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.MOBILE);
     assertThat(contact.getValue()).hasToString("+22 555 222 1313");
     assertThat(contact.hasRank()).isTrue();
@@ -53,7 +49,7 @@ public class Hl7TelecomFHIRConversionTest {
     assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
 
     // First work contact
-    contact = contacts.get(2); 
+    contact = contacts.get(2);
     assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
     assertThat(contact.getValue()).hasToString("(555) 111 1414 ext. 889");
     assertThat(contact.hasRank()).isFalse();
@@ -62,18 +58,14 @@ public class Hl7TelecomFHIRConversionTest {
   }
 
   @Test
-
   public void patient_no_telcom_test() {
 
-    String patientNoPhone =
-    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n"
-    ;
-  
+    String patientNoPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+        + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";
+
     Patient patient = PatientUtils.createPatientFromHl7Segment(patientNoPhone);
     assertThat(patient.hasTelecom()).isFalse();
 
   }
-
 
 }


### PR DESCRIPTION
Small change and test to ensure empty telecom information processes correctly -- it should create no telecom section at all.

(There are only four actual lines of code changes in the .yaml.  It looks like more because I added a test, and added hints to the Techniques documentation)