### PR TITLE
Issue#100 Handle null values causing missed type

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -65,8 +65,8 @@ public class Hl7RelatedGeneralUtils {
     }
 
     public static String generateName(Object prefix, Object first, Object middle, Object family, Object suffix) {
-        LOGGER.info("Generating name from  from prefix {}, first {}, family {} ,suffix {}", prefix,
-                first, middle, family, suffix);
+        LOGGER.info("Generating name from  from prefix {}, first {}, family {} ,suffix {}", prefix, first, middle,
+                family, suffix);
         StringBuilder sb = new StringBuilder();
         String valprefix = Hl7DataHandlerUtil.getStringValue(prefix);
         String valfirst = Hl7DataHandlerUtil.getStringValue(first);
@@ -103,7 +103,7 @@ public class Hl7RelatedGeneralUtils {
      * Returns difference between time2 - time1 in minutes
      * 
      * @param start DateTime
-     * @param end DateTime
+     * @param end   DateTime
      * @return Minutes in Long
      */
 
@@ -142,8 +142,7 @@ public class Hl7RelatedGeneralUtils {
     }
 
     public static String concatenateWithChar(Object input, String delimiterChar) {
-        String result = Hl7DataHandlerUtil.getStringValue(input, true, delimiterChar);
-        return result;
+        return Hl7DataHandlerUtil.getStringValue(input, true, delimiterChar);
     }
 
     public static List<String> makeStringArray(String... strs) {
@@ -157,46 +156,49 @@ public class Hl7RelatedGeneralUtils {
     }
 
     public static String getAddressUse(String xad7Type, String xad16Temp, String xad17Bad) {
-        LOGGER.info("Calculating address Use from XAD.7 {}, XAD.16 {}, XAD.17 {}", xad7Type,
-                xad16Temp, xad17Bad);
+        LOGGER.info("Calculating address Use from XAD.7 {}, XAD.16 {}, XAD.17 {}", xad7Type, xad16Temp, xad17Bad);
 
         String addressUse = "";
-
-        if (xad16Temp.equalsIgnoreCase("Y") || (xad16Temp.equals("") && xad7Type.equalsIgnoreCase("C"))) {
+        if (xad16Temp != null && xad16Temp.equalsIgnoreCase("Y") 
+            || ((xad16Temp == null || xad16Temp.isEmpty()) 
+                && xad7Type != null && xad7Type.equalsIgnoreCase("C"))) {
             addressUse = "temp";
-        } else if (xad17Bad.equalsIgnoreCase("Y") || (xad17Bad.equals("") && xad7Type.equalsIgnoreCase("BA"))) {
+        } else if (xad17Bad != null && xad17Bad.equalsIgnoreCase("Y") 
+            || ((xad17Bad == null || xad17Bad.isEmpty()) 
+                && xad7Type != null && xad7Type.equalsIgnoreCase("BA"))) {
             addressUse = "old";
-        } else if (xad7Type.equalsIgnoreCase("H")) {
+        } else if (xad7Type != null && xad7Type.equalsIgnoreCase("H")) {
             addressUse = "home";
-        } else if (xad7Type.equalsIgnoreCase("B") || xad7Type.equalsIgnoreCase("O")) {
+        } else if (xad7Type != null && (xad7Type.equalsIgnoreCase("B") || xad7Type.equalsIgnoreCase("O"))) {
             addressUse = "work";
-        } else if (xad7Type.equalsIgnoreCase("BI")) {
+        } else if (xad7Type != null && xad7Type.equalsIgnoreCase("BI")) {
             addressUse = "billing";
         }
         return addressUse;
-
     }
 
     public static String getAddressType(String xad7Type, String xad18Type) {
-        LOGGER.info("Calculating address Type from XAD.7 {}, XAD.18 {}", xad7Type,
-                xad18Type);
+        LOGGER.info("Calculating address Type from XAD.7 {}, XAD.18 {}", xad7Type, xad18Type);
 
         String addressType = "";
-
-        if (xad18Type.equalsIgnoreCase("M") || (xad18Type.equals("") && xad7Type.equalsIgnoreCase("M"))) {
+        if (xad18Type != null && xad18Type.equalsIgnoreCase("M") 
+            || (xad18Type == null || xad18Type.isEmpty())
+                && (xad7Type != null && xad7Type.equalsIgnoreCase("M"))) {
             addressType = "postal";
-        } else if (xad18Type.equalsIgnoreCase("V") || (xad18Type.equals("") && xad7Type.equalsIgnoreCase("SH"))) {
+        } else if (xad18Type != null && xad18Type.equalsIgnoreCase("V")     
+            || (xad18Type == null || xad18Type.isEmpty())
+                && (xad7Type != null && xad7Type.equalsIgnoreCase("SH"))) {
             addressType = "physical";
         }
         return addressType;
-
     }
 
     /**
-     * Special rules for FHIR Address District. From 18.173.1 build.fhir.org Segment PID to Patient Map.
-     * If the address has a County/Parish code, use it.
-     * However, if it is empty, and there is exactly one address (repeated) use the PID county.
-     * PID-12 maps to patient.address.District "IF PID-11 LST.COUNT EQUALS 1 AND PID-11.9 IS NOT VALUED"
+     * Special rules for FHIR Address District. From 18.173.1 build.fhir.org Segment
+     * PID to Patient Map. If the address has a County/Parish code, use it. However,
+     * if it is empty, and there is exactly one address (repeated) use the PID
+     * county. PID-12 maps to patient.address.District "IF PID-11 LST.COUNT EQUALS 1
+     * AND PID-11.9 IS NOT VALUED"
      */
     public static String getAddressDistrict(String patientCountyPid12, String addressCountyParishPid119,
             Object patient) {
@@ -212,7 +214,7 @@ public class Hl7RelatedGeneralUtils {
                 }
 
             } catch (HL7Exception e) {
-                // Do nothing.  Just eat the error.
+                // Do nothing. Just eat the error.
                 // Let the initial value stand
             }
 
@@ -239,21 +241,24 @@ public class Hl7RelatedGeneralUtils {
         return codeableConcept.getCodingFirstRep().getDisplay();
     }
 
-    // Takes all the pieces of telecom number from XTN, formats to a user friendly Telecom number based on rules documented in the steps
-    public static String getFormattedTelecomNumberValue(String xtn1Old, String xtn5Country, String xtn6Area, String xtn7Local, String xtn8Extension, String xtn12Unformatted) {
+    // Takes all the pieces of telecom number from XTN, formats to a user friendly
+    // Telecom number based on rules documented in the steps
+    public static String getFormattedTelecomNumberValue(String xtn1Old, String xtn5Country, String xtn6Area,
+            String xtn7Local, String xtn8Extension, String xtn12Unformatted) {
         String returnValue = "";
 
         // If the local number exists...
         if (xtn7Local != null && xtn7Local.length() > 0) {
             returnValue = formatCountryAndArea(xtn5Country, xtn6Area) + formatLocalNumber(xtn7Local);
-             // If an extention exists with any form of local number, append a space the extension abbreviation
+            // If an extention exists with any form of local number, append a space the
+            // extension abbreviation
             if (xtn8Extension != null && xtn8Extension.length() > 0) {
                 returnValue = returnValue + " ext. " + xtn8Extension;
             }
-        // otherwise if the unformatted number exists, use it
+            // otherwise if the unformatted number exists, use it
         } else if (xtn12Unformatted != null && xtn12Unformatted.length() > 0) {
             returnValue = xtn12Unformatted;
-       // otherwise if the string number exists, use it    
+            // otherwise if the string number exists, use it
         } else if (xtn1Old != null && xtn1Old.length() > 0) {
             returnValue = xtn1Old;
         }
@@ -263,7 +268,7 @@ public class Hl7RelatedGeneralUtils {
     // Private method to split and format the 7 digit local telecom number
     private static String formatLocalNumber(String localNumber) {
         // Split after the 3rd digit, add a space, add the rest of the number
-        // Seven digit number will format:  123 4567
+        // Seven digit number will format: 123 4567
         return localNumber.substring(0, 3) + " " + localNumber.substring(3);
     }
 
@@ -281,6 +286,6 @@ public class Hl7RelatedGeneralUtils {
             }
         }
         return returnValue;
-     }
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -136,16 +136,46 @@ public class Hl7RelatedGeneralUtilsTest {
     String ANYTHING = "anything";
     // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("C","", ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C","", null)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",null, ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",null, null)).isEqualTo("temp");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,"Y", ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,"Y", null)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,"Y", ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,"Y", null)).isEqualTo("temp");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",ANYTHING, null)).isEqualTo("");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",ANYTHING, "")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",ANYTHING, null)).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",null, "")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",null, null)).isEqualTo("old");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,ANYTHING, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,ANYTHING, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,null, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,null, "Y")).isEqualTo("old");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",null, ANYTHING)).isEqualTo("");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",ANYTHING, ANYTHING)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",null, ANYTHING)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",ANYTHING, null)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",null, null)).isEqualTo("home");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",ANYTHING, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",ANYTHING, null)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",null, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",null, null)).isEqualTo("work");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",ANYTHING, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",ANYTHING, null)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",null, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",null, null)).isEqualTo("work");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",ANYTHING, ANYTHING)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",null, ANYTHING)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",ANYTHING, null)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",null, null)).isEqualTo("billing");
     assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,null, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,ANYTHING, null)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,null, null)).isEqualTo("");
 
   }
 
@@ -154,12 +184,21 @@ public class Hl7RelatedGeneralUtilsTest {
     String ANYTHING = "anything";
     // Inputs are XAD.7 Type, XAD.18 Type 
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "M")).isEqualTo("postal");
     assertThat(Hl7RelatedGeneralUtils.getAddressType("M","")).isEqualTo("postal");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("M",null)).isEqualTo("postal");
     assertThat(Hl7RelatedGeneralUtils.getAddressType("M",ANYTHING)).isEqualTo("");
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "V")).isEqualTo("physical");
     assertThat(Hl7RelatedGeneralUtils.getAddressType("SH","")).isEqualTo("physical");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH",null)).isEqualTo("physical");
     assertThat(Hl7RelatedGeneralUtils.getAddressType("SH",ANYTHING)).isEqualTo("");
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING,ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING,null)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(null,ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(null,null)).isEqualTo("");
+
+
   }
 
   @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AddressFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AddressFHIRConversionTest.java
