### PR TITLE
Ensure Encounter refs OBX and DG1

### DIFF
--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -93,12 +93,21 @@ reasonCode:
     expressionType: resource
     specs: EVN.4 | PV2.3 
 
-reasonReference:
-    valueOf: datatype/Reference
-    evaluateLater: true
-    generateList: true
-    expressionType: resource
-    specs: $Condition | $Observation
+reasonReference_1:
+   valueOf: datatype/Reference
+   condition: $Condition NOT_NULL 
+   evaluateLater: true
+   generateList: true
+   expressionType: resource
+   specs: $Condition
+
+reasonReference_2:
+   valueOf: datatype/Reference
+   condition: $Observation NOT_NULL
+   evaluateLater: true
+   generateList: true
+   expressionType: resource
+   specs: $Observation    
 
 hospitalization:
     valueOf: secondary/Hospitalization

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -64,7 +64,7 @@ effectiveDateTime:
 
 issued:
      type: DATE_TIME
-     valueOf: OBR.22 | MSH.7| OBX.19
+     valueOf: OBR.22 | OBX.19
      expressionType: HL7Spec
 
 


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>
Encounter was not making both references when OBX and DG1 were both present.