### PR TITLE
Do not set CodeableConcept.display from hl7 CWE.2 text

### DIFF
--- a/src/main/resources/hl7/datatype/CodeableConcept.yml
+++ b/src/main/resources/hl7/datatype/CodeableConcept.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,7 +15,6 @@ coding_1 :
     vars:
       code: CWE.1 |CE.1 |CNE.1
       system: CWE.3 |CE.3 |CNE.3
-      display: CWE.2 |CE.2 |CNE.2
       version: CWE.7 |CE.6 |CNE.7
       
 coding_2: 

--- a/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
@@ -1,14 +1,16 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020. 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -19,188 +21,160 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.Test;
+
 import com.google.common.collect.Lists;
+
 import io.github.linuxforhealth.api.ResourceModel;
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.resource.ResourceReader;
 
 public class DifferentObservationValueTest {
-  private static FHIRContext context = new FHIRContext();
-  private static HL7MessageEngine engine = new HL7MessageEngine(context);
+    private static FHIRContext context = new FHIRContext();
+    private static HL7MessageEngine engine = new HL7MessageEngine(context);
 
-  private String baseMessage = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\r"
-      + "EVN|A01|20130617154644\r"
-      + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^Sr^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-      + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-      + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r";
+    private String baseMessage = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\r"
+            + "EVN|A01|20130617154644\r"
+            + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^Sr^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+            + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+            + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r";
 
+    private ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Observation");
 
-  private ResourceModel rsm =
-      ResourceReader.getInstance().generateResourceModel("resource/Observation");
+    HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
+            .withResourceName("Observation").withResourceModel(rsm).withSegment("OBX")
+            .withIsReferenced(false).withRepeats(true).build();
 
-  HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
-      .withResourceName("Observation").withResourceModel(rsm).withSegment("OBX")
-      .withIsReferenced(false).withRepeats(true).build();
+    HL7FHIRResourceTemplate observation = new HL7FHIRResourceTemplate(attributes);
 
-  HL7FHIRResourceTemplate observation = new HL7FHIRResourceTemplate(attributes);
+    private HL7MessageModel message = new HL7MessageModel("ADT", Lists.newArrayList(observation));
 
+    @Test
+    public void test_observation_NM_result() throws IOException {
+        String hl7message = baseMessage + "OBX|1|NM|0135–4^TotalProtein||7.3|gm/dl|5.9-8.4||||F";
+        String json = message.convert(hl7message, engine);
 
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+        Observation obs = (Observation) obsResource.get(0);
+        assertThat(obs.getValueQuantity()).isNotNull();
+        Quantity q = obs.getValueQuantity();
+        assertThat(q.getUnit()).isEqualTo("gm/dl");
+        assertThat(q.getValue().floatValue()).isEqualTo(7.3f);
+    }
 
-  private HL7MessageModel message = new HL7MessageModel("ADT", Lists.newArrayList(observation));
+    @Test
+    public void test_observation_TX_result() throws IOException {
+        String hl7message = baseMessage
+                + "OBX|1|TX|^Type of protein feed^L||Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F||||Alex||";
+        String json = message.convert(hl7message, engine);
 
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+        Observation obs = (Observation) obsResource.get(0);
+        assertThat(obs.getValueStringType()).isNotNull();
+        StringType q = obs.getValueStringType();
+        assertThat(q.asStringValue())
+                .isEqualTo("Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
+    }
 
+    @Test
+    public void test_observation_TX_multiple_parts_result() throws IOException {
+        String hl7message = baseMessage
+                + "OBX|1|TX|^Type of protein feed^L||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%~Fifth line, as part of a repeated field||||||F||";
+        String json = message.convert(hl7message, engine);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+        Observation obs = (Observation) obsResource.get(0);
+        assertThat(obs.getValueStringType()).isNotNull();
+        StringType q = obs.getValueStringType();
+        assertThat(q.asStringValue()).isEqualTo(
+                "HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%. Fifth line, as part of a repeated field.");
+    }
 
-  @Test
-  public void test_observation_NM_result() throws IOException {
+    @Test
+    public void test_observation_CE_result_unknown_system() throws IOException {
+        String hl7message = baseMessage + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
+        String json = message.convert(hl7message, engine);
 
-    String hl7message = baseMessage + "OBX|1|NM|0135–4^TotalProtein||7.3|gm/dl|5.9-8.4||||F";
-    String json = message.convert(hl7message, engine);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+        Observation obs = (Observation) obsResource.get(0);
+        assertThat(obs.getValueCodeableConcept()).isNotNull();
+        assertThat(obs.getStatus()).isNotNull();
+        CodeableConcept cc = obs.getValueCodeableConcept();
+        assertThat(cc.getCoding()).isNotNull();
+        assertThat(cc.getCoding().get(0)).isNotNull();
+        assertThat(cc.getCoding().get(0).getSystem()).isNull();
+        assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
+        assertThat(cc.getText()).isEqualTo("No significant change was found");
+    }
 
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    Observation obs = (Observation) obsResource.get(0);
-    assertThat(obs.getValueQuantity()).isNotNull();
-    Quantity q = obs.getValueQuantity();
-    assertThat(q.getUnit()).isEqualTo("gm/dl");
-    assertThat(q.getValue().floatValue()).isEqualTo(7.3f);
+    @Test
+    public void test_observation_CE_result_known_system() throws IOException {
+        String hl7message = baseMessage + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^LN";
+        String json = message.convert(hl7message, engine);
 
-  }
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+        Observation obs = (Observation) obsResource.get(0);
+        assertThat(obs.getValueCodeableConcept()).isNotNull();
+        assertThat(obs.getStatus()).isNotNull();
+        CodeableConcept cc = obs.getValueCodeableConcept();
+        assertThat(cc.getCoding()).isNotNull();
+        assertThat(cc.getCoding().get(0)).isNotNull();
+        assertThat(cc.getCoding().get(0).getSystem()).isEqualTo("http://loinc.org");
+        assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
+        assertThat(cc.getText()).isEqualTo("No significant change was found");
+    }
 
+    @Test
+    public void test_observation_ST_null_result() throws IOException {
+        String hl7message = baseMessage
+                + "OBX|1|ST|14151-5^HCO3 BldCo-sCnc^LN|TEST|||||||F|||20210311122016|||||20210311122153||||";
+        String json = message.convert(hl7message, engine);
 
-  @Test
-  public void test_observation_TX_result() throws IOException {
-
-    String hl7message = baseMessage
-        + "OBX|1|TX|^Type of protein feed^L||Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F||||Alex||";
-    String json = message.convert(hl7message, engine);
-
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    Observation obs = (Observation) obsResource.get(0);
-    assertThat(obs.getValueStringType()).isNotNull();
-    StringType q = obs.getValueStringType();
-    assertThat(q.asStringValue())
-        .isEqualTo("Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
-
-
-  }
-
-
-  @Test
-  public void test_observation_TX_multiple_parts_result() throws IOException {
-
-    String hl7message = baseMessage
-        + "OBX|1|TX|^Type of protein feed^L||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%~Fifth line, as part of a repeated field||||||F||";
-    String json = message.convert(hl7message, engine);
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    Observation obs = (Observation) obsResource.get(0);
-    assertThat(obs.getValueStringType()).isNotNull();
-    StringType q = obs.getValueStringType();
-    assertThat(q.asStringValue()).isEqualTo(
-        "HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%. Fifth line, as part of a repeated field.");
-
-
-  }
-
-  @Test
-  public void test_observation_CE_result_unknown_system() throws IOException {
-
-    String hl7message =
-        baseMessage + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
-    String json = message.convert(hl7message, engine);
-
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    Observation obs = (Observation) obsResource.get(0);
-    assertThat(obs.getValueCodeableConcept()).isNotNull();
-    assertThat(obs.getStatus()).isNotNull();
-    CodeableConcept cc = obs.getValueCodeableConcept();
-    assertThat(cc.getCoding()).isNotNull();
-    assertThat(cc.getCoding().get(0)).isNotNull();
-    assertThat(cc.getCoding().get(0).getSystem()).isNull();
-    assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
-    assertThat(cc.getCoding().get(0).getDisplay()).isEqualTo("No significant change was found");
-
-    assertThat(cc.getText()).isEqualTo("No significant change was found");
-
-
-  }
-
-
-  @Test
-  public void test_observation_CE_result_known_system() throws IOException {
-
-    String hl7message =
-        baseMessage + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^LN";
-    String json = message.convert(hl7message, engine);
-
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    Observation obs = (Observation) obsResource.get(0);
-    assertThat(obs.getValueCodeableConcept()).isNotNull();
-    assertThat(obs.getStatus()).isNotNull();
-    CodeableConcept cc = obs.getValueCodeableConcept();
-    assertThat(cc.getCoding()).isNotNull();
-    assertThat(cc.getCoding().get(0)).isNotNull();
-    assertThat(cc.getCoding().get(0).getSystem()).isEqualTo("http://loinc.org");
-    assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
-    assertThat(cc.getCoding().get(0).getDisplay()).isEqualTo("No significant change was found");
-
-    assertThat(cc.getText()).isEqualTo("No significant change was found");
-
-
-  }
-
-  @Test
-  public void test_observation_ST_null_result() throws IOException {
-
-    String hl7message = baseMessage
-        + "OBX|1|ST|14151-5^HCO3 BldCo-sCnc^LN|TEST|||||||F|||20210311122016|||||20210311122153||||";
-    String json = message.convert(hl7message, engine);
-
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    Observation obs = (Observation) obsResource.get(0);
-    assertThat(obs.getValueStringType()).isNotNull();
-    StringType q = obs.getValueStringType();
-    assertThat(q.asStringValue()).isEqualTo(null);
-  }
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+        Observation obs = (Observation) obsResource.get(0);
+        assertThat(obs.getValueStringType()).isNotNull();
+        StringType q = obs.getValueStringType();
+        assertThat(q.asStringValue()).isEqualTo(null);
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AllergyFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AllergyFHIRConversionTest.java
@@ -6,11 +6,14 @@
 package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.util.Date;
+import java.util.List;
 
 import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +30,7 @@ public class Hl7AllergyFHIRConversionTest {
     public void test_allergy_single() {
         String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\r"
                 + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
-                + "AL1|1|DA|^PENICILLIN|MI|PRODUCES HIVES~RASH|MI\r" //
+                + "AL1|1|DA|^PENICILLIN|MI|PRODUCES HIVES~RASH|MI\r"
                 + "AL1|2|AA|^CAT DANDER|SV";
 
         AllergyIntolerance allergy = AllergyUtils.createAllergyFromHl7Segment(hl7message);
@@ -39,13 +42,22 @@ public class Hl7AllergyFHIRConversionTest {
     }
 
     @Test
-    public void test_allergy_no_severity() {
+    public void test_allergy_no_severity_no_coding_system() {
         String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\r"
                 + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
-                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r";
+                + "AL1|1|DA|00000741^OXYCODONE||HYPOTENSION\r";
 
-        AllergyIntolerance resource = AllergyUtils.createAllergyFromHl7Segment(hl7message);
-        assertThat(resource.hasCriticality()).isFalse();
+        AllergyIntolerance allergy = AllergyUtils.createAllergyFromHl7Segment(hl7message);
+        assertThat(allergy.hasCriticality()).isFalse();
+        assertThat(allergy.getCategory().get(0).getCode()).isEqualTo("medication");
+        assertThat(allergy.getCode().getText()).isEqualTo("OXYCODONE");
+        List<Coding> codings = allergy.getCode().getCoding();
+        assertEquals(codings.size(), 1);
+        Coding coding = codings.get(0);
+        assertEquals(coding.getCode(), "00000741");
+        assertNull(coding.getDisplay());
+        assertThat(allergy.getReaction().get(0).getManifestation()).extracting(m -> m.getText())
+                .containsExactly("HYPOTENSION");
     }
 
     @Test
@@ -55,9 +67,10 @@ public class Hl7AllergyFHIRConversionTest {
     public void test_allergy_onset() {
         String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\r"
                 + "PID|0010||PID1234||DOE^JANE|||F\r"
-                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION|20210101\r";
+                + "AL1|1|DA|00000741^OXYCODONE||HYPOTENSION|20210101\r";
 
         AllergyIntolerance allergy = AllergyUtils.createAllergyFromHl7Segment(hl7message);
+        assertThat(allergy.getCategory().get(0).getCode()).isEqualTo("medication");
         assertThat(allergy.getReaction().get(0).getManifestation()).extracting(m -> m.getText())
                 .containsExactly("HYPOTENSION");
         Date onsetReaction = allergy.getReaction().get(0).getOnset();


### PR DESCRIPTION
Enhanced Allergy tests for this scenario, plus a few more checks.  Note "DRUG" is not valid for AL1-2.

The changes in the OBX test seemed reasonable.  OBX-5 is not a defined format, but in these messages seems to follow the CWE format.  The changes in DifferentObservationValueTest.java are hard to see even with whitespace changes hidden - most of it is the formatter, the real changes are removal of this check in 2 places:
`assertThat(cc.getCoding().get(0).getDisplay()).isEqualTo("No significant change was found");`
