### PR TITLE
Add contributing document for DCO legal req

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,65 @@
+## Contributing In General
+Our project gladly welcomes external contributions!  We use [Pull Requests](https://github.com/LinuxForHealth/hl7v2-fhir-converter/pulls).
+
+A good way to familiarize yourself with the codebase and contribution process is
+to look at the list of [supported messages and segments](README.md) and choose a segment that is not yet done.  You can also look at our [issue tracker](https://github.com/LinuxForHealth/hl7v2-fhir-converter).
+Before embarking on a more ambitious contribution, please [get in touch](#communication) with us.
+
+### Proposing new features
+
+If you would like to implement a new feature, please [raise an issue](https://github.com/LinuxForHealth/hl7v2-fhir-converter/issues)
+before sending a pull request so the feature can be discussed. This is to avoid
+you wasting your valuable time working on a feature that the project developers
+are not interested in accepting into the code base.
+
+### Fixing bugs
+
+If you would like to fix a bug, please [raise an issue](https://github.com/LinuxForHealth/hl7v2-fhir-converter/issues) before sending a
+pull request so it can be tracked.
+
+### Merge approval
+
+A pull request requires approval from at least two of the [maintainers](MAINTAINERS.md).
+
+## Legal
+
+Each source file must include a license header for the Apache
+Software License 2.0. Using the SPDX format is the simplest approach.
+e.g.
+
+```
+/*
+ * (C) Copyright <holder> <year of first update>[, <year of last update>]
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+```
+
+We have tried to make it as easy as possible to make contributions. This
+applies to how we handle the legal aspects of contribution. We use the [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) - which is the same that the Linux® Kernel [community](https://elinux.org/Developer_Certificate_Of_Origin)
+uses to manage code contributions.
+
+When submitting a patch for review, we require that you include a sign-off statement in the commit message.
+
+Here is an example Signed-off-by line, which indicates that the
+submitter accepts the DCO:
+
+```
+Signed-off-by: John Doe <john.doe@example.com>
+```
+
+You can include this automatically when you commit a change to your
+local git repository using the following command:
+
+```
+git commit -s
+```
+
+## Communication
+To connect with us, please open an [issue](https://github.com/LinuxForHealth/hl7v2-fhir-converter/issues) or contact one of the maintainers via email. 
+See the [MAINTAINERS.md](MAINTAINERS.md) page.
+
+## Testing
+To ensure a working build, please run the full build from the root of the project before submitting your pull request.
+Pull Requests should include necessary updates to unit tests (src/test/java of the corresponding project)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ pull request so it can be tracked.
 
 ### Merge approval
 
-A pull request requires approval from at least two of the [maintainers](MAINTAINERS.md).
+A pull request requires approval from at least one of the [maintainers](MAINTAINERS.md).
 
 ## Legal
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+Maintainers:
+
+* Pushpa Bhallamudi - pbhallam@us.ibm.com
+* Lisa Wellman - peace@us.ibm.com  
+* Kathryn Whaley - kathrynl@us.ibm.com
+* Elena Baron - ebaron@us.ibm.com

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,3 +4,4 @@ Maintainers:
 * Lisa Wellman - peace@us.ibm.com  
 * Kathryn Whaley - kathrynl@us.ibm.com
 * Elena Baron - ebaron@us.ibm.com
+* Hammad Kahn - khanh@ca.ibm.com

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The converter supports the following message segments:
 * RXR - Pharmacy/Treatment Route
 * SPM - Specimen
 
-If you need another message type/event . . .  contributions are welcome! We welcome [Pull Requests](https://github.com/LinuxForHealth/hl7v2-fhir-converter/pulls)!
+If you need another message type/event . . .  contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md)!
 
 ## Development Quickstart
 

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -204,8 +204,7 @@ String hl7message =
         + "PV1|1|B|yyy|E|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
 
         + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-        + "RXA|0|1|20170513|20170513|62^HPV quadrivalent^CVX|999|||||^^^MIICSHORTCODE|||||||00^Parental Refusal^NIP002||RE\r"
-        // + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
+        + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
         + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
         + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
         + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -214,7 +214,7 @@ String hl7message =
     HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
 
     String json = ftv.convert(hl7VUXmessageRep, OPTIONS);
-    System.out.print(json);
+
     FHIRContext context = new FHIRContext();
     IBaseResource bundleResource = context.getParser().parseResource(json);
     assertThat(bundleResource).isNotNull();


### PR DESCRIPTION
This supports the use of Developer Certificate of Origin (DCO) "assertion". DCO is a "signed-off" statement in commit messages which indicates that the specific commit/contribution is able to be contributed given the current license to the best of the developer's knowledge.

This requires a CONTRIBUTING.md document, which explains how the process works.

This PR adds that CONTRIBUTING.md document and adds hyperlinks to / from other documents, such as the README.md

For each pull request from now on, the developer must "sign" 

