### PR TITLE
Iss#149 add review tests, refactor, fix missing bi

### DIFF
--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionBiPredicates.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionBiPredicates.java
@@ -19,6 +19,7 @@ public class ConditionBiPredicates {
 
   public static final BiPredicate<Integer, Integer> GREATER_THAN = (x, y) -> x > y;
   public static final BiPredicate<Integer, Integer> EQUAL_TO = (x, y) -> x.equals(y);
+  public static final BiPredicate<Integer, Integer> NOT_EQUAL_TO = (x, y) -> !x.equals(y);
   public static final BiPredicate<Integer, Integer> LESS_THAN = (x, y) -> x < y;
   public static final BiPredicate<Integer, Integer> GREATER_THAN_OR_EQUAL_TO = (x, y) -> x >= y;
   public static final BiPredicate<Integer, Integer> LESS_THAN_OR_EQUAL_TO = (x, y) -> x <= y;

--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionPredicateEnum.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionPredicateEnum.java
@@ -17,6 +17,7 @@ public enum ConditionPredicateEnum {
 
   GREATER_THAN_INTEGER(ConditionBiPredicates.GREATER_THAN, Integer.class, Integer.class), //
   EQUALS_INTEGER(ConditionBiPredicates.EQUAL_TO, Integer.class, Integer.class), //
+  NOT_EQUALS_INTEGER(ConditionBiPredicates.NOT_EQUAL_TO, Integer.class, Integer.class), //
   LESS_THAN_INTEGER(ConditionBiPredicates.LESS_THAN, Integer.class, Integer.class), //
   GREATER_THAN_OR_EQUAL_TO_INTEGER(ConditionBiPredicates.GREATER_THAN_OR_EQUAL_TO, Integer.class,
       Integer.class), //

--- a/src/test/java/io/github/linuxforhealth/core/expression/condition/SimpleBiConditionTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/expression/condition/SimpleBiConditionTest.java
@@ -12,561 +12,258 @@ import org.junit.jupiter.api.Test;
 import io.github.linuxforhealth.api.EvaluationResult;
 import io.github.linuxforhealth.core.expression.SimpleEvaluationResult;
 
-
 public class SimpleBiConditionTest {
 
-  // Test EQUALS exhaustively
-
+  // EQUALS on strings tests
   @Test
-  public void simple_EQUALS_condition_is_evaluated_true() {
-    String condition = "$var1 EQUALS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
+  public void simple_EQUALS_condition_tests() {
+    reflexive_comparison_tests_expected_TRUE("abc", "EQUALS", "abc");
+    reflexive_comparison_tests_expected_FALSE("abc", "EQUALS", "ac");
   }
 
+  // EQUALS on integers tests
   @Test
-  public void simple_EQUALS_condition_with_two_variables_is_evaluated_true() {
-    String condition = "$var1 EQUALS $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
-    contextVariables.put("var2", new SimpleEvaluationResult("abc"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
+  public void simple_EQUALS_on_integers_condition_tests() {
+    reflexive_comparison_tests_expected_TRUE(33, "EQUALS", 33);
+    reflexive_comparison_tests_expected_FALSE(29, "EQUALS", 30);
   }
 
+  // EQUALS_INTEGER tests
   @Test
-  public void simple_EQUALS_condition_with_two_variables_is_evaluated_false_when_condition_is_not_satisfied() {
-    String condition = "$var1 EQUALS $var2";
+  public void simple_EQUALS_INTEGER_condition_tests() {
+    reflexive_comparison_tests_expected_TRUE(33, "EQUALS_INTEGER", 33);
+    reflexive_comparison_tests_expected_FALSE(29, "EQUALS_INTEGER", 30);
+  }
+
+  // NOT_EQUALS tests
+  @Test
+  public void simple_NOT_EQUALS_condition_tests() {
+    reflexive_comparison_tests_expected_TRUE("abc", "NOT_EQUALS", "ac");
+    reflexive_comparison_tests_expected_FALSE("abc", "NOT_EQUALS", "abc");
+  }
+
+  // NOT_EQUALS on integers tests
+  @Test
+  public void simple_NOT_EQUALS_on_integers_condition_tests() {
+    reflexive_comparison_tests_expected_TRUE(33, "NOT_EQUALS", 30);
+    reflexive_comparison_tests_expected_FALSE(29, "NOT_EQUALS", 29);
+  }
+
+  // NOT_EQUALS_INTEGER tests
+  @Test
+  public void simple_NOT_EQUALS_INTEGER_condition_tests() {
+    reflexive_comparison_tests_expected_TRUE(30, "NOT_EQUALS_INTEGER", 33);
+    reflexive_comparison_tests_expected_FALSE(29, "NOT_EQUALS_INTEGER", 29);
+  }
+
+  // CONTAINS tests
+  @Test
+  public void simple_CONTAINS_condition_tests() {
+    directional_comparison_tests_expected_TRUE("wxyz", "CONTAINS", "xyz");
+    directional_comparison_tests_expected_TRUE("wxyz", "CONTAINS", "wxyz"); // same expected true
+    directional_comparison_tests_expected_FALSE("xyz", "CONTAINS", "wxyz");
+  }
+
+  // NOT_CONTAINS tests
+  @Test
+  public void simple_NOT_CONTAINS_condition_tests() {
+    directional_comparison_tests_expected_TRUE("wxy", "NOT_CONTAINS", "wxyz");
+    directional_comparison_tests_expected_FALSE("wxyz", "NOT_CONTAINS", "xyz");
+    directional_comparison_tests_expected_FALSE("wxyz", "NOT_CONTAINS", "wxyz"); // same expected false
+  }
+
+  // ENDS_WITH tests
+  @Test
+  public void simple_ENDS_WITH_condition_tests() {
+    directional_comparison_tests_expected_TRUE("wxyz", "ENDS_WITH", "xyz");
+    directional_comparison_tests_expected_TRUE("wxyz", "ENDS_WITH", "wxyz"); // same expected true
+    directional_comparison_tests_expected_FALSE("wxyz", "ENDS_WITH", "w");
+  }
+
+  // NOT_ENDS_WITH tests
+  @Test
+  public void simple_NOT_ENDS_WITH_condition_tests() {
+    directional_comparison_tests_expected_TRUE("wxyz", "NOT_ENDS_WITH", "wxy");
+    directional_comparison_tests_expected_FALSE("wxyz", "NOT_ENDS_WITH", "xyz");
+    directional_comparison_tests_expected_FALSE("wxyz", "NOT_ENDS_WITH", "wxyz"); // same expected false
+  }
+
+  // STARTS_WITH tests
+  @Test
+  public void simple_STARTS_WITH_condition_tests() {
+    directional_comparison_tests_expected_TRUE("abcde", "STARTS_WITH", "abcd");
+    directional_comparison_tests_expected_TRUE("abcde", "STARTS_WITH", "abcde"); // same expected true
+    directional_comparison_tests_expected_FALSE("abcde", "STARTS_WITH", "bc");
+  }
+
+  // NOT_STARTS_WITH tests
+  @Test
+  public void simple_NOT_STARTS_WITH_condition_tests() {
+    directional_comparison_tests_expected_TRUE("abcde", "NOT_STARTS_WITH", "bcde");
+    directional_comparison_tests_expected_FALSE("abcde", "NOT_STARTS_WITH", "abc");
+    directional_comparison_tests_expected_FALSE("abcde", "NOT_STARTS_WITH", "abcde"); // same expected false
+  }
+
+  // GREATER_THAN tests
+  @Test
+  public void simple_GREATER_THAN_condition_tests() {
+    directional_comparison_tests_expected_TRUE(33, "GREATER_THAN", 6);
+    directional_comparison_tests_expected_FALSE(6, "GREATER_THAN", 33);
+  }
+
+  // GREATER_THAN_INTEGER tests
+  @Test
+  public void simple_GREATER_THAN_INTEGER_condition_tests() {
+    directional_comparison_tests_expected_TRUE(33, "GREATER_THAN_INTEGER", 6);
+    directional_comparison_tests_expected_FALSE(6, "GREATER_THAN_INTEGER", 33);
+  }
+
+  // LESS_THAN tests
+  @Test
+  public void simple_LESS_THAN_condition_tests() {
+    directional_comparison_tests_expected_TRUE(3, "LESS_THAN", 6);
+    directional_comparison_tests_expected_FALSE(6, "LESS_THAN", 3);
+  }
+
+  // LESS_THAN_INTEGER tests
+  @Test
+  public void simple_LESS_THAN_INTEGER_condition_tests() {
+    directional_comparison_tests_expected_TRUE(3, "LESS_THAN_INTEGER", 6);
+    directional_comparison_tests_expected_FALSE(6, "LESS_THAN_INTEGER", 3);
+  }
+
+  // GREATER_THAN_OR_EQUAL_TO tests
+  @Test
+  public void simple_GREATER_THAN_OR_EQUAL_TO_condition_tests() {
+    directional_comparison_tests_expected_TRUE(33, "GREATER_THAN_OR_EQUAL_TO", 6);
+    directional_comparison_tests_expected_FALSE(6, "GREATER_THAN_OR_EQUAL_TO", 33);
+    reflexive_comparison_tests_expected_TRUE(33, "GREATER_THAN_OR_EQUAL_TO", 33);
+  }
+
+  // GREATER_THAN_OR_EQUAL_TO_INTEGER tests
+  @Test
+  public void simple_GREATER_THAN_OR_EQUAL_TO_INTEGER_condition_tests() {
+    directional_comparison_tests_expected_TRUE(33, "GREATER_THAN_OR_EQUAL_TO_INTEGER", 6);
+    directional_comparison_tests_expected_FALSE(6, "GREATER_THAN_OR_EQUAL_TO_INTEGER", 33);
+    reflexive_comparison_tests_expected_TRUE(33, "GREATER_THAN_OR_EQUAL_TO_INTEGER", 33);
+  }
+
+  // LESS_THAN_OR_EQUAL_TO tests
+  @Test
+  public void simple_LESS_THAN_OR_EQUAL_TO_condition_tests() {
+    directional_comparison_tests_expected_TRUE(3, "LESS_THAN_OR_EQUAL_TO", 6);
+    directional_comparison_tests_expected_FALSE(6, "LESS_THAN_OR_EQUAL_TO", 3);
+    reflexive_comparison_tests_expected_TRUE(3, "LESS_THAN_OR_EQUAL_TO", 3);
+  }
+
+  // LESS_THAN_OR_EQUAL_TO_INTEGER tests
+  @Test
+  public void simple_LESS_THAN_OR_EQUAL_TO_INTEGER_condition_tests() {
+    directional_comparison_tests_expected_TRUE(3, "LESS_THAN_OR_EQUAL_TO_INTEGER", 6);
+    directional_comparison_tests_expected_FALSE(6, "LESS_THAN_OR_EQUAL_TO_INTEGER", 3);
+    reflexive_comparison_tests_expected_TRUE(3, "LESS_THAN_OR_EQUAL_TO_INTEGER", 3);
+  }
+
+  // Directional comparisons are only true in one direction
+  // The caller excpects all these comparisons to be TRUE
+  private void directional_comparison_tests_expected_TRUE(Object value1, String comparison, Object value2) {
+    // value1 as $var1 compares to value2 as constant should be true
+    String condition = "$var1 " + comparison + " " + value2.toString();
     SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
-    contextVariables.put("var2", new SimpleEvaluationResult("xyz"));
+    contextVariables.put("var1", new SimpleEvaluationResult(value1));
+    contextVariables.put("var2", new SimpleEvaluationResult(value2));
+    assertThat(simplecondition.test(contextVariables)).isTrue();
+
+    // forward: value1 as $var1 compares to value2 as $var2 should be true
+    condition = "$var1 " + comparison + " $var2";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
+    assertThat(simplecondition.test(contextVariables)).isTrue();
+
+  }
+
+  // Directional comparisons are only true in one direction
+  // The caller excpects all these comparisons to be FALSE
+  private void directional_comparison_tests_expected_FALSE(Object value1, String comparison, Object value2) {
+    // value1 as $var1 compares to value2 as constant should be false
+    String condition = "$var1 " + comparison + " " + value2.toString();
+    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
+    Map<String, EvaluationResult> contextVariables = new HashMap<>();
+    contextVariables.put("var1", new SimpleEvaluationResult(value1));
+    contextVariables.put("var2", new SimpleEvaluationResult(value2));
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  @Test
-  public void simple_EQUALS_condition_is_evaluated_false() {
-    String condition = "$var1 EQUALS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcdf"));
+    // forward: value1 as $var1 compares to value2 as $var2 should be false
+    condition = "$var1 " + comparison + " $var2";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  @Test
-  public void simple_EQUALS_condition_is_evaluated_false_when_var_not_found() {
-    String condition = "$var1 EQUALS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-
+    // missing variable: value1 as $var1 compares to missing $var3 should be false
+    condition = "$var1 " + comparison + " $var3";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isFalse();
+
   }
 
-  // NOT_EQUALS tested exhaustively
-
-  @Test
-  public void simple_NOT_EQUALS_condition_is_evaluated_true() {
-    String condition = "$var1 NOT_EQUALS abc";
+  // Reflexive comparisons give the same result if the values are reversed in order
+  // The caller excpects all these comparisons to be TRUE
+  private void reflexive_comparison_tests_expected_TRUE(Object value1, String comparison, Object value2) {
+    // value1 as $var1 compares to value2 as constant should be true
+    String condition = "$var1 " + comparison + " " + value2.toString();
     SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcd"));
+    contextVariables.put("var1", new SimpleEvaluationResult(value1));
+    contextVariables.put("var2", new SimpleEvaluationResult(value2));
     assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
 
-  @Test
-  public void simple_NOT_EQUALS_condition_with_two_variables_is_evaluated_true() {
-    String condition = "$var1 NOT_EQUALS $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
-    contextVariables.put("var2", new SimpleEvaluationResult("abcd"));
+    // reverse: value2 as $var2 compares to value1 as constant should be true
+    condition = "$var2 " + comparison + " " + value1.toString();
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isTrue();
+
+    // forward: value1 as $var1 compares to value2 as $var2 should be true
+    condition = "$var1 " + comparison + " $var2";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
+    assertThat(simplecondition.test(contextVariables)).isTrue();
+
+    // reverse: value2 as $var2 compares to value1 as $var1 should be true
+    condition = "$var2 " + comparison + " $var1";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
+    assertThat(simplecondition.test(contextVariables)).isTrue();
+
   }
 
-  @Test
-  public void simple_NOT_EQUALS_condition_with_two_variables_is_evaluated_false_when_condition_is_not_satisfied() {
-    String condition = "$var1 NOT_EQUALS $var2";
+  // Reflexive comparisons give the same result if the values are reversed in order
+  // The caller excpects all these comparisons to be FALSE
+  private void reflexive_comparison_tests_expected_FALSE(Object value1, String comparison, Object value2) {
+    // value1 as $var1 compares to value2 as constant should be false
+    String condition = "$var1 " + comparison + " " + value2.toString();
     SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc"));
-    contextVariables.put("var2", new SimpleEvaluationResult("abc")); // Because the same, fails NOT_EQUALS
+    contextVariables.put("var1", new SimpleEvaluationResult(value1));
+    contextVariables.put("var2", new SimpleEvaluationResult(value2));
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  @Test
-  public void simple_NOT_EQUALS_condition_is_evaluated_false() {
-    String condition = "$var1 NOT_EQUALS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abc")); // Because the same, NOT_EQUALS false
+    // reverse: value2 as $var2 compares to value1 as constant should be false
+    condition = "$var2 " + comparison + " " + value1.toString();
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  @Test
-  public void simple_NOT_EQUALS_condition_is_evaluated_false_when_var_not_found() {
-    String condition = "$var1 NOT_EQUALS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-
+    // forward: value1 as $var1 compares to value2 as $var2 should be false
+    condition = "$var1 " + comparison + " $var2";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  // CONTAINS test one true and one false
-
-  @Test
-  public void simple_CONTAINS_condition_is_evaluated_true() {
-    String condition = "$var1 CONTAINS bcd";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcde"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_CONTAINS_condition_is_evaluated_false() {
-    String condition = "$var1 CONTAINS def";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcde"));
+    // reverse: value2 as $var2 compares to value1 as $var1 should be false
+    condition = "$var2 " + comparison + " $var1";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  // NOT_CONTAINS test one true and one false
-
-  @Test
-  public void simple_NOT_CONTAINS_condition_is_evaluated_true() {
-    String condition = "$var1 NOT_CONTAINS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("defgh"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_NOT_CONTAINS_condition_is_evaluated_false() {
-    String condition = "$var1 NOT_CONTAINS abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcdef"));
+    // missing variable: value1 as $var1 compares to missing $var3 should be false
+    condition = "$var1 " + comparison + " $var3";
+    simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
     assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
 
-  // ENDS_WITH test one true and one false
-
-  @Test
-  public void simple_ENDS_WITH_condition_is_evaluated_true() {
-    String condition = "$var1 ENDS_WITH xyz";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("uvwxyz"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_ENDS_WITH_condition_is_evaluated_false() {
-    String condition = "$var1 ENDS_WITH abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("uvwxyz"));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // NOT_ENDS_WITH test one true and one false
-
-  @Test
-  public void simple_NOT_ENDS_WITH_condition_is_evaluated_true() {
-    String condition = "$var1 NOT_ENDS_WITH abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("uvwxyz"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_NOT_ENDS_WITH_condition_is_evaluated_false() {
-    String condition = "$var1 NOT_ENDS_WITH xyz";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("uvwxyz"));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // STARTS_WITH test one true and one false
-
-  @Test
-  public void simple_STARTS_WITH_condition_is_evaluated_true() {
-    String condition = "$var1 STARTS_WITH abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcdefg"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_STARTS_WITH_condition_is_evaluated_false() {
-    String condition = "$var1 STARTS_WITH abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("uvwxyz"));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // NOT_STARTS_WITH test one true and one false
-
-  @Test
-  public void simple_NOT_STARTS_WITH_condition_is_evaluated_true() {
-    String condition = "$var1 NOT_STARTS_WITH abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("uvwxyz"));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_NOT_STARTS_WITH_condition_is_evaluated_false() {
-    String condition = "$var1 NOT_STARTS_WITH abc";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult("abcdefg"));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // GREATER_THAN two vars test one true and one false
-
-  @Test
-  public void simple_GREATER_THAN_condition_with_two_vars_is_evaluated_true() {
-    String condition = "$var1 GREATER_THAN $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_GREATER_THAN_condition_with_two_vars_is_evaluated_false() {
-    String condition = "$var1 GREATER_THAN $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(100));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // GREATER_THAN test one true and one false
-
-  @Test
-  public void simple_GREATER_THAN_condition_of_integer_is_evaluated_true() {
-    String condition = "$var1 GREATER_THAN 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_GREATER_THAN_condition_of_integer_is_evaluated_false() {
-    String condition = "$var1 GREATER_THAN 12";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // GREATER_THAN_INTEGER test one true and one false
-
-  @Test
-  public void simple_GREATER_THAN_INTEGER_condition_is_evaluated_true() {
-    String condition = "$var1 GREATER_THAN_INTEGER 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_GREATER_THAN_INTEGER_condition_is_evaluated_false() {
-    String condition = "$var1 GREATER_THAN_INTEGER 100";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // LESS_THAN two vars test one true and one false
-
-  @Test
-  public void simple_LESS_THAN_condition_with_two_vars_is_evaluated_true() {
-    String condition = "$var1 LESS_THAN $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(3));
-    contextVariables.put("var2", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_LESS_THAN_condition_with_two_vars_is_evaluated_false() {
-    String condition = "$var1 LESS_THAN $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(3));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // LESS_THAN test one true and one false
-
-  @Test
-  public void simple_LESS_THAN_condition_of_integer_is_evaluated_true() {
-    String condition = "$var1 LESS_THAN 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(3));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_LESS_THAN_condition_of_integer_is_evaluated_false() {
-    String condition = "$var1 LESS_THAN 12";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(19));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // LESS_THAN_INTEGER test one true and one false
-
-  @Test
-  public void simple_LESS_THAN_INTEGER_condition_is_evaluated_true() {
-    String condition = "$var1 LESS_THAN_INTEGER 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(3));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_LESS_THAN_INTEGER_condition_is_evaluated_false() {
-    String condition = "$var1 LESS_THAN_INTEGER 100";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(101));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // EQUALS two var integers test one true and one false
-
-  @Test
-  public void simple_EQUALS_condition_with_two_integers_vars_is_evaluated_true() {
-    String condition = "$var1 EQUALS $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    contextVariables.put("var2", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_EQUALS_condition_with_two_vars_is_evaluated_false() {
-    String condition = "$var1 EQUALS $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(3));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // EQUALS integers test one true and one false
-
-  @Test
-  public void simple_EQUALS_condition_of_integer_is_evaluated_true() {
-    String condition = "$var1 EQUALS 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_EQUALS_condition_of_integer_is_evaluated_false() {
-    String condition = "$var1 EQUALS 12";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(19));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // EQUALS_INTEGER test one true and one false
-
-  @Test
-  public void simple_EQUALS_INTEGER_condition_is_evaluated_true() {
-    String condition = "$var1 EQUALS_INTEGER 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_EQUALS_INTEGER_condition_is_evaluated_false() {
-    String condition = "$var1 EQUALS_INTEGER 100";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(101));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // GREATER_THAN_OR_EQUAL_TO two vars test true and one false
-
-  @Test
-  public void simple_GREATER_THAN_OR_EQUAL_TO_condition_with_two_vars_is_evaluated_true() {
-    String condition = "$var1 GREATER_THAN_OR_EQUAL_TO $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-
-    // Equals test
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_GREATER_THAN_OR_EQUAL_TO_condition_with_two_vars_is_evaluated_false() {
-    String condition = "$var1 GREATER_THAN_OR_EQUAL_TO $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(100));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // GREATER_THAN_OR_EQUAL_TO test one true and one false
-
-  @Test
-  public void simple_GREATER_THAN_OR_EQUAL_TO_condition_of_integer_is_evaluated_true() {
-    String condition = "$var1 GREATER_THAN_OR_EQUAL_TO 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-
-    // Equals test
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_GREATER_THAN_OR_EQUAL_TO_condition_of_integer_is_evaluated_false() {
-    String condition = "$var1 GREATER_THAN_OR_EQUAL_TO 12";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // GREATER_THAN_OR_EQUAL_TO_INTEGER test one true and one false
-
-  @Test
-  public void simple_GREATER_THAN_OR_EQUAL_TO_INTEGER_condition_is_evaluated_true() {
-    String condition = "$var1 GREATER_THAN_OR_EQUAL_TO_INTEGER 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-
-    // Equals case
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_GREATER_THAN_OR_EQUAL_TO_INTEGER_condition_is_evaluated_false() {
-    String condition = "$var1 GREATER_THAN_OR_EQUAL_TO_INTEGER 100";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // LESS_THAN_OR_EQUAL_TO two vars test true and one false
-
-  @Test
-  public void simple_LESS_THAN_OR_EQUAL_TO_condition_with_two_vars_is_evaluated_true() {
-    String condition = "$var1 LESS_THAN_OR_EQUAL_TO $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(3));
-    contextVariables.put("var2", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-
-    // Equals test
-    contextVariables.put("var1", new SimpleEvaluationResult(9));
-    contextVariables.put("var2", new SimpleEvaluationResult(9));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_LESS_THAN_OR_EQUAL_TO_condition_with_two_vars_is_evaluated_false() {
-    String condition = "$var1 LESS_THAN_OR_EQUAL_TO $var2";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(109));
-    contextVariables.put("var2", new SimpleEvaluationResult(100));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // LESS_THAN_OR_EQUAL_TO test one true and one false
-
-  @Test
-  public void simple_LESS_THAN_OR_EQUAL_TO_condition_of_integer_is_evaluated_true() {
-    String condition = "$var1 LESS_THAN_OR_EQUAL_TO 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(3));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-
-    // Equals test
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_LESS_THAN_OR_EQUAL_TO_condition_of_integer_is_evaluated_false() {
-    String condition = "$var1 LESS_THAN_OR_EQUAL_TO 12";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(19));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
-  }
-
-  // LESS_THAN_OR_EQUAL_TO_INTEGER test one true and one false
-
-  @Test
-  public void simple_LESS_THAN_OR_EQUAL_TO_INTEGER_condition_is_evaluated_true() {
-    String condition = "$var1 LESS_THAN_OR_EQUAL_TO_INTEGER 6";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(3));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-
-    // Equals case
-    contextVariables.put("var1", new SimpleEvaluationResult(6));
-    assertThat(simplecondition.test(contextVariables)).isTrue();
-  }
-
-  @Test
-  public void simple_LESS_THAN_OR_EQUAL_TO_INTEGER_condition_is_evaluated_false() {
-    String condition = "$var1 LESS_THAN_OR_EQUAL_TO_INTEGER 100";
-    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition(condition);
-    Map<String, EvaluationResult> contextVariables = new HashMap<>();
-    contextVariables.put("var1", new SimpleEvaluationResult(109));
-    assertThat(simplecondition.test(contextVariables)).isFalse();
   }
 
 }


### PR DESCRIPTION
This addresses comments in review.
Rather than cut/paste 8 new similar tests, the code was refactored with common routines to reduce code, increase coverage, make future updates are easier, and make what is being tested clearer from looking at code rather than reading the comment.  In the process, discovered two missing comparators:  NOT_EQUALS and NOT_EQUALS_INTEGER.  These were also added.
NOTE:  SimpleBiConditionTest has major structural changes and moving about.   A file compare may be less useful than looking at the complete file.