### PR TITLE
Issue#141-Correct-handle-conflict-multbirths

### DIFF
--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -83,7 +83,7 @@ birthDate:
      valueOf: PID.7
      expressionType: HL7Spec
 
-multipleBirthBoolean:
+multipleBirthBoolean_1:
      condition: $multBool NOT_NULL && $multInt NULL
      type: BOOLEAN
      valueOf: PID.24
@@ -92,12 +92,22 @@ multipleBirthBoolean:
           multBool: PID.24
           multInt: PID.25
 
+multipleBirthBoolean_2:
+     condition: $multBool EQUALS N
+     type: BOOLEAN
+     valueOf: PID.24
+     expressionType: HL7Spec
+     vars:
+          multBool: String, PID.24
+          multInt: PID.25          
+
 multipleBirthInteger:
-     condition: $multInt NOT_NULL
+     condition: $multBool EQUALS Y && $multInt NOT_NULL
      type: INTEGER
      valueOf: PID.25
      expressionType: HL7Spec
      vars:
+          multBool: String, PID.24
           multInt: PID.25
 
 deceasedBoolean:

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -101,7 +101,16 @@ multipleBirthBoolean_2:
           multBool: String, PID.24
           multInt: PID.25          
 
-multipleBirthInteger:
+multipleBirthInteger_1:
+     condition: $multBool NULL && $multInt NOT_NULL
+     type: INTEGER
+     valueOf: PID.25
+     expressionType: HL7Spec
+     vars:
+          multBool: String, PID.24
+          multInt: PID.25
+
+multipleBirthInteger_2:
      condition: $multBool EQUALS Y && $multInt NOT_NULL
      type: INTEGER
      valueOf: PID.25

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -155,54 +155,60 @@ public class Hl7PatientFHIRConversionTest {
 
     String patientMsgEmptyMultiple =
     "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|||USA||||\n"
+    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA|||USA||||\n"
     ;
-    String patientMsgMultipleN =
-    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|N||USA||||\n"
-    ;
-    String patientMsgMultipleNumberOnly =
-    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA||2|USA||||\n"
-    ;
-    String patientMsgMultipleBooleanYOnly =
-    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y||USA||||\n"
-    ;
-    String patientMsgMultipleNumberAndBooleanY =
-    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|3|USA||||\n"
-    ;
-
     Patient patientObjEmptyMultiple = PatientUtils.createPatientFromHl7Segment(patientMsgEmptyMultiple);
     assertThat(patientObjEmptyMultiple.hasMultipleBirth()).isFalse();   
     assertThat(patientObjEmptyMultiple.hasMultipleBirthIntegerType()).isFalse(); 
     assertThat(patientObjEmptyMultiple.hasMultipleBirthBooleanType()).isFalse(); 
 
+    String patientMsgMultipleN =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA|N||USA||||\n"
+    ;
     Patient patientObjMultipleN = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleN);
     assertThat(patientObjMultipleN.hasMultipleBirth()).isTrue();   
     assertThat(patientObjMultipleN.hasMultipleBirthIntegerType()).isFalse(); 
     assertThat(patientObjMultipleN.hasMultipleBirthBooleanType()).isTrue(); 
-    assertThat(patientObjMultipleN.getMultipleBirthBooleanType().booleanValue()).isFalse();   
+    assertThat(patientObjMultipleN.getMultipleBirthBooleanType().booleanValue()).isFalse(); 
 
+    String patientMsgMultipleNumberOnly =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA||2|USA||||\n"
+    ;
+    // A number is ignored if there is no boolean and multiple birth is not even created
+    Patient patientObjMultipleNumberOnly = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleNumberOnly);
+    assertThat(patientObjMultipleNumberOnly.hasMultipleBirth()).isFalse();   
+
+    String patientMsgMultipleBooleanYOnly =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA|Y||USA||||\n"
+    ;
     Patient patientObjMultipleBooleanYOnly = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleBooleanYOnly);
     assertThat(patientObjMultipleBooleanYOnly.hasMultipleBirth()).isTrue();   
     assertThat(patientObjMultipleBooleanYOnly.hasMultipleBirthIntegerType()).isFalse(); 
     assertThat(patientObjMultipleBooleanYOnly.hasMultipleBirthBooleanType()).isTrue(); 
