### PR TITLE
Issue#206 First drop improved OBX support

### DIFF
--- a/TECHNIQUES.md
+++ b/TECHNIQUES.md
@@ -112,7 +112,7 @@ Not this:
 ```yaml
 telecom_1:
     condition: PID.14 NOT_NULL    
-    valueOf: datatype/Telecom
+    valueOf: datatype/ContactPoint
     generateList: true
     expressionType: resource
     specs: PID.14
@@ -124,7 +124,7 @@ Do this:
 ```yaml
 telecom_1:
     condition: $pid14 NOT_NULL    
-    valueOf: datatype/Telecom
+    valueOf: datatype/ContactPoint
     generateList: true
     expressionType: resource
     specs: PID.14

--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -10,6 +10,9 @@ import java.time.temporal.Temporal;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringTokenizer;
 import org.hl7.fhir.r4.model.codesystems.EncounterStatus;
@@ -26,27 +29,46 @@ public class Hl7RelatedGeneralUtils {
     private Hl7RelatedGeneralUtils() {
     }
 
-    public static String extractLow(Object var) {
-        String val = Hl7DataHandlerUtil.getStringValue(var);
+    // From HL7 V2.6 about range: "When the observation quantifies the amount of a toxic substance, then the upper limit of the range identifies the toxic limit. 
+    // If the observation quantifies a drug, the lower limits identify the lower therapeutic bounds and the upper limits represent 
+    // the upper therapeutic bounds above which toxic side effects are common."
+    // We don't know if it's a toxic substance or a drug, but we understand that:
+    //  1. Two values mean lower and upper limits.
+    //  2. One value only is the upper limit.
+    //
+
+    public static String extractLow(Object input) {
+        String val = Hl7DataHandlerUtil.getStringValue(input);
         if (StringUtils.isNotBlank(val)) {
-            StringTokenizer stk = new StringTokenizer(val, "-");
-            if (stk.hasNext())
-                return stk.next();
+            Pattern r = Pattern.compile("^\\D*?([\\d.]+)\\D*([\\d.]*).*");
+            Matcher m = r.matcher(val);
+
+            if (m.find() && !m.group(2).isEmpty()){
+                    return m.group(1);
+            } 
+            return null;
         }
         return null;
     }
 
-    public static String extractHigh(Object var) {
-        String val = Hl7DataHandlerUtil.getStringValue(var);
+    public static String extractHigh(Object input) {
+        String val = Hl7DataHandlerUtil.getStringValue(input);
         if (StringUtils.isNotBlank(val)) {
-            String[] values = val.split("-");
-            if (values.length == 2) {
-                return values[1];
+            Pattern r = Pattern.compile("^\\D*?([\\d.]+)\\D*([\\d.]*).*");
+            Matcher m = r.matcher(val);
+
+            if(m.find()) {
+                if (!m.group(2).isEmpty()){
+                    return m.group(2);
+                } else {
+                    return m.group(1);   
+                }
             }
+            return null;
         }
         return null;
     }
-
+  
     public static String getEncounterStatus(Object var1, Object var2, Object var3) {
         LOGGER.info("Generating encounter status from var1{}, var2 {}, var3 {}", var1, var2, var3);
         EncounterStatus status = EncounterStatus.UNKNOWN;
@@ -226,8 +248,8 @@ public class Hl7RelatedGeneralUtils {
 
 
 
-    // Takes all the pieces of telecom number from XTN, formats to a user friendly
-    // Telecom number based on rules documented in the steps
+    // Takes all the pieces of ContactPoint/telecom number from XTN, formats to a user friendly
+    // ContactPoint/Telecom number based on rules documented in the steps
     public static String getFormattedTelecomNumberValue(String xtn1Old, String xtn5Country, String xtn6Area,
             String xtn7Local, String xtn8Extension, String xtn12Unformatted) {
         String returnValue = "";

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
+import ca.uhn.hl7v2.model.Varies;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -324,6 +325,7 @@ public class SimpleDataValueResolver {
     };
 
     public static final ValueExtractor<Object, SimpleCode> CODING_SYSTEM_V2_ALTERNATE = (Object value) -> {
+        value = checkForAndUnwrapVariesObject(value);
         // ensure we have a CWE
         if (value instanceof CWE) {
             CWE cwe = (CWE) value;
@@ -337,12 +339,22 @@ public class SimpleDataValueResolver {
     };
 
     public static final ValueExtractor<Object, SimpleCode> CODING_SYSTEM_V2 = (Object value) -> {
+        value = checkForAndUnwrapVariesObject(value);
         String table = Hl7DataHandlerUtil.getTableNumber(value);
         String code = Hl7DataHandlerUtil.getStringValue(value);
         String text = Hl7DataHandlerUtil.getOriginalDisplayText(value);
         String version = Hl7DataHandlerUtil.getVersion(value);
         return commonCodingSystemV2(table, code, text, version);
     };
+
+    // For OBX.5 and other dynamic encoded fields, the real class is wrapped in the Varies class, and must be extracted from data
+    private static final Object checkForAndUnwrapVariesObject(Object value) {
+        if (value instanceof Varies) {
+            Varies v = (Varies)value;
+            value = v.getData();
+        }
+        return value;    
+    }
 
     private static final SimpleCode commonCodingSystemV2 (String table, String code, String text, String version) {
         if (table != null && code != null) {

--- a/src/main/resources/fhir/resourcemapping.yml
+++ b/src/main/resources/fhir/resourcemapping.yml
@@ -20,3 +20,4 @@ Procedure: org.hl7.fhir.r4.model.Procedure
 DocumentReference: org.hl7.fhir.r4.model.DocumentReference
 ServiceRequest: org.hl7.fhir.r4.model.ServiceRequest
 MedicationRequest: org.hl7.fhir.r4.model.MedicationRequest
+Device: org.hl7.fhir.r4.model.Device

--- a/src/main/resources/hl7/datatype/ContactPoint.yml
+++ b/src/main/resources/hl7/datatype/ContactPoint.yml
@@ -2,7 +2,8 @@
 # (C) Copyright IBM Corp. 2021
 #
 # SPDX-License-Identifier: Apache-2.0
-#
+# 
+# HL7 FHIR Data Type ContactPoint was previously called Telecom
 ---
 # system is phone or email depeding on a value in email address (XTN.4)
 system_1:

--- a/src/main/resources/hl7/resource/Device.yml
+++ b/src/main/resources/hl7/resource/Device.yml
@@ -1,0 +1,24 @@
+#
+# (C) Copyright IBM Corp. 2020, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+resourceType: Device
+id:
+  type: STRING
+  valueOf: 'UUID.randomUUID()'
+  expressionType: JEXL
+
+# The FHIR Device resource doesn't have any required fields.
+# However we do not want empty Device resources.
+# Thefore wherever Device is referenced make sure to verify the value is NOT_NULL.
+identifier:
+    valueOf: datatype/Identifier_Gen
+    generateList: true
+    expressionType: resource
+    specs: OBX.18
+    vars:
+      id: OBX.18.1
+
+  

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -154,18 +154,19 @@ method:
 
 referenceRange: 
    valueOf: secondary/ReferenceRange
+   condition: $textValue NOT_NULL
    generateList: true
    expressionType: resource
    specs: OBX.7
    vars:
-     low:  OBX.7, GeneralUtils.split(low, "-", 0)
-     high: OBX.7, GeneralUtils.split(high, "-", 1)
-     appliesto: OBX.10
-     text: OBX.7
-     type: OBX.10
+     low:  OBX.7, GeneralUtils.extractLow(low)
+     high: OBX.7, GeneralUtils.extractHigh(high)
+     appliestoValue: OBX.10
+     textValue: OBX.7
+     typeValue: OBX.10
      unit: OBX.6
 
-performer:
+performer_1:
    condition: $performerValue NOT_NULL
    valueOf: resource/Practitioner
    generateList: true
@@ -174,4 +175,23 @@ performer:
    vars:
      performerValue: OBX.16
 
+performer_2:
+   condition: $performerValue2 NOT_NULL
+   valueOf: resource/Organization
+   generateList: true
+   expressionType: reference
+   specs: OBX.23
+   vars:
+     performerValue2: OBX.23
+     orgAddressXAD: OBX.24
+     orgContactXCN: OBX.25
+
+device:
+   condition: $deviceValue NOT_NULL
+   valueOf: resource/Device
+   generateList: true
+   expressionType: reference
+   specs: OBX.18
+   vars:
+     deviceValue: OBX.18
 

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -61,7 +61,7 @@ address:
    specs: PID.11
 telecom_1:
    condition: $pid14 NOT_NULL
-   valueOf: datatype/Telecom
+   valueOf: datatype/ContactPoint
    generateList: true
    expressionType: resource
    specs: PID.14
@@ -72,7 +72,7 @@ telecom_1:
 # The yaml is processed in reverse order, therefore
 telecom_2:
    condition: $pid13 NOT_NULL
-   valueOf: datatype/Telecom
+   valueOf: datatype/ContactPoint
    generateList: true
    expressionType: resource
    specs: PID.13

--- a/src/main/resources/hl7/secondary/Contact.yml
+++ b/src/main/resources/hl7/secondary/Contact.yml
@@ -1,0 +1,12 @@
+#
+# (C) Copyright IBM Corp. 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+
+name:
+  valueOf: datatype/HumanName
+  expressionType: resource
+  specs: XCN | $contactNameXCN
+

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -116,6 +116,61 @@ public class Hl7RelatedGeneralUtilsTest {
   }
 
 
+  // ExtractHigh and ExtractLow assumes if there are two or more values, the first is low, the second is high,
+  // but if there is only one value, it is the high
+  @Test
+  public void testExtractHigh() {
+
+    String aString = "27.0-55.2";
+    String resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+    assertThat(resultValue).isEqualTo("55.2");
+
+    aString = "47.47";
+    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+    assertThat(resultValue).isEqualTo("47.47");
+
+    aString = "<0.50 IU/mL";
+    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+    assertThat(resultValue).isEqualTo("0.50");
+
+    aString = "something111another222more333done";
+    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+    assertThat(resultValue).isEqualTo("222");
+
+    aString = "Normal";
+    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+    assertThat(resultValue).isNull();
+
+  }
+
+  // ExtractHigh and ExtractLow assumes if there are two or more values, the first is low, the second is high,
+  // but if there is only one value, it is the high
+  @Test
+  public void testExtractLow() {
+
+    String aString = "27.0-55.2";
+    String resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+    assertThat(resultValue).isEqualTo("27.0");
+
+    aString = "47.47";
+    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+    assertThat(resultValue).isNull();
+
+    aString = "<0.50 IU/mL";
+    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+    assertThat(resultValue).isNull();
+
+    aString = "something111another222more333done";
+    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+    assertThat(resultValue).isEqualTo("111");
+
+    aString = "Normal";
+    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+    assertThat(resultValue).isNull();
+
+  }
+
+
   @Test
   public void test_makeStringArray() {
     // Test for 2

--- a/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020. 2021
+ * (C) Copyright IBM Corp. 2020,2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,8 +14,13 @@ import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Device;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Observation.ObservationReferenceRangeComponent;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -27,154 +32,384 @@ import com.google.common.collect.Lists;
 import io.github.linuxforhealth.api.ResourceModel;
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.resource.ResourceReader;
+import io.github.linuxforhealth.hl7.ConverterOptions;
+import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
+import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
 public class DifferentObservationValueTest {
-    private static FHIRContext context = new FHIRContext();
-    private static HL7MessageEngine engine = new HL7MessageEngine(context);
+        private static FHIRContext context = new FHIRContext();
+        private static HL7MessageEngine engine = new HL7MessageEngine(context);
+        private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
 
-    private String baseMessage = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\r"
-            + "EVN|A01|20130617154644\r"
-            + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^Sr^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-            + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-            + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r";
+        private String baseMessage = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\r"
+                        + "EVN|A01|20130617154644\r"
+                        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^Sr^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+                        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r";
 
-    private ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Observation");
+        private ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Observation");
 
-    HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
-            .withResourceName("Observation").withResourceModel(rsm).withSegment("OBX")
-            .withIsReferenced(false).withRepeats(true).build();
+        HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
+                        .withResourceName("Observation").withResourceModel(rsm).withSegment("OBX")
+                        .withIsReferenced(false).withRepeats(true).build();
 
-    HL7FHIRResourceTemplate observation = new HL7FHIRResourceTemplate(attributes);
+        HL7FHIRResourceTemplate observation = new HL7FHIRResourceTemplate(attributes);
+        private HL7MessageModel message = new HL7MessageModel("ADT", Lists.newArrayList(observation));
 
-    private HL7MessageModel message = new HL7MessageModel("ADT", Lists.newArrayList(observation));
+        @Test
+        public void test_observation_NM_result() throws IOException {
+                String hl7message = baseMessage + "OBX|1|NM|0135–4^TotalProtein||7.3|gm/dl|5.9-8.4|||R|F";
+                String json = message.convert(hl7message, engine);
+                System.out.println(json);
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.getValueQuantity()).isNotNull();
+                Quantity q = obs.getValueQuantity();
+                assertThat(q.getUnit()).isEqualTo("gm/dl");
+                assertThat(q.getValue().floatValue()).isEqualTo(7.3f);
+                assertThat(obs.hasReferenceRange()).isTrue();
+                assertThat(obs.getReferenceRange()).hasSize(1);
+                ObservationReferenceRangeComponent range = obs.getReferenceRangeFirstRep();
+                assertThat(range).isNotNull();
+                assertThat(range.hasHigh()).isTrue();
+                assertThat(range.hasLow()).isTrue();
+                Quantity high = range.getHigh();
+                assertThat(high.getUnit()).isEqualTo("gm/dl");
+                assertThat(high.getValue().floatValue()).isEqualTo(8.4f);
+                Quantity low = range.getLow();
+                assertThat(low.getValue().floatValue()).isEqualTo(5.9f);
+                assertThat(low.getUnit()).isEqualTo("gm/dl");
+        }
 
-    @Test
-    public void test_observation_NM_result() throws IOException {
-        String hl7message = baseMessage + "OBX|1|NM|0135–4^TotalProtein||7.3|gm/dl|5.9-8.4||||F";
-        String json = message.convert(hl7message, engine);
+        @Test
+        public void test_observation_TX_result() throws IOException {
+                String hl7message = baseMessage
+                                + "OBX|1|TX|^Type of protein feed^L||Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F||||Alex||";
+                String json = message.convert(hl7message, engine);
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-        Observation obs = (Observation) obsResource.get(0);
-        assertThat(obs.getValueQuantity()).isNotNull();
-        Quantity q = obs.getValueQuantity();
-        assertThat(q.getUnit()).isEqualTo("gm/dl");
-        assertThat(q.getValue().floatValue()).isEqualTo(7.3f);
-    }
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.getValueStringType()).isNotNull();
+                StringType q = obs.getValueStringType();
+                assertThat(q.asStringValue())
+                                .isEqualTo("Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
+        }
 
-    @Test
-    public void test_observation_TX_result() throws IOException {
-        String hl7message = baseMessage
-                + "OBX|1|TX|^Type of protein feed^L||Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F||||Alex||";
-        String json = message.convert(hl7message, engine);
+        @Test
+        public void test_observation_TX_multiple_parts_result() throws IOException {
+                String hl7message = baseMessage
+                                + "OBX|1|TX|^Type of protein feed^L||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%~Fifth line, as part of a repeated field||||||F||";
+                String json = message.convert(hl7message, engine);
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.getValueStringType()).isNotNull();
+                StringType q = obs.getValueStringType();
+                assertThat(q.asStringValue()).isEqualTo(
+                                "HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%. Fifth line, as part of a repeated field.");
+        }
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-        Observation obs = (Observation) obsResource.get(0);
-        assertThat(obs.getValueStringType()).isNotNull();
-        StringType q = obs.getValueStringType();
-        assertThat(q.asStringValue())
-                .isEqualTo("Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
-    }
+        @Test
+        public void test_observation_CE_result_unknown_system() throws IOException {
+                String hl7message = baseMessage
+                                + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
+                String json = message.convert(hl7message, engine);
 
-    @Test
-    public void test_observation_TX_multiple_parts_result() throws IOException {
-        String hl7message = baseMessage
-                + "OBX|1|TX|^Type of protein feed^L||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%~Fifth line, as part of a repeated field||||||F||";
-        String json = message.convert(hl7message, engine);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-        Observation obs = (Observation) obsResource.get(0);
-        assertThat(obs.getValueStringType()).isNotNull();
-        StringType q = obs.getValueStringType();
-        assertThat(q.asStringValue()).isEqualTo(
-                "HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%. Fifth line, as part of a repeated field.");
-    }
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.getValueCodeableConcept()).isNotNull();
+                assertThat(obs.getStatus()).isNotNull();
+                CodeableConcept cc = obs.getValueCodeableConcept();
+                assertThat(cc.getCoding()).isNotNull();
+                assertThat(cc.getCoding().get(0)).isNotNull();
+                assertThat(cc.getCoding().get(0).getSystem()).isNull();
+                assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
+                assertThat(cc.getText()).isEqualTo("No significant change was found");
+        }
 
-    @Test
-    public void test_observation_CE_result_unknown_system() throws IOException {
-        String hl7message = baseMessage + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
-        String json = message.convert(hl7message, engine);
+        @Test
+        public void test_observation_CE_result_known_system() throws IOException {
+                String hl7message = baseMessage
+                                + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^LN";
+                String json = message.convert(hl7message, engine);
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-        Observation obs = (Observation) obsResource.get(0);
-        assertThat(obs.getValueCodeableConcept()).isNotNull();
-        assertThat(obs.getStatus()).isNotNull();
-        CodeableConcept cc = obs.getValueCodeableConcept();
-        assertThat(cc.getCoding()).isNotNull();
-        assertThat(cc.getCoding().get(0)).isNotNull();
-        assertThat(cc.getCoding().get(0).getSystem()).isNull();
-        assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
-        assertThat(cc.getText()).isEqualTo("No significant change was found");
-    }
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.getValueCodeableConcept()).isNotNull();
+                assertThat(obs.getStatus()).isNotNull();
+                CodeableConcept cc = obs.getValueCodeableConcept();
+                assertThat(cc.getCoding()).isNotNull();
+                assertThat(cc.getCoding().get(0)).isNotNull();
+                assertThat(cc.getCoding().get(0).getSystem()).isEqualTo("http://loinc.org");
+                assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
+                assertThat(cc.getText()).isEqualTo("No significant change was found");
+        }
 
-    @Test
-    public void test_observation_CE_result_known_system() throws IOException {
-        String hl7message = baseMessage + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^LN";
-        String json = message.convert(hl7message, engine);
+        @Test
+        public void test_observation_ST_null_result() throws IOException {
+                String hl7message = baseMessage
+                                + "OBX|1|ST|14151-5^HCO3 BldCo-sCnc^LN|TEST|||||||F|||20210311122016|||||20210311122153||||";
+                String json = message.convert(hl7message, engine);
+                System.out.println(json);
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.getValueStringType()).isNotNull();
+                StringType q = obs.getValueStringType();
+                assertThat(q.asStringValue()).isNull();
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-        Observation obs = (Observation) obsResource.get(0);
-        assertThat(obs.getValueCodeableConcept()).isNotNull();
-        assertThat(obs.getStatus()).isNotNull();
-        CodeableConcept cc = obs.getValueCodeableConcept();
-        assertThat(cc.getCoding()).isNotNull();
-        assertThat(cc.getCoding().get(0)).isNotNull();
-        assertThat(cc.getCoding().get(0).getSystem()).isEqualTo("http://loinc.org");
-        assertThat(cc.getCoding().get(0).getCode()).isEqualTo("1305");
-        assertThat(cc.getText()).isEqualTo("No significant change was found");
-    }
+                // Check the coding  (OBX.3)
+                assertThat(obs.hasCode()).isTrue();
+                checkCommonCodeableConceptAssertions(obs.getCode(), "14151-5", "HCO3 BldCo-sCnc", "http://loinc.org",
+                                "HCO3 BldCo-sCnc");
 
-    @Test
-    public void test_observation_ST_null_result() throws IOException {
-        String hl7message = baseMessage
-                + "OBX|1|ST|14151-5^HCO3 BldCo-sCnc^LN|TEST|||||||F|||20210311122016|||||20210311122153||||";
-        String json = message.convert(hl7message, engine);
+                // Check the effective Date Time  (OBX 14)
+                assertThat(obs.hasEffective()).isTrue();
+                assertThat(obs.hasEffectiveDateTimeType()).isTrue();
+                assertThat(obs.getEffectiveDateTimeType().asStringValue()).isEqualTo("2021-03-11T12:20:16+08:00");
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-        Observation obs = (Observation) obsResource.get(0);
-        assertThat(obs.getValueStringType()).isNotNull();
-        StringType q = obs.getValueStringType();
-        assertThat(q.asStringValue()).isEqualTo(null);
-    }
+        }
+
+        // Tests most fields of OBX
+        @Test
+        public void extendedObservationCWEtest() throws IOException {
+                String hl7message = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A01^ADT_A01|||2.6||||||||2.6\r"
+                                + "OBX|1|CWE|DQW^Some text 1^SNM3|100|DQW^Other text 2^SNM3|mm^Text 3^SNM3|56-98|IND|25|ST|F|20210322153839|LKJ|20210320153850|N56|1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567|20210322153925|Observation Site^Text 5^SNM3|Instance Identifier||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
+
+                String json = message.convert(hl7message, engine);
+                System.out.println(json);
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(1);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.hasValueCodeableConcept()).isTrue();
+
+                // Check the coding  (OBX.3)
+                assertThat(obs.hasCode()).isTrue();
+                checkCommonCodeableConceptAssertions(obs.getCode(), "DQW", "Some text 1",
+                                "http://terminology.hl7.org/CodeSystem/SNM3", "Some text 1");
+
+                // Check the value  (OBX.5)
+                assertThat(obs.hasValueCodeableConcept()).isTrue();
+                checkCommonCodeableConceptAssertions(obs.getValueCodeableConcept(), "DQW", "Other text 2",
+                                "http://terminology.hl7.org/CodeSystem/SNM3", "Other text 2");
+
+                // OBX.6 is ignored because the record can only have one valueX and this one is valueCodeableConcept. See test test_observation_NM_result.
+                assertThat(obs.hasReferenceRange()).isTrue();
+                assertThat(obs.getReferenceRange()).hasSize(1);
+                ObservationReferenceRangeComponent range = obs.getReferenceRangeFirstRep();
+                assertThat(range).isNotNull();
+                assertThat(range.hasHigh()).isTrue();
+                assertThat(range.hasLow()).isTrue();
+                Quantity high = range.getHigh();
+                assertThat(high.getUnit()).isEqualTo("mm");
+                assertThat(high.getValue().floatValue()).isEqualTo(98.0f);
+                Quantity low = range.getLow();
+                assertThat(low.getValue().floatValue()).isEqualTo(56.0f);
+                assertThat(low.getUnit()).isEqualTo("mm");
+
+                // Check interpretation (OBX.8)
+                assertThat(obs.hasInterpretation()).isTrue();
+                assertThat(obs.getInterpretation()).hasSize(1);
+                checkCommonCodeableConceptAssertions(obs.getInterpretationFirstRep(), "IND", "Indeterminate",
+                                "http://terminology.hl7.org/CodeSystem/v2-0078", "IND");
+
+                // Check the effective Date Time  (OBX.14)
+                assertThat(obs.hasEffective()).isTrue();
+                assertThat(obs.hasEffectiveDateTimeType()).isTrue();
+                assertThat(obs.getEffectiveDateTimeType().asStringValue()).isEqualTo("2021-03-20T15:38:50+08:00");
+
+                // Check performer  (OBX.16 Practictioner + OBX.23/OBX.24/OBX.25 Organization)
+                assertThat(obs.hasPerformer()).isTrue();
+                assertThat(obs.getPerformer()).hasSize(2); // Practioner and Organization
+                // Get Practitioner and see that it is populated with OBX.16 information
+                assertThat(obs.getPerformer().get(0).hasReference()).isTrue();
+                List<Resource> practitionerResource = e.stream()
+                                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(practitionerResource).hasSize(1);
+                Practitioner doctor = getResourcePractitioner(practitionerResource.get(0));
+                assertThat(doctor.getName().get(0).getFamily()).isEqualTo("ClinicianLastName");
+                // Get Organization and see that it is populated with OBX.23/OBX.24/OBX.25 information
+                assertThat(obs.getPerformer().get(1).hasReference()).isTrue();
+                List<Resource> organizationResource = e.stream()
+                                .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(organizationResource).hasSize(1);
+                Organization org = getResourceOrganization(organizationResource.get(0));
+                assertThat(org.getName()).isEqualTo("Radiology");; // from OBX.23
+                assertThat(org.getAddress().get(0).getCity()).isEqualTo("Albany"); // from OBX.24
+                assertThat(org.getContact().get(0).getName().getFamily()).isEqualTo("ContactLastName"); // from OBX.25
+
+                // Check method  (OBX.17)
+                assertThat(obs.hasMethod()).isTrue();
+                checkCommonCodeableConceptAssertions(obs.getMethod(), "Manual", "Text the 4th",
+                                "http://terminology.hl7.org/CodeSystem/SNM3", "Text the 4th");
+
+                // Check device  (OBX.18)
+                assertThat(obs.hasDevice()).isTrue();
+                assertThat(obs.getDevice().hasReference()).isTrue();
+                List<Resource> deviceResource = e.stream()
+                                .filter(v -> ResourceType.Device == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(deviceResource).hasSize(1);
+                Device device = getResourceDevice(deviceResource.get(0));
+                assertThat(device.getIdentifier().get(0).getValue()).isEqualTo("Device_1234567");
+
+                // Check bodySite  (OBX.20)
+                assertThat(obs.hasBodySite()).isTrue();
+                checkCommonCodeableConceptAssertions(obs.getBodySite(), "Observation Site", "Text 5",
+                                "http://terminology.hl7.org/CodeSystem/SNM3", "Text 5");
+
+                // OBX.23/OBX.24/OBX.25 went into Performer: Organization.  Checked above
+
+        }
+
+        // A companion test to extendedObservationCWEtest that looks for edge cases
+        @Test
+        public void extendedObservationUnusualRangeTest() throws IOException {
+                String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
+                                + "PID|1||||DOE^JANE||||||||||||\r"
+                                + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
+                                + "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
+                                + "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
+                                + "OBX|2|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
+
+                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+                String json = ftv.convert(ORU_r01, OPTIONS);
+
+                FHIRContext context = new FHIRContext();
+                IBaseResource bundleResource = context.getParser().parseResource(json);
+                assertThat(bundleResource).isNotNull();
+                Bundle b = (Bundle) bundleResource;
+                List<BundleEntryComponent> e = b.getEntry();
+                List<Resource> obsResource = e.stream()
+                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                assertThat(obsResource).hasSize(2);
+                Observation obs = (Observation) obsResource.get(0);
+                assertThat(obs.hasReferenceRange()).isTrue();
+                assertThat(obs.getReferenceRange()).hasSize(1);
+                ObservationReferenceRangeComponent range = obs.getReferenceRangeFirstRep();
+                assertThat(range).isNotNull();
+                assertThat(range.hasHigh()).isFalse();
+                assertThat(range.hasLow()).isFalse();
+                assertThat(range.hasText()).isTrue();
+                assertThat(range.getText()).isEqualTo("Normal");
+
+                obs = (Observation) obsResource.get(1);
+                assertThat(obs.hasReferenceRange()).isTrue();
+                assertThat(obs.getReferenceRange()).hasSize(1);
+                range = obs.getReferenceRangeFirstRep();
+                assertThat(range).isNotNull();
+                assertThat(range.hasHigh()).isTrue();
+                assertThat(range.hasLow()).isFalse();
+                Quantity high = range.getHigh();
+                assertThat(high.getUnit()).isEqualTo("[IU]/mL");
+                assertThat(high.getValue().floatValue()).isEqualTo(0.5f);
+                assertThat(range.hasText()).isTrue();
+                assertThat(range.getText()).isEqualTo("<0.50 IU/mL");
+
+        }
+
+        // Common check for values of a codeable concept.  Null in any input indicates it should check False
+        public static void checkCommonCodeableConceptAssertions(CodeableConcept cc, String code, String display,
+                        String system, String text) {
+                if (text == null) {
+                        assertThat(cc.hasText()).isFalse();
+                } else {
+                        assertThat(cc.hasText()).isTrue();
+                        assertThat(cc.getText()).isEqualTo(text);
+                }
+
+                if (code == null && display == null && system == null) {
+                        assertThat(cc.hasCoding()).isFalse();
+                } else {
+                        assertThat(cc.hasCoding()).isTrue();
+                        assertThat(cc.getCoding().size()).isEqualTo(1);
+                        Coding coding = cc.getCoding().get(0);
+                        if (code == null) {
+                                assertThat(coding.hasCode()).isFalse();
+                        } else {
+                                assertThat(coding.hasCode()).isTrue();
+                                assertThat(coding.getCode()).isEqualTo(code);
+                        }
+                        if (display == null) {
+                                assertThat(coding.hasDisplay()).isFalse();
+                        } else {
+                                assertThat(coding.hasDisplay()).isTrue();
+                                assertThat(coding.getDisplay()).isEqualTo(display);
+                        }
+                        if (system == null) {
+                                assertThat(coding.hasSystem()).isFalse();
+                        } else {
+                                assertThat(coding.hasSystem()).isTrue();
+                                assertThat(coding.getSystem()).isEqualTo(system);
+                        }
+                }
+        }
+
+        private static Practitioner getResourcePractitioner(Resource resource) {
+                String s = context.getParser().encodeResourceToString(resource);
+                Class<? extends IBaseResource> klass = Practitioner.class;
+                return (Practitioner) context.getParser().parseResource(klass, s);
+        }
+
+        private static Organization getResourceOrganization(Resource resource) {
+                String s = context.getParser().encodeResourceToString(resource);
+                Class<? extends IBaseResource> klass = Organization.class;
+                return (Organization) context.getParser().parseResource(klass, s);
+        }
+
+        private static Device getResourceDevice(Resource resource) {
+                String s = context.getParser().encodeResourceToString(resource);
+                Class<? extends IBaseResource> klass = Device.class;
+                return (Device) context.getParser().parseResource(klass, s);
+        }
 
 }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Change datatype/Telecom to datatype/ContactPoint to be more consistent with HL7 FHIR terminology
Add support for ranges with only a High value
Add support for dynamic encoded field content, such as OBX.5 that wrapper values in a Varies object
Add Device object for referencing
Add Organization as Performer reference
Add support for Contact object
Add unit tests to verify OBX CWE, OBX: 3, 5, 6, 8, 14, 16, 17, 18, 20, 23, 24, 25