### PR TITLE
Issue#244  Support for ORC & OBR. Initial drop.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -74,6 +74,8 @@ repositories {
 
 test {
     useJUnitPlatform()
+    // Use parallel processing as possible
+    maxParallelForks = (int) (Runtime.runtime.availableProcessors() / 2 + 1)
     finalizedBy jacocoTestReport // report is always generated after tests run
 }
 

--- a/src/main/resources/hl7/message/ORU_R01.yml
+++ b/src/main/resources/hl7/message/ORU_R01.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -67,3 +67,9 @@ resources:
           - .NTE
           - .OBSERVATION.OBX
           - MSH
+
+  # ServiceRequest is created as a result of creating the DiagnosticReport.
+  # There will always be a DiagnosticReport before a ServiceRequest.
+  # DiagnosticReport is required.  ServiceRequest is optional.
+
+           

--- a/src/main/resources/hl7/resource/DiagnosticReport.yml
+++ b/src/main/resources/hl7/resource/DiagnosticReport.yml
@@ -93,6 +93,15 @@ resultsInterpreter:
    vars:
       interpreter: OBR.32
 
+basedOn:
+   condition: $basedOnORC NOT_NULL
+   valueOf: resource/ServiceRequest
+   generateList: true
+   expressionType: reference
+   specs: ORC
+   vars:
+      basedOnORC: ORC      
+
 specimen:
    valueOf: datatype/Reference
    generateList: true

--- a/src/main/resources/hl7/resource/DiagnosticReport.yml
+++ b/src/main/resources/hl7/resource/DiagnosticReport.yml
@@ -57,6 +57,7 @@ category:
    specs: OBR.24
    vars:
       code: OBR.24
+      
 code:
    valueOf: datatype/CodeableConcept
    expressionType: resource
@@ -64,6 +65,7 @@ code:
    required: true
    vars:
       code: OBR.4
+
 encounter:
    valueOf: datatype/Reference
    expressionType: resource

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -65,3 +65,39 @@ subject:
    valueOf: datatype/Reference
    expressionType: resource
    specs: $Patient
+
+requisition:
+   valueOf: datatype/Identifier_var
+   expressionType: resource
+   specs: ORC.4
+   vars:
+      valueIn: ORC.4.1
+      systemCX:  ORC.4.2
+
+authoredOn:
+   type: DATE_TIME
+   valueOf: ORC.9 | OBR.6
+   expressionType: HL7Spec
+
+occurrenceDateTime:   
+   type: DATE_TIME
+   valueOf: ORC.15 | OBR.7 | OBR.27.4
+   expressionType: HL7Spec
+
+requester:
+   condition: $request NOT_NULL 
+   valueOf: resource/Practitioner
+   generateList: true
+   expressionType: reference
+   specs: ORC.12 | OBR.16
+   vars:
+      request: ORC.12 | OBR.16
+
+reasonCode:
+   condition: $reasonCWE NOT_NULL 
+   valueOf: datatype/CodeableConcept
+   generateList: true
+   expressionType: resource
+   specs: OBR.31 | ORC.16  
+   vars:
+      reasonCWE: OBR.31 | ORC.16      

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -87,7 +87,6 @@ occurrenceDateTime:
 requester:
    condition: $request NOT_NULL 
    valueOf: resource/Practitioner
-   generateList: true
    expressionType: reference
    specs: ORC.12 | OBR.16
    vars:
@@ -101,3 +100,11 @@ reasonCode:
    specs: OBR.31 | ORC.16  
    vars:
       reasonCWE: OBR.31 | ORC.16      
+
+code:
+   condition: $codeCWE NOT_NULL 
+   valueOf: datatype/CodeableConcept
+   expressionType: resource
+   specs: OBR.4
+   vars:
+      codeCWE: OBR.4       

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Assertions;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -35,6 +34,7 @@ public class Hl7OrderRequestFHIRConversionTest {
   private static FHIRContext context = new FHIRContext(true, false);
   private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MedicationRequestFHIRConversionTest.class);
 