@@ -6,7 +6,6 @@
 package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import java.io.IOException;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.StringType;
@@ -52,13 +51,13 @@ public class Hl7AddressFHIRConversionTest {
     
     List<StringType> lines = address.getLine();
     assertThat(lines.size()).isEqualTo(3);
-    assertThat(lines.get(0).toString()).isEqualTo("111 1st Street");
-    assertThat(lines.get(1).toString()).isEqualTo("Suite #1");
-    assertThat(lines.get(2).toString()).isEqualTo("c/o Pluto19");
+    assertThat(lines.get(0).toString()).hasToString("111 1st Street");
+    assertThat(lines.get(1).toString()).hasToString("Suite #1");
+    assertThat(lines.get(2).toString()).hasToString("c/o Pluto19");
 
     assertThat(address.hasUse()).isTrue(); 
-    assertThat(address.getUse().toString()).isEqualTo("TEMP");
-    assertThat(address.getType().toString()).isEqualTo("PHYSICAL");
+    assertThat(address.getUse()).isEqualTo(Address.AddressUse.TEMP);
+    assertThat(address.getType()).isEqualTo(Address.AddressType.PHYSICAL);
 
   }
 
@@ -215,5 +214,24 @@ public class Hl7AddressFHIRConversionTest {
     assertThat(address.getPostalCode()).isEqualTo("22222");
   }
 
+  @Test
+  public void patient_postal_mail_test() {
+
+    String patientAddressWithPostalMail =
+    "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||NE|AL||||||RI543763\n"
+    // "M" is postal mail
+    + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M"
+    ;
+    
+    // If address county, ignore patient county
+    Patient patient = PatientUtils.createPatientFromHl7Segment(patientAddressWithPostalMail);
+    assertThat(patient.hasAddress()).isTrue();
+    List<Address> addresses = patient.getAddress(); 
+    assertThat(addresses.size()).isEqualTo(1);
+
+    Address address = addresses.get(0); 
+    assertThat(address.getType()).isEqualTo(Address.AddressType.POSTAL); 
+
+  }
   
 }


### PR DESCRIPTION
This solves the problem of missing address types in some cases.  That error revealed a gap in testing for null values, which has been addressed in multiple places. Tests added to check both null and empty conditions.

(Formatting caused the changes in General Utils to appear for otherwise unchanged methods.  `getAddressUse` and `getAddressType` have the real changes.)