### PR TITLE
Issue#220 additional obx support

### DIFF
--- a/src/main/resources/hl7/datatype/Quantity.yml
+++ b/src/main/resources/hl7/datatype/Quantity.yml
@@ -14,9 +14,12 @@ comparator :
 unit : 
    type: String
    valueOf: $unit
-system : 
+system_1 : 
    type: URI
    valueOf: $system
+system_2: 
+   type: STRING
+   valueOf: $resolvedSystem   
 code : 
    type: String
    valueOf: $code

--- a/src/main/resources/hl7/message/ORU_R01.yml
+++ b/src/main/resources/hl7/message/ORU_R01.yml
@@ -41,6 +41,7 @@ resources:
       additionalSegments: 
           - .OBR
           - .OBSERVATION.NTE
+          - .SPECIMEN.SPM
           - MSH
         
     - resourceName: Specimen

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -100,17 +100,7 @@ note:
    vars:
       obx3: STRING, OBX.3.1
       text: STRING, OBX.5
-reasonCode:
-   valueOf: datatype/CodeableConcept_var
-   expressionType: resource
-   generateList: true
-   condition: $obx3 EQUALS 59785-6
-   specs: OBX
-   vars:
-      obx3: STRING, OBX.3.1
-      code: STRING, OBX.5.1
-      text: STRING, OBX.5.2
-      system: STRING, OBX.5.3
+
       
 reasonReference:
    valueOf: datatype/Reference

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -23,6 +23,15 @@ identifier_1: #joins filler | placer | MSH.7 with whatever gets returned from BU
       sys: "urn:id:extID"
       joinChar: '-'
 
+identifier_2:
+   condition: $valueIn NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true
+   expressionType: resource
+   vars:
+      valueIn: OBX.21.1 
+      systemCX: OBX.21.2  
+
 status:
    type: OBSERVATION_STATUS
    default: unknown
@@ -73,8 +82,9 @@ valueQuantity:
     condition: $obx2 EQUALS NM
     vars: 
       value: OBX.5
-      unit: OBX.6
+      unit: OBX.6.1
       obx2: STRING, OBX.2
+      resolvedSystem: SYSTEM_URL, OBX.6.3
 
 
 valueCodeableConcept:
@@ -139,6 +149,7 @@ note_1:
 note_2:
    valueOf: datatype/Annotation
    generateList: true
+   condition: NTE NOT_NULL
    expressionType: resource
    specs: NTE
 
@@ -195,3 +206,15 @@ device:
    vars:
      deviceValue: OBX.18
 
+category:
+   condition: $specimen NOT_NULL
+   valueOf: datatype/CodeableConcept_var
+   generateList: true
+   expressionType: resource
+   vars: 
+      system: SYSTEM_URL, $system_code
+      specimen: SPM.4
+   constants:
+      code: 'laboratory'
+      system_code: 'observation-category'
+      display: 'Laboratory'

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -46,3 +46,8 @@ contact:
    generateList: true
    expressionType: resource
    specs: $orgContactXCN
+   constants:
+      code: 'ADMIN'
+      system_code: 'contactentity-type'
+      display: 'Administrative'
+      text: 'Organization Medical Director'

--- a/src/main/resources/hl7/secondary/Contact.yml
+++ b/src/main/resources/hl7/secondary/Contact.yml
@@ -4,8 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-  
+purpose:
+   valueOf: datatype/CodeableConcept_var
+   condition: $code NOT_NULL || $display NOT_NULL || $system_code NOT_NULL || text NOT_NULL
+   generateList: true
+   expressionType: resource
+   vars: 
+      system: SYSTEM_URL, $system_code
+
 name:
   valueOf: datatype/HumanName
   expressionType: resource
   specs: XCN | $contactNameXCN
+

--- a/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
@@ -284,12 +284,17 @@ public class DifferentObservationValueTest {
                 assertThat(organizationResource).hasSize(1);
                 Organization org = getResourceOrganization(organizationResource.get(0));
                 assertThat(org.getName()).isEqualTo("Radiology"); // from OBX.23
-                assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString()).isEqualTo("467 Albany Hospital"); // from OBX.24
+                assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString())
+                                .isEqualTo("467 Albany Hospital"); // from OBX.24
                 assertThat(org.getAddress().get(0).getCity()).isEqualTo("Albany"); // from OBX.24
                 assertThat(org.getAddress().get(0).getState()).isEqualTo("NY"); // from OBX.24
                 assertThat(org.getContact().get(0).getName().getFamily()).isEqualTo("ContactLastName"); // from OBX.25
                 assertThat(org.getContact().get(0).getName().getGiven().get(0).getValueAsString()).isEqualTo("Jane"); // from OBX.25
                 assertThat(org.getContact().get(0).getName().getText()).isEqualTo("Dr. Jane Q ContactLastName"); // from OBX.25
+                assertThat(org.getContact().get(0).hasPurpose()).isTrue(); // purpose added because of OBX.25
+                checkCommonCodeableConceptAssertions(org.getContact().get(0).getPurpose(), "ADMIN", "Administrative",
+                                "http://terminology.hl7.org/CodeSystem/contactentity-type",
+                                "Organization Medical Director");
 
                 // Check method  (OBX.17)
                 assertThat(obs.hasMethod()).isTrue();
@@ -382,8 +387,8 @@ public class DifferentObservationValueTest {
                 assertThat(obs.hasCategory()).isTrue();
                 assertThat(obs.getCategory()).hasSize(1);
                 checkCommonCodeableConceptAssertions(obs.getCategoryFirstRep(), "laboratory", "Laboratory",
-                "http://terminology.hl7.org/CodeSystem/observation-category", null);
- 
+                                "http://terminology.hl7.org/CodeSystem/observation-category", null);
+
         }
 
         // Common check for values of a codeable concept.  Null in any input indicates it should check False

