### PR TITLE
Issue#212 provide text when unknown id codings

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,6 +34,7 @@ public enum SimpleDataTypeMapper {
   OBJECT(SimpleDataValueResolver.OBJECT),
   CODING_SYSTEM_V2(SimpleDataValueResolver.CODING_SYSTEM_V2),
   CODING_SYSTEM_V2_ALTERNATE(SimpleDataValueResolver.CODING_SYSTEM_V2_ALTERNATE),
+  CODING_SYSTEM_V2_IDENTIFIER(SimpleDataValueResolver.CODING_SYSTEM_V2_IDENTIFIER),
   SYSTEM_URL(SimpleDataValueResolver.SYSTEM_URL),
   SYSTEM_ID(SimpleDataValueResolver.SYSTEM_ID),
 

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -324,6 +324,25 @@ public class SimpleDataValueResolver {
         return value;
     };
 
+    // Special case of a SYSTEM V2.  Identifiers allow unkown codes.
+    // When an unknown code is detected, return a null so that the text is displayed instead.
+    // Only a known code returns a coding.
+    public static final ValueExtractor<Object, SimpleCode> CODING_SYSTEM_V2_IDENTIFIER = (Object value) -> {
+        value = checkForAndUnwrapVariesObject(value);
+        String table = Hl7DataHandlerUtil.getTableNumber(value);
+        String code = Hl7DataHandlerUtil.getStringValue(value);
+        if (table != null && code != null) {
+            // Found table and a code. Try looking it up.
+            SimpleCode coding = TerminologyLookup.lookup(table, code);
+            // A non-null, non-empty value in display means a good code from lookup.
+            if (coding != null && coding.getDisplay()!=null && !coding.getDisplay().isEmpty()) {
+                return coding;
+            }
+        }    
+        // All other situations return null.  
+        return null;
+    };
+
     public static final ValueExtractor<Object, SimpleCode> CODING_SYSTEM_V2_ALTERNATE = (Object value) -> {
         value = checkForAndUnwrapVariesObject(value);
         // ensure we have a CWE

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -324,7 +324,7 @@ public class SimpleDataValueResolver {
         return value;
     };
 
-    // Special case of a SYSTEM V2.  Identifiers allow unkown codes.
+    // Special case of a SYSTEM V2.  Identifiers allow unknown codes.
     // When an unknown code is detected, return a null so that the text is displayed instead.
     // Only a known code returns a coding.
     public static final ValueExtractor<Object, SimpleCode> CODING_SYSTEM_V2_IDENTIFIER = (Object value) -> {

--- a/src/main/resources/hl7/datatype/CodeableConcept.yml
+++ b/src/main/resources/hl7/datatype/CodeableConcept.yml
@@ -19,7 +19,7 @@ coding_1:
 
 coding_2:
    condition: $code NOT_NULL && $coding NULL
-   type: CODING_SYSTEM_V2
+   type: CODING_SYSTEM_V2_IDENTIFIER
    valueOf: ID |IS |TX
    generateList: true
    expressionType: HL7Spec
@@ -49,10 +49,9 @@ coding_5:
    condition: $coding NOT_NULL
    generateList: true
    
-# If hideText is not passed by parent, the value is NULL, making it backward compatible with all other uses of CodeableConcept
-# Any value in hideText will cause the text to be hidden.  Used by Identifier_SystemID. 
+# Require available text, and the absense of an identifierCoding
 text:
-   condition: $hideText NULL && $displayText NOT_NULL
+   condition: $displayText NOT_NULL && identifierCoding NULL
    type: STRING
    valueOf: $displayText
    vars:

--- a/src/main/resources/hl7/datatype/Identifier_SystemID.yml
+++ b/src/main/resources/hl7/datatype/Identifier_SystemID.yml
@@ -9,9 +9,10 @@ type:
    valueOf: datatype/CodeableConcept
    expressionType: resource
    specs: CX.5 | $type
-   constants: 
-      # Because calculated system id's don't have text, force the calculated text from code to be hidden
-      hideText: 'HIDE'
+   vars: 
+     # Because calculated system id's don't have text if there is a valid system, 
+     # see if there is a valid code and system as input to creating text in the CodeableConcept
+     identifierCoding: CODING_SYSTEM_V2_IDENTIFIER, CX.5
 
 system: 
      condition: $systemExists NOT_NULL

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -110,14 +110,14 @@ public class Hl7IdentifierFHIRConversionTest {
     @Test
     public void patientIdentifiersSpecialCasesTest() {
         String patientIdentifiersSpecialCases = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-                // First ID has blanks in the authority.  Second ID has no authority provided.
-                + "PID|1||MRN12345678^^^Regional Health ID^MR~111223333^^^^SS|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";
+                // First ID has blanks in the authority.  Second ID has no authority provided.  Third ID has an unknown CODE in the standard v2 table. 
+                + "PID|1||MRN12345678^^^Regional Health ID^MR~111223333^^^^SS~A100071402^^^^AnUnknownCode|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";
         Patient patient = PatientUtils.createPatientFromHl7Segment(patientIdentifiersSpecialCases);
 
         // Expect 2 identifiers
         assertThat(patient.hasIdentifier()).isTrue();
         List<Identifier> identifiers = patient.getIdentifier();
-        assertThat(identifiers.size()).isEqualTo(2);
+        assertThat(identifiers.size()).isEqualTo(3);
 
         // First identifier (Medical Record) deep check
         Identifier identifier = identifiers.get(0);
@@ -134,7 +134,7 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getCode()).hasToString("MR");
         assertThat(coding.getDisplay()).hasToString("Medical record number");
 
-        // Deep check for second identifier
+        // Second identifier
         identifier = identifiers.get(1);
         // We expect no system because there was no authority.
         assertThat(identifier.hasSystem()).isFalse();
@@ -147,6 +147,22 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getSystem()).hasToString("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).hasToString("SS");
         assertThat(coding.getDisplay()).hasToString("Social Security number");
+
+        // Third identifier - unknown code.  Create the following:
+        // "identifier": [ {
+        //         "type": {
+        //           "text": "AnUnknownCode"
+        //         },
+        //         "value": "A100071402"
+        //       },
+        identifier = identifiers.get(2);
+        assertThat(identifier.hasSystem()).isFalse();
+        assertThat(identifier.getValue()).hasToString("A100071402");
+        assertThat(identifier.hasType()).isTrue();
+        cc = identifier.getType();
+        assertThat(cc.hasText()).isTrue();
+        assertThat(cc.getText()).hasToString("AnUnknownCode");     
+        assertThat(cc.hasCoding()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Code adjusted so that IDs that look up to a valid coding and system, the coding and system are provided, but not text.  FHIR search will still work because the the original code value is in the coding.  Text is unneeded, and is duplicate.

When a code does not resolve to the implied system, the type will contain only a text field with the code.