+  // Read comments carefully.  Tests
   @Test
   public void testBroadORCFields() {
 
@@ -47,17 +47,16 @@ public class Hl7OrderRequestFHIRConversionTest {
             //  NOTE: ORC is optional; OBR is required.
             //  Key input data set up:
             //  1. Checking fields ORC.4 to ServiceRequest.requisition
-            //  2. ORC.9 to ServiceRequest.authoredOn
+            //  2. ORC.9 to ServiceRequest.authoredOn (overrides secondary OBR.6)
             //  3. ORC.12 to ServiceRequest.requester AND Practitioner object and reference to Practictioner
-            //  4. ORC.15 to ServiceRequest.occurrenceDateTime
+            //  4. ORC.15 to ServiceRequest.occurrenceDateTime (overrides secondary OBR.7)
             //  5. ORC.16 is set to a reason code (secondary to OBR.31, which is purposely not present in this case)
             + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||20120628071200|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI||(781)849-2400^^^^^781^8492400|20170917151717|042^Human immunodeficiency virus [HIV] disease [42]^I9CDX^^^^29|||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
-            //  10. ORB.16 is here as a test to show that it is ignored as Practitioner because ORC.12 has priority 
-            //  11. ORB.31 is omitted purposely so the ORC.16 is used for the reason code
-            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||54321678^SCHMIDT^FRIEDA^^MD^^^^^^^^^NPI|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120613071200|||||&Roache&Gerard&&||||||||||||||||||\n"
-            + "TQ1|1||||||20180924152721|20180924235959|R\n"
-            + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
-            + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||\n";
+            //  10. OBR.16 is here as a test to show that it is ignored as Practitioner because ORC.12 has priority 
+            //  11. OBR.31 is omitted purposely so the ORC.16 is used for the reason code
+            //  12. OBR.6 is purposely present, but will be ignored because ORC.9 has a value and is preferred.
+            //  13. OBR.7 is purposely present, but will be ignored because ORC.15 has a value and is preferred.
+            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||20120606120606|20120606120606||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||54321678^SCHMIDT^FRIEDA^^MD^^^^^^^^^NPI|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120613071200|||||&Roache&Gerard&&||||||||||||||||||\n";
 
     HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
     String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
@@ -95,7 +94,8 @@ public class Hl7OrderRequestFHIRConversionTest {
     assertThat(serviceRequest.hasReasonCode()).isTrue();
     assertThat(serviceRequest.getReasonCode()).hasSize(1);
     DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getReasonCodeFirstRep(), "042",
-        "Human immunodeficiency virus [HIV] disease [42]", "http://terminology.hl7.org/CodeSystem/ICD-9CM-diagnosiscodes",
+        "Human immunodeficiency virus [HIV] disease [42]",
+        "http://terminology.hl7.org/CodeSystem/ICD-9CM-diagnosiscodes",
         "Human immunodeficiency virus [HIV] disease [42]");
 
     // ORC.12 should create an ServiceRequest.requester reference
@@ -122,7 +122,7 @@ public class Hl7OrderRequestFHIRConversionTest {
   }
 
   // This test is a companion to testBroadORCFields.   ORC and OBR records often have repeated data; one taking priority over the other.
-  // Read comments carefully.  This often test the other condition and even the opposite to the tests in testBroadORCFields.
+  // Read comments carefully.  This sometimes tests the secondary value and may be the opposite to the tests in testBroadORCFields.
   @Test
   public void testBroadORCPlusOBRFields() {
 
@@ -139,10 +139,9 @@ public class Hl7OrderRequestFHIRConversionTest {
         //  5. ORC.16 is set to a reason code (but it is ignored because it is secondary to OBR.31, which is present in this case and therefore overrides ORC.16)
         + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker||||||||||(781)849-2400^^^^^781^8492400||042^Human immunodeficiency virus [HIV] disease [42]^I9CDX^^^^29|||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
         //  10. OBR.32 will be turned into a Practioner and referenced and the DiagnositicReport.resultsInterpreter
-        + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||20120606120606|20170707150707||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||54321678^SCHMIDT^FRIEDA^^MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120613071200||||HIV^HIV/Aids^L^^^^V1|323232^Mahoney^Paul^J||||||||||||||||||\n"
-        + "TQ1|1||||||20180924152721|20180924235959|R\n"
-        + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
-        + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||\n";
+        //  11. OBR.4 maps to both ServiceRequest.code and DiagnosticReport.code
+        //  12. OBR.16 creates a ServiceRequest.requester reference
+        + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||20120606120606|20170707150707||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||54321678^SCHMIDT^FRIEDA^^MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120613071200||||HIV^HIV/Aids^L^^^^V1|323232^Mahoney^Paul^J||||||||||||||||||\n";
 
     HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
     String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
@@ -162,11 +161,11 @@ public class Hl7OrderRequestFHIRConversionTest {
     assertThat(serviceRequest.hasStatus()).isTrue();
 
     // ORC.4 checked in testBroadORCFields
-    // OBR.5 should create basedOn because ORC.9 is not filled in
+    // OBR.6 should create authoredOn because ORC.9 is not filled in
     assertThat(serviceRequest.hasAuthoredOn()).isTrue();
     assertThat(serviceRequest.getAuthoredOnElement().toString()).containsPattern("2012-06-06T12:06:06");
 
-    // ORC.15 should create an ServiceRequest.occurrenceDateTime date
+    // OBR.7 is used to create an ServiceRequest.occurrenceDateTime date because ORC.15 is empty
     assertThat(serviceRequest.hasOccurrenceDateTimeType()).isTrue();
     assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2017-07-07T15:07:07");
 
@@ -176,13 +175,18 @@ public class Hl7OrderRequestFHIRConversionTest {
     DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getReasonCodeFirstRep(), "HIV", "HIV/Aids",
         "urn:id:L", "HIV/Aids");
 
-    // OBR.22 should create an ServiceRequest.requester reference
+    // OBR.16 should create an ServiceRequest.requester reference
     assertThat(serviceRequest.hasRequester()).isTrue();
     String requesterRef = serviceRequest.getRequester().getReference();
     Practitioner pract = ResourceUtils.getSpecificPractitionerFromBundle(bundle, requesterRef);
     // Confirm that the matching practitioner by ID has the correct content (simple validation)
-    // Should be OBR.16.1 because ORC.12 is empty.
+    // Should be OBR.16 because ORC.12 is empty. Check OBR.16.1 which is the ID.
     assertThat(pract.getIdentifierFirstRep().getValue()).isEqualTo("54321678");
+
+    // OBR.4 maps to ServiceRequest.code.  Verify resulting CodeableConcept.
+    assertThat(serviceRequest.hasCode()).isTrue();
+    DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getCode(), "83036E", "HEMOGLOBIN A1C",
+        "urn:id:PACSEAP", "HEMOGLOBIN A1C");
 
     List<Resource> diagnosticReportList = e.stream()
         .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
@@ -190,20 +194,27 @@ public class Hl7OrderRequestFHIRConversionTest {
     assertThat(diagnosticReportList).hasSize(1);
     DiagnosticReport diagnosticReport = getDiagnosticReport(diagnosticReportList.get(0));
 
+    // OBR.4 ALSO maps to DiagnosticReport.code.  Verify resulting CodeableConcept.
+    assertThat(diagnosticReport.hasCode()).isTrue();
+    DatatypeUtils.checkCommonCodeableConceptAssertions(diagnosticReport.getCode(), "83036E", "HEMOGLOBIN A1C",
+        "urn:id:PACSEAP", "HEMOGLOBIN A1C");
+
     assertThat(diagnosticReport.hasBasedOn()).isTrue();
     assertThat(diagnosticReport.getBasedOn()).hasSize(1);
 
     // Check for issued instant of OBR.22
     assertThat(diagnosticReport.hasIssued()).isTrue();
+    // NOTE: The data is kept as an InstantType, and is extracted with .toInstant
+    // thus results in a different format than other time stamps that are based on DateTimeType
     assertThat(diagnosticReport.getIssued().toInstant().toString()).contains("2018-09-24T07:29:00Z");
 
-    // Get the diagnosticReport.resultsInterpreter, which should match the Practitioner from OBR.32
+    // Get the diagnosticReport.resultsInterpreter, which should match the Practitioner data from OBR.32
     assertThat(diagnosticReport.hasResultsInterpreter()).isTrue();
     assertThat(diagnosticReport.getResultsInterpreter()).hasSize(1);
     String resultsInterpreterRef = diagnosticReport.getResultsInterpreter().get(0).getReference();
     pract = ResourceUtils.getSpecificPractitionerFromBundle(bundle, resultsInterpreterRef);
     // Confirm that the matching practitioner by ID has the correct content (simple validation)
-    // Should be OBR.32
+    // Should be the value OBR.32
     assertThat(pract.getIdentifierFirstRep().getValue()).isEqualTo("323232");
   }
 
@@ -218,10 +229,7 @@ public class Hl7OrderRequestFHIRConversionTest {
             + "PV1|1|||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
             //  ORC.15 is empty, OBR.7 is empty, so use OBR-27[0].4 as ServiceRequest.occurrenceDateTime
             + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||20120628071200|||1457352338^TEITLEMAN^CHRISTOPHER^A^MD^^^^^^^^^NPISER||(781)849-2400^^^^^781^8492400|||||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
-            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||1457352338^TEITLEMAN^CHRISTOPHER^A^MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120606120606|||||&Roache&Gerard&&||||||||||||||||||\n"
-            + "TQ1|1||||||20180924152721|20180924235959|R\n"
-            + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
-            + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||\n";
+            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||1457352338^TEITLEMAN^CHRISTOPHER^A^MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120606120606|||||&Roache&Gerard&&||||||||||||||||||\n";
 
     HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
     String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
@@ -245,7 +253,6 @@ public class Hl7OrderRequestFHIRConversionTest {
     assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2012-06-06T12:06:06");
 
   }
-
 
   private static ServiceRequest getServiceRequest(Resource resource) {
     String s = context.getParser().encodeResourceToString(resource);

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
@@ -100,7 +100,6 @@ public class Hl7OrderRequestFHIRConversionTest {
     // ORC.12 should create an ServiceRequest.requester reference
     assertThat(serviceRequest.hasRequester()).isTrue();
     String requesterRef = serviceRequest.getRequester().getReference();
-    // assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2017-09-17T15:17:17");
 
     // Find the practitioner resources from the FHIR bundle.
     List<Resource> practitioners = e.stream()

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
@@ -1,0 +1,279 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.segments;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.ServiceRequest;
+
+import io.github.linuxforhealth.fhir.FHIRContext;
+import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
+import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
+import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Hl7OrderRequestFHIRConversionTest {
+
+  private static FHIRContext context = new FHIRContext(true, false);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MedicationRequestFHIRConversionTest.class);
+
+  @Test
+  public void testBroadORCFields() {
+
+    String hl7message =
+
+        "MSH|^~\\&|Epic|ATRIUS|||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||PHLabReport-Ack^^2.16.840.1.114222.4.10.3^ISO||\n"
+            + "SFT|Epic Systems Corporation^L^^^^ANSI&1.2.840&ISO^XX^^^1.2.840.114350|Epic 2015 |Bridges|8.2.2.0||20160605043244\n"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+            + "PV1|1|||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
+            //  NOTE: ORC is optional; OBR is required.
+            //  Key input data set up:
+            //  1. Checking fields ORC.4 to ServiceRequest.requisition
+            //  2. ORC.9 to ServiceRequest.authoredOn
+            //  3. ORC.12 to ServiceRequest.requester AND Practitioner object and reference to Practictioner
+            //  4. ORC.15 to ServiceRequest.occurrenceDateTime
+            //  5. ORC.16 is set to a reason code (secondary to OBR.31, which is purposely not present in this case)
+            + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||20120628071200|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI||(781)849-2400^^^^^781^8492400|20170917151717|042^Human immunodeficiency virus [HIV] disease [42]^I9CDX^^^^29|||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
+            //  10. ORB.16 is here as a test to show that it is ignored as Practitioner because ORC.12 has priority 
+            //  11. ORB.31 is omitted purposely so the ORC.16 is used for the reason code
+            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||54321678^SCHMIDT^FRIEDA^^MD^^^^^^^^^NPI|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120613071200|||||&Roache&Gerard&&||||||||||||||||||\n"
+            + "TQ1|1||||||20180924152721|20180924235959|R\n"
+            + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
+            + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||\n";
+
+    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+    String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+    assertThat(json).isNotBlank();
+
+    IBaseResource bundleResource = context.getParser().parseResource(json);
+    assertThat(bundleResource).isNotNull();
+    Bundle b = (Bundle) bundleResource;
+    List<BundleEntryComponent> e = b.getEntry();
+
+    List<Resource> serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    // Important that we have exactly one service request (no duplication).  OBR creates it as a reference.        
+    assertThat(serviceRequestList).hasSize(1);
+    ServiceRequest serviceRequest = getServiceRequest(serviceRequestList.get(0));
+    assertThat(serviceRequest.hasStatus()).isTrue();
+
+    // ORC.4 should create a requisition in the serviceRequest.
+    assertThat(serviceRequest.hasRequisition()).isTrue();
+    assertThat(serviceRequest.getRequisition().hasSystem()).isTrue();
+    assertThat(serviceRequest.getRequisition().getSystem()).isEqualToIgnoringCase("urn:id:Beaker");
+    assertThat(serviceRequest.getRequisition().hasValue()).isTrue();
+    assertThat(serviceRequest.getRequisition().getValue()).isEqualToIgnoringCase("ML18267-C00001");
+
+    // ORC.9 should create an serviceRequest.authoredOn date 
+    assertThat(serviceRequest.hasAuthoredOn()).isTrue();
+    assertThat(serviceRequest.getAuthoredOnElement().toString()).containsPattern("2012-06-28T07:12:00");
+
+    // ORC.15 should create an ServiceRequest.occurrenceDateTime date
+    assertThat(serviceRequest.hasOccurrenceDateTimeType()).isTrue();
+    assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2017-09-17T15:17:17");
+
+    // ORC.16 should create a ServiceRequest.reasonCode CWE
+    assertThat(serviceRequest.hasReasonCode()).isTrue();
+    assertThat(serviceRequest.getReasonCode()).hasSize(1);
+    DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getReasonCodeFirstRep(), "042",
+        "Human immunodeficiency virus [HIV] disease [42]", "http://terminology.hl7.org/CodeSystem/ICD-9CM-diagnosiscodes",
+        "Human immunodeficiency virus [HIV] disease [42]");
+
+    // ORC.12 should create an ServiceRequest.requester reference
+    assertThat(serviceRequest.hasRequester()).isTrue();
+    String requesterRef = serviceRequest.getRequester().getReference();
+    // assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2017-09-17T15:17:17");
+
+    // Find the practitioner resources from the FHIR bundle.
+    List<Resource> practitioners = e.stream()
+        .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    assertThat(practitioners.size()).isPositive(); // Confirm there is at least one practitioner
+    // Find all practitioners with matching Id's in the list of practitioners.
+    List<Resource> matchingPractitioners = new ArrayList<Resource>();
+    for (int i = 0; i < practitioners.size(); i++) {
+      if (practitioners.get(i).getId().equalsIgnoreCase(requesterRef)) {
+        matchingPractitioners.add(practitioners.get(i));
+      }
+    }
+    assertThat(matchingPractitioners).hasSize(1); // Count must be exactly 1.  
+    // Confirm that the matching practitioner by ID has the correct content (simple validation)
+    // Should be ORC.12.1 and NOT OBR.16.1
+    Practitioner pract = (Practitioner) matchingPractitioners.get(0);
+    assertThat(pract.getIdentifierFirstRep().getValue()).isEqualTo("5742200012");
+
+    // Get the DiagnosticReport and see that it's basedOn cross-references to the ServiceRequest object
+    List<Resource> diagnosticReportList = e.stream()
+        .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    assertThat(diagnosticReportList).hasSize(1);
+    DiagnosticReport diagnosticReport = getDiagnosticReport(diagnosticReportList.get(0));
+
+    assertThat(diagnosticReport.hasBasedOn()).isTrue();
+    assertThat(diagnosticReport.getBasedOn()).hasSize(1);
+    //Check that the cross reference is equal to the serviceRequest id
+    assertThat(diagnosticReport.getBasedOnFirstRep().getReference()).hasToString(serviceRequest.getId());
+
+  }
+
+  // This test is a companion to testBroadORCFields.   ORC and OBR records often have repeated data; one taking priority over the other.
+  // Read comments carefully.  This often test the other condition and even the opposite to the tests in testBroadORCFields.
+  @Test
+  public void testBroadORCPlusOBRFields() {
+
+    String hl7message = "MSH|^~\\&|Epic|ATRIUS|||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||PHLabReport-Ack^^2.16.840.1.114222.4.10.3^ISO||\n"
+        + "SFT|Epic Systems Corporation^L^^^^ANSI&1.2.840&ISO^XX^^^1.2.840.114350|Epic 2015 |Bridges|8.2.2.0||20160605043244\n"
+        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+        + "PV1|1|||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
+        //  NOTE: ORC is optional; OBR is required.
+        //  Key input data set up:
+        //  1. ORC.15 is empty, so OBR.7 used as ServiceRequest.occurrenceDateTime
+        //  2. Leave ORC.9 empty so that OBR.6 is used for ServiceRequest.authoredOn
+        //  3. OBR.22 used and DiagnosticReport.issued
+        //  4. Leave ORC.12 empty so OBR.16 is used for Practitioner reference
+        //  5. ORC.16 is set to a reason code (but it is ignored because it is secondary to OBR.31, which is present in this case and therefore overrides ORC.16)
+        + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker||||||||||(781)849-2400^^^^^781^8492400||042^Human immunodeficiency virus [HIV] disease [42]^I9CDX^^^^29|||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
+        + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||20120606120606|20170707150707||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||54321678^SCHMIDT^FRIEDA^^MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120613071200||||HIV^HIV/Aids^L^^^^V1|&Roache&Gerard&&||||||||||||||||||\n"
+        + "TQ1|1||||||20180924152721|20180924235959|R\n"
+        + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
+        + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||\n";
+
+    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+    String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+    assertThat(json).isNotBlank();
+
+    IBaseResource bundleResource = context.getParser().parseResource(json);
+    assertThat(bundleResource).isNotNull();
+    Bundle b = (Bundle) bundleResource;
+    List<BundleEntryComponent> e = b.getEntry();
+
+    List<Resource> serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    // Important that we have exactly one service request (no duplication).  OBR creates it as a reference.        
+    assertThat(serviceRequestList).hasSize(1);
+    ServiceRequest serviceRequest = getServiceRequest(serviceRequestList.get(0));
+    assertThat(serviceRequest.hasStatus()).isTrue();
+
+    // ORC.4 checked in testBroadORCFields
+    // OBR.5 should create basedOn because ORC.9 is not filled in
+    assertThat(serviceRequest.hasAuthoredOn()).isTrue();
+    assertThat(serviceRequest.getAuthoredOnElement().toString()).containsPattern("2012-06-06T12:06:06");
+
+    // ORC.15 should create an ServiceRequest.occurrenceDateTime date
+    assertThat(serviceRequest.hasOccurrenceDateTimeType()).isTrue();
+    assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2017-07-07T15:07:07");
+
+    // OBR.31 should create the ServiceRequest.reasonCode CWE
+    assertThat(serviceRequest.hasReasonCode()).isTrue();
+    assertThat(serviceRequest.getReasonCode()).hasSize(1);
+    DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getReasonCodeFirstRep(), "HIV", "HIV/Aids",
+        "urn:id:L", "HIV/Aids");
+
+    // OBR.22 should create an ServiceRequest.requester reference
+    assertThat(serviceRequest.hasRequester()).isTrue();
+    String requesterRef = serviceRequest.getRequester().getReference();
+
+    // Find the practitioner resources from the FHIR bundle.
+    List<Resource> practitioners = e.stream()
+        .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    assertThat(practitioners.size()).isPositive(); // Confirm there is at least one practitioner
+    // Find all practitioners with matching Id's in the list of practitioners.
+    List<Resource> matchingPractitioners = new ArrayList<Resource>();
+    for (int i = 0; i < practitioners.size(); i++) {
+      if (practitioners.get(i).getId().equalsIgnoreCase(requesterRef)) {
+        matchingPractitioners.add(practitioners.get(i));
+      }
+    }
+    assertThat(matchingPractitioners).hasSize(1); // Count must be exactly 1.  
+    // Confirm that the matching practitioner by ID has the correct content (simple validation)
+    // Should be OBR.16.1 because ORC.12 is empty.
+    Practitioner pract = (Practitioner) matchingPractitioners.get(0);
+    assertThat(pract.getIdentifierFirstRep().getValue()).isEqualTo("54321678");
+
+    List<Resource> diagnosticReportList = e.stream()
+        .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    assertThat(diagnosticReportList).hasSize(1);
+    DiagnosticReport diagnosticReport = getDiagnosticReport(diagnosticReportList.get(0));
+
+    assertThat(diagnosticReport.hasBasedOn()).isTrue();
+    assertThat(diagnosticReport.getBasedOn()).hasSize(1);
+
+    // Check for issued instant of OBR.22
+    assertThat(diagnosticReport.hasIssued()).isTrue();
+    assertThat(diagnosticReport.getIssued().toInstant().toString()).contains("2018-09-24T07:29:00Z");
+  }
+
+  @Test
+  public void testBroadORCPlusOBRFields2() {
+
+    String hl7message =
+
+        "MSH|^~\\&|Epic|ATRIUS|||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||PHLabReport-Ack^^2.16.840.1.114222.4.10.3^ISO||\n"
+            + "SFT|Epic Systems Corporation^L^^^^ANSI&1.2.840&ISO^XX^^^1.2.840.114350|Epic 2015 |Bridges|8.2.2.0||20160605043244\n"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+            + "PV1|1|||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
+            //  ORC.15 is empty, OBR.7 is empty, so use OBR-27[0].4 as ServiceRequest.occurrenceDateTime
+            + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||20120628071200|||1457352338^TEITLEMAN^CHRISTOPHER^A^MD^^^^^^^^^NPISER||(781)849-2400^^^^^781^8492400|||||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
+            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||L||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||1457352338^TEITLEMAN^CHRISTOPHER^A^MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F||^^^20120606120606|||||&Roache&Gerard&&||||||||||||||||||\n"
+            + "TQ1|1||||||20180924152721|20180924235959|R\n"
+            + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
+            + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||\n";
+
+    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+    String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+    assertThat(json).isNotBlank();
+
+    IBaseResource bundleResource = context.getParser().parseResource(json);
+    assertThat(bundleResource).isNotNull();
+    Bundle b = (Bundle) bundleResource;
+    List<BundleEntryComponent> e = b.getEntry();
+
+    List<Resource> serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    // Important that we have exactly one service request (no duplication).  OBR creates it as a reference.        
+    assertThat(serviceRequestList).hasSize(1);
+    ServiceRequest serviceRequest = getServiceRequest(serviceRequestList.get(0));
+    assertThat(serviceRequest.hasStatus()).isTrue();
+
+    // OBR.27[0].4 should create an ServiceRequest.occurrenceDateTime date
+    assertThat(serviceRequest.hasOccurrenceDateTimeType()).isTrue();
+    assertThat(serviceRequest.getOccurrenceDateTimeType().toString()).containsPattern("2012-06-06T12:06:06");
+
+  }
+
+
+  private static ServiceRequest getServiceRequest(Resource resource) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = ServiceRequest.class;
+    return (ServiceRequest) context.getParser().parseResource(klass, s);
+  }
+
+  private static DiagnosticReport getDiagnosticReport(Resource resource) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = DiagnosticReport.class;
+    return (DiagnosticReport) context.getParser().parseResource(klass, s);
+  }
+
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -208,5 +209,26 @@ public class ResourceUtils {
     Class<? extends IBaseResource> klass = MedicationAdministration.class;
 
     return (MedicationAdministration) context.getParser().parseResource(klass, s);
+  }
+
+  // Given a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
+  // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
+  public static Practitioner getSpecificPractitionerFromBundle(Bundle bundle, String practitionerRef) {
+    List<BundleEntryComponent> entries = bundle.getEntry();
+    // Find the practitioner resources from the FHIR bundle.
+    List<Resource> practitioners = entries.stream()
+        .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    assertThat(practitioners.size()).isPositive(); // Confirm there is at least one practitioner
+    // Find all practitioners with matching Id's in the list of practitioners.
+    List<Resource> matchingPractitioners = new ArrayList<Resource>();
+    for (int i = 0; i < practitioners.size(); i++) {
+      if (practitioners.get(i).getId().equalsIgnoreCase(practitionerRef)) {
+        matchingPractitioners.add(practitioners.get(i));
+      }
+    }
+    assertThat(matchingPractitioners).hasSize(1); // Count must be exactly 1.  
+    Practitioner pract = (Practitioner) matchingPractitioners.get(0);
+    return pract;
   }
 }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Provides:
1.  Performance improvement for Gradle tests by using multi processors when available.
2. ORC.4 creates a requisition in the serviceRequest.
2. ORC.9 / OBR.6 maps to ServiceRequest.authoredOn
3. ORC.12 / OBR.16 maps to ServiceRequest.requester 
4. Practitioner object is created and referenced from ServiceRequest.requester
4. ORC.15 / OBR.7  maps to ServiceRequest.occurrenceDateTime
5. OBR.31 / ORC.16  map to ServiceRequest reason code 
6. Create DiagnosticReport.basedOn reference to ServiceRequest
7. OBR.22 used for DiagnosticReport.issued
8. OBR.32 used for creating and reference to a Practitioner for DiagnosticReport.resultsInterpreter
9. OBR.4 maps to DiagnosticReport.code and ServiceRequest.code