### PR TITLE
Issue#127 Handle edge conditions for IDs

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -278,9 +278,16 @@ public class SimpleDataValueResolver {
         return UrlLookup.getSystemUrl(val);
     };
 
+    // Convert an authority string to a valid system value
+    // Prepend "urn:id:"; convert any spaces to underscores
     public static final ValueExtractor<Object, String> SYSTEM_ID = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
-        return "urn:id:" + val;
+        if (val != null && val.length() > 0) {
+            return "urn:id:" + val.replace(" ", "_");
+        } else {
+            return null;
+        }
+
     };
 
     public static final ValueExtractor<Object, List<?>> ARRAY = (Object value) -> {

--- a/src/main/resources/hl7/datatype/CodeableConcept.yml
+++ b/src/main/resources/hl7/datatype/CodeableConcept.yml
@@ -43,7 +43,10 @@ coding_4:
        display: CWE.5
        version: CWE.8
 
-text:  
+text:
+     # If hideText is not passed by parent, the value is NULL, making it backward compatible with all other uses of CodeableConcept
+     # Any value in hideText will cause the text to be hidden.  Used by Identifier_SystemID.
+     condition: $hideText NULL 
      type: STRING
      valueOf: CWE.2 |CWE.9 |CE.2 |CNE.2| ST |TX |ID |IS | CWE.5
      expressionType: HL7Spec

--- a/src/main/resources/hl7/datatype/Identifier_SystemID.yml
+++ b/src/main/resources/hl7/datatype/Identifier_SystemID.yml
@@ -11,9 +11,12 @@ type:
    specs: CX.5 | $type
 
 system: 
+     condition: $systemExists NOT_NULL
      type: SYSTEM_ID
      valueOf: CX.4 | CWE.4 |EI.2
      expressionType: HL7Spec
+     vars:
+          systemExists: CX.4 | CWE.4 | EI.2
     
 value: 
      type: STRING

--- a/src/main/resources/hl7/datatype/Identifier_SystemID.yml
+++ b/src/main/resources/hl7/datatype/Identifier_SystemID.yml
@@ -9,6 +9,9 @@ type:
    valueOf: datatype/CodeableConcept
    expressionType: resource
    specs: CX.5 | $type
+   constants: 
+      # Because calculated system id's don't have text, force the calculated text from code to be hidden
+      hideText: 'HIDE'
 
 system: 
      condition: $systemExists NOT_NULL

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -33,8 +33,8 @@ identifier_2:
       system: "http://terminology.hl7.org/CodeSystem/v2-0203"
       code: "SS"
       display: "Social Security number"
-      text: "SS"
-      # There is no default authority for PID.19
+      # There is no text for PID.19
+      # There is no authority for PID.19
 
 name:
     valueOf: datatype/HumanName

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -34,7 +34,7 @@ identifier_2:
       code: "SS"
       display: "Social Security number"
       text: "SS"
-      systemId: "urn:id:USA"
+      # There is no default authority for PID.19
 
 name:
     valueOf: datatype/HumanName

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -206,6 +206,14 @@ public class SimpleDataValueResolverTest {
   public void get_UUID_value_valid() {
     String gen = VALID_UUID;
     assertThat(SimpleDataValueResolver.UUID_VAL.apply(gen)).isEqualTo(UUID.fromString(VALID_UUID));
+  }
+
+  @Test
+  public void get_system_id_value_valid() {
+    assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("ABC")).isEqualTo("urn:id:ABC");
+    assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("A B C")).isEqualTo("urn:id:A_B_C");
+    assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("")).isNull();
+    assertThat(SimpleDataValueResolver.SYSTEM_ID.apply(null)).isNull();
   }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -44,7 +44,7 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(identifier.getValue()).hasToString("MRN12345678");
     assertThat(identifier.hasType()).isTrue(); 
     CodeableConcept cc = identifier.getType();
-    assertThat(cc.getText()).hasToString("MR");
+    assertThat(cc.hasText()).isFalse();
     assertThat(cc.hasCoding()).isTrue(); 
     Coding coding = cc.getCodingFirstRep();
     assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203"); 
