### PR TITLE
BJC - Correct pervasive misspelling of Compound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ bin/
 
 # Jetbrains IDEA
 .idea
+
+# Local Hisory files
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,5 @@ bin/
 # Jetbrains IDEA
 .idea
 
-# Local Hisory files
+# Local History files
 .history

--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/CompoundAndCondition.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/CompoundAndCondition.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,16 +12,15 @@ import com.google.common.base.Preconditions;
 import io.github.linuxforhealth.api.Condition;
 import io.github.linuxforhealth.api.EvaluationResult;
 
-public class CompountORCondition implements Condition {
+public class CompoundAndCondition implements Condition {
 
   private List<Condition> conditions;
 
 
-
-  public CompountORCondition(List<Condition> conditions) {
+  public CompoundAndCondition(List<Condition> conditions) {
     Preconditions.checkArgument(conditions != null && !conditions.isEmpty(),
-        "onditions cannot be null or empty");
-    this.conditions = new ArrayList<>(conditions);
+        "conditions cannot be null or empty");
+    this.conditions = conditions;
   }
 
 
@@ -29,11 +28,11 @@ public class CompountORCondition implements Condition {
   @Override
   public boolean test(Map<String, EvaluationResult> contextVariables) {
     for (Condition c : conditions) {
-      if (c.test(contextVariables)) {
-        return true;
+      if (!c.test(contextVariables)) {
+        return false;
       }
     }
-    return false;
+    return true;
   }
 
 
@@ -41,7 +40,6 @@ public class CompountORCondition implements Condition {
   public List<Condition> getConditions() {
     return new ArrayList<>(conditions);
   }
-
 
 
 

--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/CompoundORCondition.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/CompoundORCondition.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,15 +12,16 @@ import com.google.common.base.Preconditions;
 import io.github.linuxforhealth.api.Condition;
 import io.github.linuxforhealth.api.EvaluationResult;
 
-public class CompountAndCondition implements Condition {
+public class CompoundORCondition implements Condition {
 
   private List<Condition> conditions;
 
 
-  public CompountAndCondition(List<Condition> conditions) {
+
+  public CompoundORCondition(List<Condition> conditions) {
     Preconditions.checkArgument(conditions != null && !conditions.isEmpty(),
-        "conditions cannot be null or empty");
-    this.conditions = conditions;
+        "onditions cannot be null or empty");
+    this.conditions = new ArrayList<>(conditions);
   }
 
 
@@ -28,11 +29,11 @@ public class CompountAndCondition implements Condition {
   @Override
   public boolean test(Map<String, EvaluationResult> contextVariables) {
     for (Condition c : conditions) {
-      if (!c.test(contextVariables)) {
-        return false;
+      if (c.test(contextVariables)) {
+        return true;
       }
     }
-    return true;
+    return false;
   }
 
 
@@ -40,6 +41,7 @@ public class CompountAndCondition implements Condition {
   public List<Condition> getConditions() {
     return new ArrayList<>(conditions);
   }
+
 
 
 

--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionUtil.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -61,20 +61,20 @@ public class ConditionUtil {
     }
   }
 
-  private static CompountAndCondition getListAndConditions(StringTokenizer ands) {
+  private static CompoundAndCondition getListAndConditions(StringTokenizer ands) {
     List<Condition> conditions = new ArrayList<>();
     for (String tok : ands.getTokenList()) {
       conditions.add(createSimpleCondition(tok));
     }
-    return new CompountAndCondition(conditions);
+    return new CompoundAndCondition(conditions);
   }
 
-  private static CompountORCondition getListOrConditions(StringTokenizer ors) {
+  private static CompoundORCondition getListOrConditions(StringTokenizer ors) {
     List<Condition> conditions = new ArrayList<>();
     for (String tok : ors.getTokenList()) {
       conditions.add(createSimpleCondition(tok));
     }
-    return new CompountORCondition(conditions);
+    return new CompoundORCondition(conditions);
   }
 
 }

--- a/src/test/java/io/github/linuxforhealth/core/expression/condition/CompoundAndConditionTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/expression/condition/CompoundAndConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,30 +11,32 @@ import java.util.Map;
 import org.junit.Test;
 import io.github.linuxforhealth.api.EvaluationResult;
 import io.github.linuxforhealth.core.expression.SimpleEvaluationResult;
-import io.github.linuxforhealth.core.expression.condition.CompountORCondition;
+import io.github.linuxforhealth.core.expression.condition.CompoundAndCondition;
 import io.github.linuxforhealth.core.expression.condition.ConditionUtil;
-public class CompountORConditionTest {
+
+public class CompoundAndConditionTest {
 
   @Test
-  public void compount_condition_evaluated_to_true() {
-    String condition = "$var1 EQUALS abc || $var1 EQUALS xyz";
-    CompountORCondition simplecondition =
-        (CompountORCondition) ConditionUtil.createCondition(condition);
+  public void compound_condition_evaluated_to_true() {
+    String condition = "$var1 EQUALS abc && $var2 EQUALS xyz";
+    CompoundAndCondition simplecondition =
+        (CompoundAndCondition) ConditionUtil.createCondition(condition);
 
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
     contextVariables.put("var1", new SimpleEvaluationResult("abc"));
+    contextVariables.put("var2", new SimpleEvaluationResult("xyz"));
     assertThat(simplecondition.test(contextVariables)).isTrue();
   }
 
 
   @Test
-  public void compount_condition_evaluated_to_false() {
-    String condition = "$var1 EQUALS abc || $var1 EQUALS xyz";
-    CompountORCondition simplecondition =
-        (CompountORCondition) ConditionUtil.createCondition(condition);
+  public void compound_condition_evaluated_to_false() {
+    String condition = "$var1 EQUALS abc && $var2 EQUALS xyz";
+    CompoundAndCondition simplecondition =
+        (CompoundAndCondition) ConditionUtil.createCondition(condition);
 
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("tuv"));
+    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
     assertThat(simplecondition.test(contextVariables)).isFalse();
   }
 

--- a/src/test/java/io/github/linuxforhealth/core/expression/condition/CompoundORConditionTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/expression/condition/CompoundORConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,32 +11,30 @@ import java.util.Map;
 import org.junit.Test;
 import io.github.linuxforhealth.api.EvaluationResult;
 import io.github.linuxforhealth.core.expression.SimpleEvaluationResult;
-import io.github.linuxforhealth.core.expression.condition.CompountAndCondition;
+import io.github.linuxforhealth.core.expression.condition.CompoundORCondition;
 import io.github.linuxforhealth.core.expression.condition.ConditionUtil;
-
-public class CompountAndConditionTest {
+public class CompoundORConditionTest {
 
   @Test
-  public void compount_condition_evaluated_to_true() {
-    String condition = "$var1 EQUALS abc && $var2 EQUALS xyz";
-    CompountAndCondition simplecondition =
-        (CompountAndCondition) ConditionUtil.createCondition(condition);
+  public void compound_condition_evaluated_to_true() {
+    String condition = "$var1 EQUALS abc || $var1 EQUALS xyz";
+    CompoundORCondition simplecondition =
+        (CompoundORCondition) ConditionUtil.createCondition(condition);
 
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
     contextVariables.put("var1", new SimpleEvaluationResult("abc"));
-    contextVariables.put("var2", new SimpleEvaluationResult("xyz"));
     assertThat(simplecondition.test(contextVariables)).isTrue();
   }
 
 
   @Test
-  public void compount_condition_evaluated_to_false() {
-    String condition = "$var1 EQUALS abc && $var2 EQUALS xyz";
-    CompountAndCondition simplecondition =
-        (CompountAndCondition) ConditionUtil.createCondition(condition);
+  public void compound_condition_evaluated_to_false() {
+    String condition = "$var1 EQUALS abc || $var1 EQUALS xyz";
+    CompoundORCondition simplecondition =
+        (CompoundORCondition) ConditionUtil.createCondition(condition);
 
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
+    contextVariables.put("var1", new SimpleEvaluationResult("tuv"));
     assertThat(simplecondition.test(contextVariables)).isFalse();
   }
 

--- a/src/test/java/io/github/linuxforhealth/core/expression/condition/ConditionUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/expression/condition/ConditionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import io.github.linuxforhealth.core.expression.condition.CheckNotNull;
 import io.github.linuxforhealth.core.expression.condition.CheckNull;
-import io.github.linuxforhealth.core.expression.condition.CompountAndCondition;
-import io.github.linuxforhealth.core.expression.condition.CompountORCondition;
+import io.github.linuxforhealth.core.expression.condition.CompoundAndCondition;
+import io.github.linuxforhealth.core.expression.condition.CompoundORCondition;
 import io.github.linuxforhealth.core.expression.condition.ConditionUtil;
 import io.github.linuxforhealth.core.expression.condition.SimpleBiCondition;
 
@@ -47,8 +47,8 @@ public class ConditionUtilTest {
   @Test
   public void multiple_or_condition() {
     String condition = "$var1 EQUALS abc || $var1 EQUALS xyz";
-    CompountORCondition simplecondition =
-        (CompountORCondition) ConditionUtil.createCondition(condition);
+    CompoundORCondition simplecondition =
+        (CompoundORCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition).isNotNull();
     assertThat(simplecondition.getConditions()).hasSize(2);
 
@@ -57,8 +57,8 @@ public class ConditionUtilTest {
   @Test
   public void multiple_and_condition() {
     String condition = "$var1 EQUALS abc && $var1 EQUALS xyz";
-    CompountAndCondition simplecondition =
-        (CompountAndCondition) ConditionUtil.createCondition(condition);
+    CompoundAndCondition simplecondition =
+        (CompoundAndCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition).isNotNull();
     assertThat(simplecondition.getConditions()).hasSize(2);
 


### PR DESCRIPTION
Compound was misspelled as "Compount" throughout many classes and tests.  This is a straight forward refactor which corrects that.  Isolating this to a separate PR for tracking and management.