### PR TITLE
YAML update for groups

### DIFF
--- a/src/main/resources/hl7/message/ADT_A01.yml
+++ b/src/main/resources/hl7/message/ADT_A01.yml
@@ -13,7 +13,6 @@ resources:
       isReferenced: false
       additionalSegments: 
              - EVN
-             - MSH
 
     - resourceName: Patient
       segment: PID
@@ -52,7 +51,6 @@ resources:
       repeats: true
       isReferenced: true
       additionalSegments:
-        - ORC
         - MSH
 
     - resourceName: AllergyIntolerance
@@ -72,5 +70,3 @@ resources:
         - MSH
         - PID
         - PV1
-        - ORC
-        - OBR

--- a/src/main/resources/hl7/message/ADT_A40.yml
+++ b/src/main/resources/hl7/message/ADT_A40.yml
@@ -23,4 +23,4 @@ resources:
       additionalSegments:
              - .PD1
              - MSH
-             - MRG
+             - .MRG

--- a/src/main/resources/hl7/message/MDM_T02.yml
+++ b/src/main/resources/hl7/message/MDM_T02.yml
@@ -32,7 +32,7 @@ resources:
         - MSH
 
     - resourceName: Observation
-      segment: OBX
+      segment: OBSERVATION.OBX
       resourcePath: resource/Observation
       repeats: true
       isReferenced: true
@@ -46,5 +46,5 @@ resources:
       additionalSegments:
         - MSH
         - PID
-        - ORC
-        - OBR
+        - COMMON_ORDER.ORC
+        - COMMON_ORDER.OBR

--- a/src/main/resources/hl7/message/MDM_T04.yml
+++ b/src/main/resources/hl7/message/MDM_T04.yml
@@ -32,8 +32,9 @@ resources:
              - MSH
              
     - resourceName: Observation
-      segment: OBX
+      segment: .OBX
       resourcePath: resource/Observation
+      group: OBSERVATION
       repeats: true
       isReferenced: true
       additionalSegments:

--- a/src/main/resources/hl7/message/MDM_T06.yml
+++ b/src/main/resources/hl7/message/MDM_T06.yml
@@ -32,8 +32,9 @@ resources:
              - MSH
 
     - resourceName: Observation
-      segment: OBX
+      segment: .OBX
       resourcePath: resource/Observation
+      group: OBSERVATION
       repeats: true
       isReferenced: true
       additionalSegments:

--- a/src/main/resources/hl7/message/MDM_T08.yml
+++ b/src/main/resources/hl7/message/MDM_T08.yml
@@ -32,7 +32,8 @@ resources:
              - MSH
 
     - resourceName: Observation
-      segment: OBX
+      segment: .OBX
+      group: OBSERVATION
       resourcePath: resource/Observation
       repeats: true
       isReferenced: true

--- a/src/main/resources/hl7/message/MDM_T10.yml
+++ b/src/main/resources/hl7/message/MDM_T10.yml
@@ -32,7 +32,8 @@ resources:
              - MSH
 
     - resourceName: Observation
-      segment: OBX
+      segment: .OBX
+      group: OBSERVATION
       resourcePath: resource/Observation
       repeats: true
       isReferenced: true

--- a/src/main/resources/hl7/message/OMP_O09.yml
+++ b/src/main/resources/hl7/message/OMP_O09.yml
@@ -45,7 +45,7 @@ resources:
       - MSH
 
   - resourceName: AllergyIntolerance
-    segment: AL1
+    segment: PATIENT.AL1
     resourcePath: resource/AllergyIntolerance
     repeats: true
     additionalSegments:

--- a/src/main/resources/hl7/message/ORM_O01.yml
+++ b/src/main/resources/hl7/message/ORM_O01.yml
@@ -12,7 +12,6 @@ resources:
       repeats: false
       isReferenced: false
       additionalSegments: 
-             - EVN
    
     - resourceName: Patient
       segment: .PID
@@ -35,22 +34,25 @@ resources:
              - MSH
 
     - resourceName: Observation
-      segment: OBX
+      segment: .ORDER_DETAIL.OBSERVATION.OBX
       resourcePath: resource/Observation
+      group: ORDER
       repeats: true
       isReferenced: true
       additionalSegments:
       
     - resourceName: AllergyIntolerance
-      segment: AL1
+      segment: .AL1
       resourcePath: resource/AllergyIntolerance
+      group: PATIENT
       repeats: true
       additionalSegments:
              - MSH
 
     - resourceName: Condition