@@ -58,7 +58,7 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(identifier.getValue()).hasToString("111223333");
     assertThat(identifier.hasType()).isTrue(); 
     cc = identifier.getType();
-    assertThat(cc.getText()).hasToString("SS");
+    assertThat(cc.hasText()).isFalse();
     assertThat(cc.hasCoding()).isTrue(); 
 
     // Third identifier (Driver's license) medium check
@@ -68,7 +68,7 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(identifier.getValue()).hasToString("MN1234567");
     assertThat(identifier.hasType()).isTrue();
     cc = identifier.getType();
-    assertThat(cc.getText()).hasToString("DL");
+    assertThat(cc.hasText()).isFalse();
     assertThat(cc.hasCoding()).isTrue();  
 
     // Deep check for fourth identifier, which is assembled from PID.19 SSN
@@ -79,7 +79,7 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(identifier.getValue()).hasToString("444556666"); 
     assertThat(identifier.hasType()).isTrue(); 
     cc = identifier.getType();
-    assertThat(cc.getText()).hasToString("SS");
+    assertThat(cc.hasText()).isFalse();
     assertThat(cc.hasCoding()).isTrue();
     coding = cc.getCodingFirstRep();
     assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203"); 
@@ -99,7 +99,6 @@ public class Hl7IdentifierFHIRConversionTest {
 
     Patient patient = PatientUtils.createPatientFromHl7Segment(patientIdentifiersSpecialCases);
     assertThat(patient.hasIdentifier()).isTrue();
-
     List<Identifier> identifiers = patient.getIdentifier();
     assertThat(identifiers.size()).isEqualTo(2);
 
@@ -111,7 +110,7 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(identifier.getValue()).hasToString("MRN12345678");
     assertThat(identifier.hasType()).isTrue(); 
     CodeableConcept cc = identifier.getType();
-    assertThat(cc.getText()).hasToString("MR");
+    assertThat(cc.hasText()).isFalse();
     assertThat(cc.hasCoding()).isTrue(); 
     Coding coding = cc.getCodingFirstRep();
     assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203"); 
@@ -125,7 +124,7 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(identifier.getValue()).hasToString("111223333"); 
     assertThat(identifier.hasType()).isTrue(); 
     cc = identifier.getType();
-    assertThat(cc.getText()).hasToString("SS");
+    assertThat(cc.hasText()).isFalse();
     assertThat(cc.hasCoding()).isTrue();
     coding = cc.getCodingFirstRep();
     assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203"); 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -73,8 +73,8 @@ public class Hl7IdentifierFHIRConversionTest {
 
     // Deep check for fourth identifier, which is assembled from PID.19 SSN
     identifier = identifiers.get(3);
-    assertThat(identifier.hasSystem()).isTrue();
-    assertThat(identifier.getSystem()).hasToString("urn:id:USA");
+    assertThat(identifier.hasSystem()).isFalse();
+    // PID.19 SSN has no authority value and therefore no system id
     // Using different SS than ID#2 to confirm coming from PID.19
     assertThat(identifier.getValue()).hasToString("444556666"); 
     assertThat(identifier.hasType()).isTrue(); 
@@ -86,6 +86,52 @@ public class Hl7IdentifierFHIRConversionTest {
     assertThat(coding.getCode()).hasToString("SS");
     assertThat(coding.getDisplay()).hasToString("Social Security number");
     
+  }
+
+  @Test
+  public void patient_identifiers_special_cases_test() {
+
+    String patientIdentifiersSpecialCases =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    // First ID has blanks in the authority.  Second ID has no authority provided.
+    + "PID|1||MRN12345678^^^Regional Health ID^MR~111223333^^^^SS|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n"
+    ;
+
+    Patient patient = PatientUtils.createPatientFromHl7Segment(patientIdentifiersSpecialCases);
+    assertThat(patient.hasIdentifier()).isTrue();
+
+    List<Identifier> identifiers = patient.getIdentifier();
+    assertThat(identifiers.size()).isEqualTo(2);
+
+    // First identifier (Medical Record) deep check
+    Identifier identifier = identifiers.get(0);
+    assertThat(identifier.hasSystem()).isTrue();
+    // Ensure system blanks are filled in with _'s
+    assertThat(identifier.getSystem()).hasToString("urn:id:Regional_Health_ID"); 
+    assertThat(identifier.getValue()).hasToString("MRN12345678");
+    assertThat(identifier.hasType()).isTrue(); 
+    CodeableConcept cc = identifier.getType();
+    assertThat(cc.getText()).hasToString("MR");
+    assertThat(cc.hasCoding()).isTrue(); 
+    Coding coding = cc.getCodingFirstRep();
+    assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203"); 
+    assertThat(coding.getCode()).hasToString("MR");
+    assertThat(coding.getDisplay()).hasToString("Medical record number");
+
+    // Deep check for second identifier
+    identifier = identifiers.get(1);
+    // We expect no system because there was no authority.
+    assertThat(identifier.hasSystem()).isFalse();
+    assertThat(identifier.getValue()).hasToString("111223333"); 
+    assertThat(identifier.hasType()).isTrue(); 
+    cc = identifier.getType();
+    assertThat(cc.getText()).hasToString("SS");
+    assertThat(cc.hasCoding()).isTrue();
+    coding = cc.getCodingFirstRep();
+    assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203"); 
+    assertThat(coding.getCode()).hasToString("SS");
+    assertThat(coding.getDisplay()).hasToString("Social Security number");
+
   }
   
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
@@ -26,13 +26,13 @@ public class Hl7TelecomFHIRConversionTest {
   public void patient_telcom_test() {
 
     String patientPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-        // Home has 2 phones and an email, work has one phone
-        + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^3~^PRN^CP^^22^555^2221313^^^^^^^^^^^1~^NET^X.400^email.test@gmail.com^^^^^^^^^^^^^^2|^PRN^PH^^^555^1111414^889||||||||||||||||\n";
+        // Home has 2 phones and an email, work has one phone and two emails
+        + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^3~^PRN^CP^^22^555^2221313^^^^^^^^^^^1~^NET^X.400^email.test@gmail.com^^^^^^^^^^^^^^2|^PRN^PH^^^555^1111414^889~^^^professional@buisness.com~^^^moose.mickey@buisness.com^^^^^^^^^^^^^^4||||||||||||||||\n";
 
     Patient patient = PatientUtils.createPatientFromHl7Segment(patientPhone);
     assertThat(patient.hasTelecom()).isTrue();
     List<ContactPoint> contacts = patient.getTelecom();
-    assertThat(contacts.size()).isEqualTo(4);
+    assertThat(contacts.size()).isEqualTo(6);
 
     // First home contact
     ContactPoint contact = contacts.get(0);
@@ -58,12 +58,27 @@ public class Hl7TelecomFHIRConversionTest {
     assertThat(contact.getRank()).hasToString("2");
     assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
 
-    // First work contact
+    // First work contact is work phone
     contact = contacts.get(3);
     assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
     assertThat(contact.getValue()).hasToString("(555) 111 1414 ext. 889");
     assertThat(contact.hasRank()).isFalse();
     assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
+
+    // Second work contact is external work email
+    contact = contacts.get(4);
+    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
+    assertThat(contact.getValue()).hasToString("professional@buisness.com");
+    assertThat(contact.hasRank()).isFalse();
+    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
+
+    // Third work contact is internal work email and is ranked for contact
+    contact = contacts.get(5);
+    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
+    assertThat(contact.getValue()).hasToString("moose.mickey@buisness.com");
+    assertThat(contact.hasRank()).isTrue();
+    assertThat(contact.getRank()).hasToString("4");
+    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
 
   }
 


### PR DESCRIPTION
Improvements to handle edge conditions for ID's:

If the authority has blanks in the name, replace blanks with _'s so the System ID is valid
If the authority is not present in the HL7 message ID's, do not create a System ID in the ID resource
Improve SYSTEM_ID data handler to return null on input of null or empty to support no System ID creation.
Do not assume an authority for an ID created from a PID.19 SSN.