--- a/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/DifferentObservationValueTest.java
@@ -215,7 +215,7 @@ public class DifferentObservationValueTest {
         @Test
         public void extendedObservationCWEtest() throws IOException {
                 String hl7message = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A01^ADT_A01|||2.6||||||||2.6\r"
-                                + "OBX|1|CWE|DQW^Some text 1^SNM3|100|DQW^Other text 2^SNM3|mm^Text 3^SNM3|56-98|IND|25|ST|F|20210322153839|LKJ|20210320153850|N56|1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567|20210322153925|Observation Site^Text 5^SNM3|Instance Identifier||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
+                                + "OBX|1|CWE|DQW^Some text 1^SNM3|100|DQW^Other text 2^SNM3|mm^Text 3^SNM3|56-98|IND|25|ST|F|20210322153839|LKJ|20210320153850|N56|1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
 
                 String json = message.convert(hl7message, engine);
 
@@ -311,19 +311,28 @@ public class DifferentObservationValueTest {
                 checkCommonCodeableConceptAssertions(obs.getBodySite(), "Observation Site", "Text 5",
                                 "http://terminology.hl7.org/CodeSystem/SNM3", "Text 5");
 
-                // OBX.23/OBX.24/OBX.25 went into Performer: Organization.  Checked above
+                // Check identifier  (OBX.21)
+                assertThat(obs.hasIdentifier()).isTrue();
+                assertThat(obs.getIdentifier()).hasSize(2);
+                assertThat(obs.getIdentifier().get(1).getValue()).isEqualTo("INST");
+                assertThat(obs.getIdentifier().get(1).getSystem()).isEqualTo("urn:id:Instance_Identifier_System");
 
+                // OBX.23/OBX.24/OBX.25 went into Performer: Organization.  Checked above.
+
+                // Check for ABSENCE of category (because no SPM)  Presence of category tested in extendedObservationUnusualRangesAndOtherTest
+                assertThat(obs.hasCategory()).isFalse();
         }
 
         // A companion test to extendedObservationCWEtest that looks for edge cases
         @Test
-        public void extendedObservationUnusualRangeTest() throws IOException {
+        public void extendedObservationUnusualRangesAndOtherTest() throws IOException {
                 String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
                                 + "PID|1||||DOE^JANE||||||||||||\r"
                                 + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
                                 + "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
                                 + "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
-                                + "OBX|2|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
+                                + "OBX|2|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400\r"
+                                + "SPM|1|SpecimenID||BLOOD^Blood^^87612001^BLOOD^SCT^^||||Cord Art^Blood, Cord Arterial^^^^^^^|||P||||||201110060535|201110060821||Y||||||1\r";
 
                 HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
                 String json = ftv.convert(ORU_r01, OPTIONS);
@@ -348,6 +357,15 @@ public class DifferentObservationValueTest {
                 assertThat(range.getText()).isEqualTo("Negative");
 
                 obs = (Observation) obsResource.get(1);
+                assertThat(obs.hasValueQuantity()).isTrue();
+                Quantity q = obs.getValueQuantity();
+                assertThat(q.hasUnit()).isTrue();
+                assertThat(q.getUnit()).isEqualTo("[IU]/mL");
+                assertThat(q.hasValue()).isTrue();
+                assertThat(q.getValue().floatValue()).isEqualTo(0.7f);
+                assertThat(q.hasSystem()).isTrue();
+                assertThat(q.getSystem()).isEqualTo("http://unitsofmeasure.org");
+
                 assertThat(obs.hasReferenceRange()).isTrue();
                 assertThat(obs.getReferenceRange()).hasSize(1);
                 range = obs.getReferenceRangeFirstRep();
@@ -360,6 +378,12 @@ public class DifferentObservationValueTest {
                 assertThat(range.hasText()).isTrue();
                 assertThat(range.getText()).isEqualTo("<0.50 IU/mL");
 
+                // Because there is an SPM record, there should be a category.  (Absence of SPM and category checkedin extendedObservationCWEtest)
+                assertThat(obs.hasCategory()).isTrue();
+                assertThat(obs.getCategory()).hasSize(1);
+                checkCommonCodeableConceptAssertions(obs.getCategoryFirstRep(), "laboratory", "Laboratory",
+                "http://terminology.hl7.org/CodeSystem/observation-category", null);
+ 
         }
 
         // Common check for values of a codeable concept.  Null in any input indicates it should check False

--- a/src/test/java/io/github/linuxforhealth/hl7/message/ImmunizationTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/ImmunizationTest.java
@@ -70,7 +70,7 @@ public class ImmunizationTest {
                 .isEqualTo("http://hl7.org/fhir/sid/cvx");
         assertThat(resource.getVaccineCode().getCoding().get(0).getCode()).isEqualTo("48");
         assertThat(resource.getVaccineCode().getText()).isEqualTo("HIB PRP-T");
-        assertThat(resource.getOccurrence().toString()).isEqualTo("DateTimeType[2013-05-31]");
+        assertThat(resource.getOccurrence()).hasToString("DateTimeType[2013-05-31]");
 
         assertThat(resource.getReportOrigin().getCoding().get(0).getSystem()).isEqualTo("urn:id:NIP001");
         assertThat(resource.getReportOrigin().getCoding().get(0).getCode()).isEqualTo("00");


### PR DESCRIPTION

Add support for:

Category=laboratory when SPM is present
Identifier from OBX.21 when present.
Add purpose to Organization Contact.

Fixes exceptions related to NTE's.