-    assertThat(patientObjMultipleBooleanYOnly.getMultipleBirthBooleanType().booleanValue()).isTrue();  
-
-    // A number supercedes any boolean value, and multiple births are assumed true 
-    Patient patientObjMultipleNumberOnly = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleNumberOnly);
-    assertThat(patientObjMultipleNumberOnly.hasMultipleBirth()).isTrue();   
-    assertThat(patientObjMultipleNumberOnly.hasMultipleBirthIntegerType()).isTrue(); 
-    assertThat(patientObjMultipleNumberOnly.hasMultipleBirthBooleanType()).isFalse(); 
-    assertThat(patientObjMultipleNumberOnly.getMultipleBirthIntegerType().asStringValue()).isEqualTo("2"); 
-
+    assertThat(patientObjMultipleBooleanYOnly.getMultipleBirthBooleanType().booleanValue()).isTrue(); 
+ 
+    String patientMsgMultipleNumberAndBooleanY =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA|Y|3|USA||||\n"
+    ;
     Patient patientObjMultipleNumberAndBooleanY = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleNumberAndBooleanY);
     assertThat(patientObjMultipleNumberAndBooleanY.hasMultipleBirth()).isTrue();   
     assertThat(patientObjMultipleNumberAndBooleanY.hasMultipleBirthIntegerType()).isTrue(); 
     assertThat(patientObjMultipleNumberAndBooleanY.hasMultipleBirthBooleanType()).isFalse(); 
     assertThat(patientObjMultipleNumberAndBooleanY.getMultipleBirthIntegerType().asStringValue()).isEqualTo("3");  //DateUtil.formatToDate
+
+    String patientMsgMultipleN16 =
+    "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+    + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA|N|16|USA||||\n"
+    ;
+    Patient patientObjMultipleN16 = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleN16);
+    assertThat(patientObjMultipleN16.hasMultipleBirth()).isTrue();   
+    assertThat(patientObjMultipleN16.hasMultipleBirthIntegerType()).isFalse(); 
+    assertThat(patientObjMultipleN16.hasMultipleBirthBooleanType()).isTrue(); 
+    assertThat(patientObjMultipleN16.getMultipleBirthBooleanType().booleanValue()).isFalse();  
   }
 
   @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -153,6 +153,18 @@ public class Hl7PatientFHIRConversionTest {
   @Test
   public void patient_multiple_birth_conversion_test() {
 
+    /** 
+     * Simplified logic for multiple birth  
+     * 
+     * Y + number = number
+     * N + number = N
+     * Y + blank = Y
+     * N + blank = N
+     * blank + number = number
+     * blank + blank = nothing. 
+     * 
+     */
+
     String patientMsgEmptyMultiple =
     "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
     + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA|||USA||||\n"
@@ -176,9 +188,12 @@ public class Hl7PatientFHIRConversionTest {
     "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
     + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^||||||||||||||||||Born in USA||2|USA||||\n"
     ;
-    // A number is ignored if there is no boolean and multiple birth is not even created
+    // A number when the boolean is missing presumes the number has meaning.  An integer is created.
     Patient patientObjMultipleNumberOnly = PatientUtils.createPatientFromHl7Segment(patientMsgMultipleNumberOnly);
-    assertThat(patientObjMultipleNumberOnly.hasMultipleBirth()).isFalse();   
+    assertThat(patientObjMultipleNumberOnly.hasMultipleBirth()).isTrue();   
+    assertThat(patientObjMultipleNumberOnly.hasMultipleBirthIntegerType()).isTrue(); 
+    assertThat(patientObjMultipleNumberOnly.hasMultipleBirthBooleanType()).isFalse(); 
+    assertThat(patientObjMultipleNumberOnly.getMultipleBirthIntegerType().asStringValue()).isEqualTo("2"); 
 
     String patientMsgMultipleBooleanYOnly =
     "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"


### PR DESCRIPTION
Changes to correct handling of multiple birth information when only integer or N+integer are present.
See bug description for implemented behavior.

BTW, I did simplify the input and the order of the tests to make them easier to follow.