### PR TITLE
620 config home env

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The converter configuration file, config.properties, supports the following sett
 The config.properties file location is set using the Environment Variable or System property `HL7CONVERTER_CONFIG_HOME`
 
 * HL7CONVERTER_CONFIG_HOME environment variable is checked first
-* The variable can only be set as System Property ``` -DHL7CONVERTER_CONFIG_HOME=/opt/converter/config_home_folder/```
+* The variable can only be set as System Property 
+   ``` -DHL7CONVERTER_CONFIG_HOME=/opt/converter/config_home_folder/ ```
+
 * Lastly, the local resource folder will be searched for config.properties
 
 ## Additional Documentation

--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ The converter configuration file, config.properties, supports the following sett
 | default.zoneid          | ISO 8601 timezone offset (optional). The zoneid is applied to translations when the target FHIR resource field requires a timezone, but the source HL7 field does not include it. | +08:00                          |
 | additional.conceptmap   | Path to additional concept map configuration. Concept maps are used for mapping one code system to another.                                                                       | /opt/converter/concept-map.yaml |
 
-The config.properties file location is set using the System property, `config.home`
+### HL7 Converter Configuration Property Location
 
-```
--Dconfig.home=/opt/converter/config
-```
+The config.properties file location is set using the Environment Variable or System property `HL7CONVERTER_CONFIG_HOME`
+
+* HL7CONVERTER_CONFIG_HOME environment variable is checked first
+* The variable can only be set as System Property ``` -DHL7CONVERTER_CONFIG_HOME=/opt/converter/config_home_folder/```
+* Lastly, the local resource folder will be searched for config.properties
 
 ## Additional Documentation
 * [Templating Configuration](./TEMPLATING.md)

--- a/README.md
+++ b/README.md
@@ -95,13 +95,14 @@ The converter configuration file, config.properties, supports the following sett
 
 ### HL7 Converter Configuration Property Location
 
-The config.properties file location is set using the Environment Variable or System property `HL7CONVERTER_CONFIG_HOME`
+The config.properties file location is searched in the following order:
 
 * HL7CONVERTER_CONFIG_HOME environment variable is checked first
-* The variable can only be set as System Property 
-   ``` -DHL7CONVERTER_CONFIG_HOME=/opt/converter/config_home_folder/ ```
+* hl7converter.config.home system property is checked next 
+   
+   ``` -Dhl7converter.config.home=/opt/converter/config_home_folder/```
 
-* Lastly, the local resource folder will be searched for config.properties
+* Lastly, the local classpath resource folder will be searched for config.properties
 
 ## Additional Documentation
 * [Templating Configuration](./TEMPLATING.md)

--- a/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
@@ -17,8 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
-  private static final String ENV_CONF_PROP_HOME = "hl7converter.config.home";
-  private static final String CONF_PROP_HOME = "config.home";
+  private static final String CONF_PROP_HOME = "HL7CONVERTER_CONFIG_HOME";
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ConfigDirectoryLocationStrategy.class);
 
@@ -66,7 +65,7 @@ public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
 
   private static String fetchHomeDirectory() {
-	String homeDirectory = System.getenv(ENV_CONF_PROP_HOME);
+	String homeDirectory = System.getenv(CONF_PROP_HOME);
 	if (homeDirectory==null || homeDirectory.isBlank())
 		return System.getProperty(CONF_PROP_HOME);
 	return homeDirectory;

--- a/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
@@ -17,7 +17,9 @@ import org.slf4j.LoggerFactory;
 
 public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
-  private static final String CONF_PROP_HOME = "HL7CONVERTER_CONFIG_HOME";
+  private static final String CONF_PROP_HOME_SYSTEM_PROP = "hl7converter.config.home";
+  private static final String CONF_PROP_HOME_ENV_VAR = "HL7CONVERTER_CONFIG_HOME";
+		  
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ConfigDirectoryLocationStrategy.class);
 
