### PR TITLE
Issue#127 additional patient identification + ssn

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -34,6 +34,7 @@ public enum SimpleDataTypeMapper {
   OBJECT(SimpleDataValueResolver.OBJECT),
   CODING_SYSTEM_V2(SimpleDataValueResolver.CODING_SYSTEM_V2),
   SYSTEM_URL(SimpleDataValueResolver.SYSTEM_URL),
+  SYSTEM_ID(SimpleDataValueResolver.SYSTEM_ID),
 
   ALLERGY_INTOLERANCE_CATEGORY(SimpleDataValueResolver.ALLERGY_INTOLERANCE_CATEGORY_CODE_FHIR),
   ALLERGY_INTOLERANCE_CRITICALITY(

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -279,6 +279,11 @@ public class SimpleDataValueResolver {
         return UrlLookup.getSystemUrl(val);
     };
 
+    public static final ValueExtractor<Object, String> SYSTEM_ID = (Object value) -> {
+        String val = Hl7DataHandlerUtil.getStringValue(value);
+        return "urn:id:" + val;
+    };
+
     public static final ValueExtractor<Object, List<?>> ARRAY = (Object value) -> {
         if (value != null) {
             List list = new ArrayList<>();

--- a/src/main/resources/hl7/datatype/Identifier.yml
+++ b/src/main/resources/hl7/datatype/Identifier.yml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+# Creates an identifier with an assigner + reference + referenced object.
 ---
 type: 
    valueOf: datatype/CodeableConcept

--- a/src/main/resources/hl7/datatype/IdentifierPatient.yml
+++ b/src/main/resources/hl7/datatype/IdentifierPatient.yml
@@ -1,0 +1,37 @@
+#
+# (C) Copyright IBM Corp. 2020
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+type: 
+   valueOf: datatype/CodeableConcept
+   expressionType: resource
+   specs: CX.5 | $type
+
+system: 
+     type: SYSTEM_ID
+     valueOf: CX.4 | CWE.4 |EI.2
+     expressionType: HL7Spec
+    
+value: 
+     type: STRING
+     valueOf: CX.1 | CWE.1 |EI.1
+     expressionType: HL7Spec
+     required: true
+
+period:  
+    valueOf: datatype/Period
+    expressionType: resource
+    vars: 
+       start: CX.7 | CWE.7
+       end: CX.8 | CWE.8
+
+# assigner:
+#    valueOf: resource/Organization_Simple
+#    expressionType: reference
+#    vars:
+#      name: $assigningAuth
+#      id: CX.4| CWE.4
+#    constants:
+#       assigningAuth: 'Assigning Authority'

--- a/src/main/resources/hl7/datatype/Identifier_Gen.yml
+++ b/src/main/resources/hl7/datatype/Identifier_Gen.yml
@@ -1,8 +1,9 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+# Creates an identifier with an assigner reference but without a coding
 ---
 
 system: 

--- a/src/main/resources/hl7/datatype/Identifier_Gen.yml
+++ b/src/main/resources/hl7/datatype/Identifier_Gen.yml
@@ -20,6 +20,7 @@ period:
     vars: 
        start: $start
        end: $end
+       
 assigner:
    valueOf: resource/Organization_Simple
    expressionType: reference

--- a/src/main/resources/hl7/datatype/Identifier_SystemID.yml
+++ b/src/main/resources/hl7/datatype/Identifier_SystemID.yml
@@ -1,8 +1,9 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+# Creates an identifier with a System: uri:id  instead of an assigner + reference + referenced object.
 ---
 type: 
    valueOf: datatype/CodeableConcept
@@ -26,12 +27,3 @@ period:
     vars: 
        start: CX.7 | CWE.7
        end: CX.8 | CWE.8
-
-# assigner:
-#    valueOf: resource/Organization_Simple
-#    expressionType: reference
-#    vars:
-#      name: $assigningAuth
-#      id: CX.4| CWE.4
-#    constants:
-#       assigningAuth: 'Assigning Authority'

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -1,0 +1,22 @@
+#
+# (C) Copyright IBM Corp. 2020
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+type: 
+   valueOf: datatype/CodeableConcept_var
+   generateList: true
+   expressionType: resource
+    
+value: 
+   type: STRING
+   valueOf: $valueIn
+
+system:
+   type: STRING
+   valueOf: $assignerSystem  
+   # #   expressionType: resource
+   # #   required: true
+   #   vars: 
+   #     theValue: $valueIn

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+# Creates an identifier, you must provide all the values and variables, including those for CodeableConcept_var
 ---
 type: 
    valueOf: datatype/CodeableConcept_var
@@ -15,8 +16,5 @@ value:
 
 system:
    type: STRING
-   valueOf: $assignerSystem  
-   # #   expressionType: resource
-   # #   required: true
-   #   vars: 
-   #     theValue: $valueIn
+   valueOf: $systemId 
+

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -13,7 +13,7 @@ id:
   expressionType: JEXL
 
 identifier:
-    valueOf: datatype/IdentifierGen
+    valueOf: datatype/Identifier_Gen
     generateList: true
     expressionType: resource
     vars:

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -9,7 +9,7 @@ id:
    valueOf: UUID.randomUUID()
    expressionType: JEXL
 identifier:
-   valueOf: datatype/IdentifierGen
+   valueOf: datatype/Identifier_Gen
    generateList: true  
    expressionType: resource
    vars:

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -14,15 +14,16 @@ id:
   expressionType: JEXL
 
 identifier_1:
-    valueOf: datatype/IdentifierPatient
+    valueOf: datatype/Identifier_SystemID
     generateList: true
     expressionType: resource
     specs: PID.3
     vars: 
        assignerSystem: String, PID.3.4
 
+# Gets the SSN from PID.19 and formats and adds it as an ID
 identifier_2: 
-#     condition: $valueIn NOT_NULL
+    condition: $valueIn NOT_NULL
     valueOf: datatype/Identifier_var
     generateList: true
     expressionType: resource
@@ -32,9 +33,8 @@ identifier_2:
       system: "http://terminology.hl7.org/CodeSystem/v2-0203"
       code: "SS"
       display: "Social Security number"
-      text: "Sample text"
-
-
+      text: "SS"
+      systemId: "urn:id:USA"
 
 name:
     valueOf: datatype/HumanName

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -13,11 +13,29 @@ id:
   valueOf: "UUID.randomUUID()"
   expressionType: JEXL
 
-identifier:
-    valueOf: datatype/Identifier
+identifier_1:
+    valueOf: datatype/IdentifierPatient
     generateList: true
     expressionType: resource
     specs: PID.3
+    vars: 
+       assignerSystem: String, PID.3.4
+
+identifier_2: 
+#     condition: $valueIn NOT_NULL
+    valueOf: datatype/Identifier_var
+    generateList: true
+    expressionType: resource
+    vars:
+      valueIn: String, PID.19
+    constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "SS"
+      display: "Social Security number"
+      text: "Sample text"
+
+
+
 name:
     valueOf: datatype/HumanName
     generateList: true

--- a/src/main/resources/hl7/resource/Practitioner.yml
+++ b/src/main/resources/hl7/resource/Practitioner.yml
@@ -11,7 +11,7 @@ id:
   expressionType: JEXL
   
 identifier:
-    valueOf: datatype/IdentifierGen
+    valueOf: datatype/Identifier_Gen
     generateList: true
     expressionType: resource
     specs: XCN | CNN|NDL

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -246,6 +246,8 @@ String hl7message =
     List<Resource> organizationRes = e.stream()
         .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
         .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    // Patient organizations use a system urn:id reference for the organization, 
+    // so we only expect the manufacturer to have an organization.    
     assertThat(organizationRes).hasSize(1);
   }
 

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -246,7 +246,7 @@ String hl7message =
     List<Resource> organizationRes = e.stream()
         .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
         .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(organizationRes).hasSize(2);
+    assertThat(organizationRes).hasSize(1);
   }
 
   @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -206,7 +206,7 @@ public class Hl7ORUMessageTest {
       List<Resource> organizationResource = e.stream()
               .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(organizationResource).hasSize(1);
+      assertThat(organizationResource).isEmpty();
 
       List<Resource> messageHeader = e.stream()
               .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
@@ -282,7 +282,7 @@ public class Hl7ORUMessageTest {
       List<Resource> organizationResource = e.stream()
               .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(organizationResource).hasSize(1);
+      assertThat(organizationResource).isEmpty(); 
 
       List<Resource> messageHeader = e.stream()
               .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -206,6 +206,8 @@ public class Hl7ORUMessageTest {
       List<Resource> organizationResource = e.stream()
               .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+      // Patient organizations use a system urn:id reference for the organization, 
+      // so we expect no organization resources to be generated.      
       assertThat(organizationResource).isEmpty();
 
       List<Resource> messageHeader = e.stream()
@@ -282,6 +284,8 @@ public class Hl7ORUMessageTest {
       List<Resource> organizationResource = e.stream()
               .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+      // Patient organizations use a system urn:id reference for the organization, 
+      // so we expect no organization resources to be generated. 
       assertThat(organizationResource).isEmpty(); 
 
       List<Resource> messageHeader = e.stream()

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.segments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.ContactPoint;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
+
+public class Hl7IdentifierFHIRConversionTest {
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+
+  @Test
+
+  public void patient_identifiers_test() {
+
+    String patientPhone =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^ID-XYZ^MR~111223333^^^USA^SS~MN1234567^^^MNDOT^DL|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^2~^PRN^CP^^22^555^2221313^^^^^^^^^^^1|^PRN^PH^^^555^1111414^889|||||444556666|||||||||||\n"
+    ;
+
+    Patient patient = PatientUtils.createPatientFromHl7Segment(patientPhone);
+    assertThat(patient.hasTelecom()).isTrue();
+    List<ContactPoint> contacts = patient.getTelecom();
+    assertThat(contacts.size()).isEqualTo(3);
+
+    // First home contact
+  }
+
+  
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -12,7 +12,6 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,9 +22,7 @@ public class Hl7IdentifierFHIRConversionTest {
   @Rule
   public ExpectedException exceptionRule = ExpectedException.none();
 
-
   @Test
-
   public void patient_identifiers_test() {
 
     String patientIdentifiers =
@@ -64,12 +61,15 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(cc.getText()).hasToString("SS");
     assertThat(cc.hasCoding()).isTrue(); 
 
-    // Third identifier (Driver's license) shallow check
+    // Third identifier (Driver's license) medium check
     identifier = identifiers.get(2);
     assertThat(identifier.hasSystem()).isTrue();
     assertThat(identifier.getSystem()).hasToString("urn:id:MNDOT");
     assertThat(identifier.getValue()).hasToString("MN1234567");
-    assertThat(identifier.hasType()).isTrue(); 
+    assertThat(identifier.hasType()).isTrue();
+    cc = identifier.getType();
+    assertThat(cc.getText()).hasToString("DL");
+    assertThat(cc.hasCoding()).isTrue();  
 
     // Deep check for fourth identifier, which is assembled from PID.19 SSN
     identifier = identifiers.get(3);


### PR DESCRIPTION
This adds / improves patient identifier function
1.  Multiple IDs
2. Uses System ID format rather than  assigner:reference
3. Uses SSN from PID.19 if it is present.

Adds tests
Updates naming convention for DataTypes that are slightly different from each other.