-      segment: DG1
+      segment: .ORDER_DETAIL.DG1
       resourcePath: resource/Condition
+      group: ORDER
       repeats: true
       additionalSegments:
         - MSH

--- a/src/main/resources/hl7/message/ORU_R01.yml
+++ b/src/main/resources/hl7/message/ORU_R01.yml
@@ -14,7 +14,8 @@ resources:
       additionalSegments:
    
     - resourceName: Patient
-      segment: PATIENT_RESULT.PATIENT.PID
+      segment: .PID
+      group: PATIENT_RESULT.PATIENT
       resourcePath: resource/Patient
       isReferenced: true
       repeats: false

--- a/src/main/resources/hl7/message/PPR_PC1.yml
+++ b/src/main/resources/hl7/message/PPR_PC1.yml
@@ -19,7 +19,6 @@ resources:
       isReferenced: true
       repeats: false
       additionalSegments:
-             - PD1
              - MSH
       
     - resourceName: Encounter

--- a/src/main/resources/hl7/message/PPR_PC2.yml
+++ b/src/main/resources/hl7/message/PPR_PC2.yml
@@ -19,7 +19,6 @@ resources:
       isReferenced: true
       repeats: false
       additionalSegments:
-             - PD1
              - MSH
       
     - resourceName: Encounter

--- a/src/main/resources/hl7/message/PPR_PC3.yml
+++ b/src/main/resources/hl7/message/PPR_PC3.yml
@@ -19,7 +19,6 @@ resources:
       isReferenced: true
       repeats: false
       additionalSegments:
-             - .PD1
              - MSH
       
     - resourceName: Encounter

--- a/src/main/resources/hl7/message/RDE_O11.yml
+++ b/src/main/resources/hl7/message/RDE_O11.yml
@@ -34,7 +34,7 @@ resources:
       - MSH
       
   - resourceName: AllergyIntolerance
-    segment: AL1
+    segment: PATIENT.AL1
     resourcePath: resource/AllergyIntolerance
     repeats: true
     additionalSegments:

--- a/src/main/resources/hl7/message/RDE_O25.yml
+++ b/src/main/resources/hl7/message/RDE_O25.yml
@@ -45,7 +45,7 @@ resources:
       - PATIENT.PID
 
   - resourceName: AllergyIntolerance
-    segment: AL1
+    segment: PATIENT.AL1
     resourcePath: resource/AllergyIntolerance
     repeats: true
     additionalSegments:


### PR DESCRIPTION
Signed-off-by: Lisa Dierkhising <lisadier@us.ibm.com>

ADT_A01: 
In MessageHeader, removed MSH from additionalSegments because it is the segment, not needed in both.
In Observation, ORC segment is not in ADT_A01(not even the sub-groups), so removed it.
In Procedure, ORC and OBR segments are not in ADT_A01(not even the sub-groups), so removed it.

MDM_T02:
In Observation, OBX is hidden within OBSERVATION (even though caristix calls the group ‘OBXNTE’, using the debugger I found that the parser encodes it in group ‘OBSERVATION’, also confirmed with HL7 spec)
In DocumentReference, ORC and OBR are within COMMON_ORDER. ***TODO: I haven’t yet figured out how to get around this exception: Additional segements cannot be from a group if primary segment is not defined to be from same group. I decided to deliver because this is a better state than it was in, but I'll have to look at this more on Monday.


MDM_T06:
In Observation, OBX is hidden within OBSERVATION (even though Caristix calls it OBXNTE).

MDM_T04, T08, and T10:
In Observation, OBX is hidden within OBSERVATION (even though Caristix calls it OBXNTE). ***Note: couldn’t find a test to verify my changes were ok.

OMP_O09:
AL1 is within the PATIENT group.

ORM_O01:
There is no EVN in Caristix nor the HL7 spec, so removed it from MessageHeader
OBX is nested in ORDER.ORDER_DETAIL.OBSERVATION.OBX
AL1 is within PATIENT
DG1 is within ORDER.ORDER_DETAIL

OUR_R01:
In Patient resource, I don’t think that PD1 will get picked up because there is no group defined.  —I tried to fix but still not getting the Patient.generalPractitioner set.  (I've started a new test test_oru_patient_general_practitioner which I'll deliver in a future PR if we decide we want to have a test for this.)

PPR_PC1, PPR_PC2, PPR_PC3:
Removed PD1 from Patient because that segment isn’t available in this message (confirmed on Caristix and in our MessageTypesToSegments ss).