@@ -65,9 +67,9 @@ public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
 
   private static String fetchHomeDirectory() {
-	String homeDirectory = System.getenv(CONF_PROP_HOME);
+	String homeDirectory = System.getenv(CONF_PROP_HOME_ENV_VAR);
 	if (homeDirectory==null || homeDirectory.trim().isEmpty())
-		return System.getProperty(CONF_PROP_HOME);
+		return System.getProperty(CONF_PROP_HOME_SYSTEM_PROP);
 	return homeDirectory;
   }
 }

--- a/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
@@ -66,7 +66,7 @@ public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
   private static String fetchHomeDirectory() {
 	String homeDirectory = System.getenv(CONF_PROP_HOME);
-	if (homeDirectory==null || homeDirectory.isBlank())
+	if (homeDirectory==null || homeDirectory.trim().isEmpty())
 		return System.getProperty(CONF_PROP_HOME);
 	return homeDirectory;
   }

--- a/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConfigDirectoryLocationStrategy.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
+  private static final String ENV_CONF_PROP_HOME = "hl7converter.config.home";
   private static final String CONF_PROP_HOME = "config.home";
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ConfigDirectoryLocationStrategy.class);
@@ -65,6 +66,9 @@ public class ConfigDirectoryLocationStrategy implements FileLocationStrategy {
 
 
   private static String fetchHomeDirectory() {
-    return System.getProperty(CONF_PROP_HOME);
+	String homeDirectory = System.getenv(ENV_CONF_PROP_HOME);
+	if (homeDirectory==null || homeDirectory.isBlank())
+		return System.getProperty(CONF_PROP_HOME);
+	return homeDirectory;
   }
 }

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -25,7 +25,7 @@ import io.github.linuxforhealth.core.terminology.UrlLookup;
 public class ConverterConfigurationTest {
 
 
-	private static final String CONF_PROP_HOME = "config.home";
+	private static final String CONF_PROP_HOME = "HL7CONVERTER_CONFIG_HOME";
     @TempDir
     static File folder;
     
@@ -56,7 +56,7 @@ public class ConverterConfigurationTest {
     public void test_that_additional_conceptmap_values_are_loaded() throws IOException {
     	File configFile = new File(folder, "config.properties");
         writeProperties(configFile);
-        System.setProperty("config.home", configFile.getParent());
+        System.setProperty(CONF_PROP_HOME, configFile.getParent());
         ConverterConfiguration.reset();
         UrlLookup.reset(Constants.CODING_SYSTEM_MAPPING);
         String url = UrlLookup.getSystemUrl("LN");

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -13,7 +13,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -22,15 +24,33 @@ import io.github.linuxforhealth.core.terminology.UrlLookup;
 
 public class ConverterConfigurationTest {
 
+
+	private static final String CONF_PROP_HOME = "config.home";
     @TempDir
     static File folder;
+    
+    static String originalConfigHome;
+    
+    @BeforeAll
+    public static void saveConfigHomeProperty() {
+    	originalConfigHome = System.getProperty(CONF_PROP_HOME);
+    }
 
     @AfterEach
     public void reset() {
-        System.clearProperty("config.home");
+        System.clearProperty(CONF_PROP_HOME);
         ConverterConfiguration.reset();
         UrlLookup.reset();
     }
+    @AfterAll
+    public static void reloadPreviousConfigurations() {
+    	if (originalConfigHome != null)
+    		System.setProperty(CONF_PROP_HOME, originalConfigHome);
+    	else
+    		System.clearProperty(CONF_PROP_HOME);
+        UrlLookup.reset();
+    }
+
 
     @Test
     public void test_that_additional_conceptmap_values_are_loaded() throws IOException {

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -25,8 +25,9 @@ import io.github.linuxforhealth.core.terminology.UrlLookup;
 public class ConverterConfigurationTest {
 
 
-	private static final String CONF_PROP_HOME = "HL7CONVERTER_CONFIG_HOME";
-    @TempDir
+	private static final String CONF_PROP_HOME = "hl7converter.config.home";
+    
+	@TempDir
     static File folder;
     
     static String originalConfigHome;


### PR DESCRIPTION
Introduced HL7CONVERTER_CONFIG_HOME environment that should point to the location (folder) of the config.properties. 
The order of operations is to look for Config Directory and find first non empty entry:
* Environment variable
* System Properties

If Config Directory is empty the Classpath Location Strategy is used to search local resource folder