### PR TITLE
"ICD-10" missing from CodingSystemMappings

### DIFF
--- a/src/main/resources/hl7/codesystem/CodingSystemMapping.yml
+++ b/src/main/resources/hl7/codesystem/CodingSystemMapping.yml
@@ -134,6 +134,11 @@
   # change from http://hl7.org/fhir/sid/icd-10 to http://hl7.org/fhir/sid/icd-10-cm temporarily, see Issue #189
   url: "http://hl7.org/fhir/sid/icd-10-cm"
   oid: "urn:oid:2.16.840.1.113883.6.3"
+- id: "ICD-10"
+  description: "ICD-10"
+  # change from http://hl7.org/fhir/sid/icd-10 to http://hl7.org/fhir/sid/icd-10-cm temporarily, see Issue #189
+  url: "http://hl7.org/fhir/sid/icd-10-cm"
+  oid: "urn:oid:2.16.840.1.113883.6.3"  
 - id: "I10P"
   description: "ICD-10 Procedure Codes"
   url: "http://www.cms.gov/Medicare/Coding/ICD10"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
@@ -12,6 +12,9 @@ import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Property;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -238,6 +241,24 @@ public class HL7ConditionFHIRConversionTest {
                 .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(conditionResource).hasSize(4);
+
+        Condition condition = (Condition) conditionResource.get(1);
+        assertThat(condition.hasCode()).isTrue();
+        CodeableConcept condCC = condition.getCode();
+        assertThat(condCC.hasText()).isTrue();
+        assertThat(condCC.getText()).isEqualTo("Tachycardia, unspecified");
+        assertThat(condCC.hasCoding()).isTrue();
+        assertThat(condCC.getCoding().size()).isEqualTo(1);
+
+        Coding condCoding = condCC.getCoding().get(0);
+        assertThat(condCoding.hasSystem()).isTrue();
+        // change from http://hl7.org/fhir/sid/icd-10 to http://hl7.org/fhir/sid/icd-10-cm temporarily, see Issue #189
+        assertThat(condCoding.getSystem()).isEqualTo("http://hl7.org/fhir/sid/icd-10-cm");
+        assertThat(condCoding.hasCode()).isTrue();
+        assertThat(condCoding.getCode()).isEqualTo("R00.0");
+        assertThat(condCoding.hasDisplay()).isTrue();
+        assertThat(condCoding.getDisplay()).isEqualTo("Tachycardia, unspecified");
+        assertThat(condCoding.hasVersion()).isFalse();
 
         // TODO: Each condition should have condition.reasonReference and condition.diagnosis values (use and rank)
         // including a reference to the condition. We can not add these now because of a defect that will be addressed soon (see internal bug 665)


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

We had ICD10 and I10, but not ICD-10 as a mapping.  Simple change and small test addition to catch it.