### PR TITLE
Issue#244 SR status, Effective time, testing

### DIFF
--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -22,11 +22,17 @@ ObservationStatus:
    I: registered
    P: preliminary
    W: entered-in-error
+
 ServiceRequestStatus:
-   # Only mapped a subset as there was not a clear mapping for the rest, they will default to unknown
-   F: completed	
-   U: completed
-   W: entered-in-error	
+   A: active
+   CA: revoked
+   CM: completed
+   DC: revoked
+   ER: entered-in-error
+   HD: on-hold
+   IP: active
+   SC: active
+      
 AdministrativeGender:
    A: other
    F: female
@@ -34,15 +40,16 @@ AdministrativeGender:
    N: unknown
    O: other
    U: unknown
+
 DiagnosticReportStatus:
    A: partial
    C: corrected
    F: final
-   I: unknown
-   O: unknown
+   I: registered
+   O: registered
    P: preliminary
-   R: registered
-   S: unknown
+   R: partial
+   S: registered
    X: cancelled
    Y: unknown
    Z: unknown
@@ -329,4 +336,4 @@ MedicationRequestStatus:
    RQ: active
    RR: active
    RU: active
-   
+

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -45,11 +45,11 @@ DiagnosticReportStatus:
    A: partial
    C: corrected
    F: final
-   I: registered
-   O: registered
+   I: unknown
+   O: unknown
    P: preliminary
    R: partial
-   S: registered
+   S: unknown
    X: cancelled
    Y: unknown
    Z: unknown

--- a/src/main/resources/hl7/message/OMP_O09.yml
+++ b/src/main/resources/hl7/message/OMP_O09.yml
@@ -53,15 +53,7 @@ resources:
     additionalSegments:
       - MSH
 
-  - resourceName: ServiceRequest
-    segment: .ORC
-    resourcePath: resource/ServiceRequest
-    group: ORDER
-    repeats: true
-    additionalSegments:
-      - MSH
-      - PATIENT.PID
-      - PATIENT.PATIENT_VISIT.PV1
+
 
   - resourceName: Observation
     segment: .OBSERVATION.OBX

--- a/src/main/resources/hl7/resource/DiagnosticReport.yml
+++ b/src/main/resources/hl7/resource/DiagnosticReport.yml
@@ -77,9 +77,21 @@ subject:
    specs: $Patient
    
 effectiveDateTime:
+   condition: $start NOT_NULL && $end NULL
    type: DATE_TIME
    valueOf: OBR.7
    expressionType: HL7Spec
+   vars:
+      start: OBR.7
+      end: OBR.8
+
+effectivePeriod:
+   valueOf: datatype/Period
+   condition: $start NOT_NULL && $end NOT_NULL
+   expressionType: resource
+   vars:
+      start: OBR.7
+      end: OBR.8
 
 issued:
    type: INSTANT

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -51,8 +51,8 @@ identifier_3:
 status:
    type: SERVICE_REQUEST_STATUS
    default: "unknown"
-   valueOf: OBX.11
-   expressionType: HL7Spec
+   valueOf: ORC.5
+   expressionType: HL7Spec   
 
 intent:
    type: STRING

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -149,9 +149,9 @@ public class SimpleDataValueResolverTest {
 
   @Test
   public void get_service_request_status_value_valid() {
-    String gen = "f";
+    String gen = "SC";
     assertThat(SimpleDataValueResolver.SERVICE_REQUEST_STATUS.apply(gen))
-		.isEqualTo(ServiceRequestStatus.COMPLETED.toCode());
+		.isEqualTo(ServiceRequestStatus.ACTIVE.toCode());
   }
 
   

--- a/src/test/java/io/github/linuxforhealth/hl7/message/ImmunizationTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/ImmunizationTest.java
@@ -23,6 +23,7 @@ import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.resource.ResourceReader;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class ImmunizationTest {
     private static FHIRContext context = new FHIRContext(true, false);
@@ -101,7 +102,7 @@ public class ImmunizationTest {
         List<Resource> immu = e.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(immu).hasSize(1);
-        Immunization resource = getResource(immu.get(0));
+        Immunization resource = ResourceUtils.getResourceImmunization(immu.get(0),context);
         assertThat(resource).isNotNull();
 
         assertThat(resource.getStatus().getDisplay()).isEqualTo("completed");
@@ -129,12 +130,12 @@ public class ImmunizationTest {
 
         assertThat(resource.getManufacturer().isEmpty()).isFalse();
 
-    }
+        // Test that a ServiceRequest is not created for VXU_V04
+        List<Resource> serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Confirm that a serviceRequest was not created.      
+        assertThat(serviceRequestList).isEmpty();
 
-    private static Immunization getResource(Resource resource) {
-        String s = context.getParser().encodeResourceToString(resource);
-        Class<? extends IBaseResource> klass = Immunization.class;
-        return (Immunization) context.getParser().parseResource(klass, s);
     }
-
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -849,15 +849,21 @@ public class Hl7IdentifierFHIRConversionTest {
 //          assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
 //      }
 
+
+
     @Test
     public void serviceRequestIdentifierTest1() {
-        //  - Visit number with MSH-7
-        //  - filler and placer from ORC
-        String serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|OMP^O09^OMP_O09|1|P^I|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
-                + "PID|||12345^^^^MR||smith^john\r"
-                + "ORC|NW|1000^OE|9999999^RX\r"
-                + "OBR|1|2233|4455\r"
-                + "OBX|1|TX|^hunchback|1|Increasing||||||S\r";
+        // Test 1 removed:  OMP_O09 messages do not create a service request
+
+        // Test 2:
+        //  - Visit number with PID-18
+        //  - filler and placer from OBR
+        String serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n" +
+                "PID|1||000054321^^^MRN|||||||||||||M|CAT|78654||||N\n" +
+                "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n" +
+                "ORC||||||E|^Q6H^D10^^^R\n" +
+                "OBR|1|CD150920001336^OE|CD150920001336^IE|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||";
+
         ServiceRequest serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
         // Expect 3 identifiers
@@ -868,51 +874,9 @@ public class Hl7IdentifierFHIRConversionTest {
         Identifier identifier = serviceReq.getIdentifier().get(0);
         String value = identifier.getValue();
         String system = identifier.getSystem();
-        assertThat(value).isEqualTo("200603081747"); // MSH.7
-        assertThat(system).isNull();
-        CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-
-        // Identifier 2: filler
-        identifier = serviceReq.getIdentifier().get(1);
-        value = identifier.getValue();
-        system = identifier.getSystem();
-        assertThat(value).isEqualTo("9999999"); // ORC.3.1
-        assertThat(system).isEqualTo("urn:id:RX"); // ORC.3.2
-        type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-
-        // Identifier 3: placer
-        identifier = serviceReq.getIdentifier().get(2);
-        value = identifier.getValue();
-        system = identifier.getSystem();
-        assertThat(value).isEqualTo("1000"); // ORC.2.1
-        assertThat(system).isEqualTo("urn:id:OE"); // ORC.2.2
-        type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-
-        // Test 2:
-        //  - Visit number with PID-18
-        //  - filler and placer from OBR
-        serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n" +
-                "PID|1||000054321^^^MRN|||||||||||||M|CAT|78654||||N\n" +
-                "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n" +
-                "ORC||||||E|^Q6H^D10^^^R\n" +
-                "OBR|1|CD150920001336^OE|CD150920001336^IE|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||";
-
-        serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
-
-        // Expect 3 identifiers
-        assertThat(serviceReq.hasIdentifier()).isTrue();
-        assertThat(serviceReq.getIdentifier()).hasSize(3);
-
-        // Identifier 1: visit number
-        identifier = serviceReq.getIdentifier().get(0);
-        value = identifier.getValue();
-        system = identifier.getSystem();
         assertThat(value).isEqualTo("78654"); // PID.18
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: filler

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
@@ -15,179 +15,210 @@ import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Enumerations;
-import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus;
-import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Practitioner;
-import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.codesystems.V3MaritalStatus;
 
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Hl7MedicationRequestFHIRConversionTest {
 
-  private static FHIRContext context = new FHIRContext(true, false);
-  private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MedicationRequestFHIRConversionTest.class);
+    private static FHIRContext context = new FHIRContext(true, false);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MedicationRequestFHIRConversionTest.class);
 
-  @Test
-  public void test_medicationreq_patient() {
-    String hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
-    		+ "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-    		+ "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON,CARL|0148^ADDISON,JAMES||SUR|||||||0100^ANDERSON,CARL|S|V446911|A|||||||||||||||||||SF|K||||20180622230000\n"
-    		+ "ORC|NW|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
-    		+ "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
-    		+ "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
+    @Test
+    public void test_medicationreq_patient() {
+        String hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON,CARL|0148^ADDISON,JAMES||SUR|||||||0100^ANDERSON,CARL|S|V446911|A|||||||||||||||||||SF|K||||20180622230000\n"
+                + "ORC|NW|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
+                + "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
+                + "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-	String json = ftv.convert(hl7message , PatientUtils.OPTIONS);
-    assertThat(json).isNotBlank();
-    
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+        assertThat(json).isNotBlank();
 
-    List<Resource> patientList =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientList).hasSize(1);
-    Patient patient = getResourcePatient(patientList.get(0));
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
 
-    List<Resource> medicationRequestList =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(medicationRequestList).hasSize(1);
-    MedicationRequest medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
-    assertThat(medicationRequest.getSubject()).isNotNull();
-    assertThat(medicationRequest.getSubject().getReference()).isEqualTo(patient.getId());
+        List<Resource> patientList = e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientList).hasSize(1);
+        Patient patient = ResourceUtils.getResourcePatient(patientList.get(0), context);
 
-  }
-  
-  @Test
-  public void test_medicationreq_status() {
-	  
-	//ORC.1 = NW -> Expected medication status = ACTIVE
-    String hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
-    		+ "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-    		+ "ORC|NW|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
-    		+ "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
-    		+ "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
+        List<Resource> medicationRequestList = e.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(medicationRequestList).hasSize(1);
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
+        assertThat(medicationRequest.getSubject()).isNotNull();
+        assertThat(medicationRequest.getSubject().getReference()).isEqualTo(patient.getId());
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-	String json = ftv.convert(hl7message , PatientUtils.OPTIONS);
-    assertThat(json).isNotBlank();
-    
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-
-    List<Resource> medicationRequestList =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(medicationRequestList).hasSize(1);
-    MedicationRequest medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
-    assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.ACTIVE);
+        // Test that RDE_O11 messages don't create ServiceRequests
+        List<Resource> serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Confirm that a serviceRequest was not created.      
+        assertThat(serviceRequestList).isEmpty();
 
 
-	//ORC.1 = SC -> Expected medication status = UNKNWON
-    hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
-    		+ "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-    		+ "ORC|SC|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
-    		+ "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
-    		+ "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
-    ftv = new HL7ToFHIRConverter();
-	json = ftv.convert(hl7message , PatientUtils.OPTIONS);
-    assertThat(json).isNotBlank();
-    
-    bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    b = (Bundle) bundleResource;
-    e = b.getEntry();
-    
-    medicationRequestList.clear();
-    medicationRequestList =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(medicationRequestList).hasSize(1);
-    medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
-    assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.UNKNOWN);
-    
-    
+    }
 
-	//ORC.1 = DC -> Expected medication status = STOPPED
-    hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
-    		+ "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-    		+ "ORC|DC|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
-    		+ "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
-    		+ "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
-    ftv = new HL7ToFHIRConverter();
-	json = ftv.convert(hl7message , PatientUtils.OPTIONS);
-    assertThat(json).isNotBlank();
-    
-    bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    b = (Bundle) bundleResource;
-    e = b.getEntry();
-    
-    medicationRequestList.clear();
-    medicationRequestList =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(medicationRequestList).hasSize(1);
-    medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
-    assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.STOPPED);
-    
+    @Test
+    public void test_medicationreq_status() {
 
-	//ORC.1 = CA -> Expected medication status = CANCELLED
-    hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
-    		+ "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-    		+ "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON,CARL|0148^ADDISON,JAMES||SUR|||||||0100^ANDERSON,CARL|S|V446911|A|||||||||||||||||||SF|K||||20180622230000\n"
-    		+ "ORC|CA|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
-    		+ "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
-    		+ "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
-    ftv = new HL7ToFHIRConverter();
-	json = ftv.convert(hl7message , PatientUtils.OPTIONS);
-    assertThat(json).isNotBlank();
-    
-    bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    b = (Bundle) bundleResource;
-    e = b.getEntry();
-    
-    medicationRequestList.clear();
-    medicationRequestList =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(medicationRequestList).hasSize(1);
-    medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
-    assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.CANCELLED);
-  }
+        //ORC.1 = NW -> Expected medication status = ACTIVE
+        String hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "ORC|NW|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
+                + "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
+                + "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
 
-  private MedicationRequest getResourceMedicationRequest(Resource resource) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = MedicationRequest.class;
-    return (MedicationRequest) context.getParser().parseResource(klass, s);
-  }
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+        assertThat(json).isNotBlank();
 
-  private static Patient getResourcePatient(Resource resource) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Patient.class;
-    return (Patient) context.getParser().parseResource(klass, s);
-  }
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
 
+        List<Resource> medicationRequestList = e.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(medicationRequestList).hasSize(1);
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
+        assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.ACTIVE);
+
+        //ORC.1 = SC -> Expected medication status = UNKNWON
+        hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "ORC|SC|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
+                + "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
+                + "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
+        ftv = new HL7ToFHIRConverter();
+        json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+        assertThat(json).isNotBlank();
+
+        bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        b = (Bundle) bundleResource;
+        e = b.getEntry();
+
+        medicationRequestList.clear();
+        medicationRequestList = e.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(medicationRequestList).hasSize(1);
+        medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
+        assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.UNKNOWN);
+
+        //ORC.1 = DC -> Expected medication status = STOPPED
+        hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "ORC|DC|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
+                + "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
+                + "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
+        ftv = new HL7ToFHIRConverter();
+        json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+        assertThat(json).isNotBlank();
+
+        bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        b = (Bundle) bundleResource;
+        e = b.getEntry();
+
+        medicationRequestList.clear();
+        medicationRequestList = e.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(medicationRequestList).hasSize(1);
+        medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
+        assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.STOPPED);
+
+        // Test that RDE_O11 messages don't create ServiceRequests
+        List<Resource> serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Confirm that a serviceRequest was not created.      
+        assertThat(serviceRequestList).isEmpty();
+
+        //ORC.1 = CA -> Expected medication status = CANCELLED
+        hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON,CARL|0148^ADDISON,JAMES||SUR|||||||0100^ANDERSON,CARL|S|V446911|A|||||||||||||||||||SF|K||||20180622230000\n"
+                + "ORC|CA|F800006^OE|P800006^RX|||E|10^BID^D4^^^R||20180622230000\n"
+                + "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\n"
+                + "RXE|^^^20180622230000^^R|62756-017^Testosterone Cypionate^NDC|100||mg|||||10||5\n";
+        ftv = new HL7ToFHIRConverter();
+        json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+        assertThat(json).isNotBlank();
+
+        bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        b = (Bundle) bundleResource;
+        e = b.getEntry();
+
+        medicationRequestList.clear();
+        medicationRequestList = e.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(medicationRequestList).hasSize(1);
+        medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
+        assertThat(medicationRequest.getStatus()).isEqualTo(MedicationRequestStatus.CANCELLED);
+
+        // Test that RDE_O11 messages don't create ServiceRequests
+        serviceRequestList.clear();  
+        serviceRequestList = e.stream()
+        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Confirm that a serviceRequest was not created.      
+        assertThat(serviceRequestList).isEmpty();
+    }
+
+    // Test that OMP_O09 messages don't create ServiceRequests, they create MedicationRequests
+    @Test
+    public void medicationFromOMPTest() {
+        // Minimal valid ORC message.  Requires RXO and RXR segments.
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210101000000|90103687|OMP^O09|MSGID|T|2.6\n"
+                + "PID|||1234||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_111|||||||||||||||||||||||||20210101000000\n"
+                + "ORC|OP|1234|1234|0827|||^Every 6 hours^^20210101||20210101000000|2739^BY^ENTERED|2799^BY^VERIFIED|3122^PROVIDER^ORDERING|||20210101000000||||||ORDERING FAC NAME|ADDR^^CITY^STATE^ZIP^USA|(9\n"
+                + "RXO|00054418425^Dexamethasone 4 MG Oral Tablet^NDC^^^^^^dexamethasone (DECADRON) 4 MG TABS||||||Take 1 tablet by mouth every 6 (six) hours.||G||4|tablet^tablet|0|222^JONES^JON^E.||||||||||^DECADRON\n"
+                + "RXR|PO^Oral\n";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, PatientUtils.OPTIONS);
+        assertThat(json).isNotBlank();
+
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle bundle = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = bundle.getEntry();
+
+        List<Resource> medicationRequestList = e.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Confirm that one medicationRequest was created. 
+        assertThat(medicationRequestList).hasSize(1);
+
+        List<Resource> serviceRequestList = e.stream()
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Confirm that a serviceRequest was not created.      
+        assertThat(serviceRequestList).isEmpty();
+    }
 
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
@@ -263,7 +263,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
                 .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestList).hasSize(1);
-        MedicationRequest medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
         
         // Verify Authored On date is correct.
         Date authoredOnDate = medicationRequest.getAuthoredOn();      
@@ -320,7 +320,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
                 .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestList).hasSize(1);
-        MedicationRequest medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
         
         // Verify Authored On date is correct.
         Date authoredOnDate = medicationRequest.getAuthoredOn();      
@@ -378,7 +378,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
                 .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestList).hasSize(1);
-        MedicationRequest medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
 
         // Verify authored on is not present
         assertThat(medicationRequest.getAuthoredOn()).isNull();
@@ -431,7 +431,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
                 .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestList).hasSize(1);
-        MedicationRequest medicationRequest = getResourceMedicationRequest(medicationRequestList.get(0));
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
 
         // Verify authored on is not present
         assertThat(medicationRequest.getAuthoredOn()).isNull();
@@ -450,15 +450,4 @@ public class Hl7MedicationRequestFHIRConversionTest {
 
     }
 
-
-    private MedicationRequest getResourceMedicationRequest(Resource resource) {
-        String s = context.getParser().encodeResourceToString(resource);
-        Class<? extends IBaseResource> klass = MedicationRequest.class;
-        return (MedicationRequest) context.getParser().parseResource(klass, s);
-    }
-
-    private static Patient getResourcePatient(Resource resource) {
-        String s = context.getParser().encodeResourceToString(resource);
-        Class<? extends IBaseResource> klass = Patient.class;
-        return (Patient) context.getParser().parseResource(klass, s);
-    }
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ServiceRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ServiceRequestFHIRConversionTest.java
@@ -46,7 +46,7 @@ public class Hl7ServiceRequestFHIRConversionTest {
             + "PV1||I|6N^1234^A^GENHOS|||||||SUR||||||||S||||||||||||||||||||||||||\n"
             + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
             + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||W\n"
-            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
+            + "ORC|NW|1000^OE|9999999^RX||SC|E|^Q6H^D10^^^R\n"
             + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
             + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
             + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n";
@@ -73,7 +73,7 @@ public class Hl7ServiceRequestFHIRConversionTest {
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
     ServiceRequest sr = (ServiceRequest) serviceRequestResource.get(0);
    
-    assertEquals("Completed", sr.getStatus().getDisplay()); //From OBX.11 'F'
+    assertEquals("Active", sr.getStatus().getDisplay()); //From ORC.5 'SC'
   }
   
   @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -231,4 +231,34 @@ public class ResourceUtils {
     Practitioner pract = (Practitioner) matchingPractitioners.get(0);
     return pract;
   }
+ 
+  public static ServiceRequest getResourceServiceRequest(Resource resource, FHIRContext context ) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = ServiceRequest.class;
+    return (ServiceRequest) context.getParser().parseResource(klass, s);
+  }
+
+  public static DiagnosticReport getResourceDiagnosticReport(Resource resource, FHIRContext context) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = DiagnosticReport.class;
+    return (DiagnosticReport) context.getParser().parseResource(klass, s);
+  }
+
+  public static MedicationRequest getResourceMedicationRequest(Resource resource, FHIRContext context) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = MedicationRequest.class;
+    return (MedicationRequest) context.getParser().parseResource(klass, s);
+  }
+
+  public static Patient getResourcePatient(Resource resource, FHIRContext context) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = Patient.class;
+    return (Patient) context.getParser().parseResource(klass, s);
+  }
+
+  public static Immunization getResourceImmunization(Resource resource, FHIRContext context) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = Immunization.class;
+    return (Immunization) context.getParser().parseResource(klass, s);
+}
 }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Remove ServiceRequest from OMP-O09
Test that OMP_O09 messages don't create ServiceRequests, they create MedicationRequests
Correct mapping form ServiceRequestStatus, now from ORC.5
Add EffectiveDateTime to DiagnosticReport From OBR.7
Add EffectivePeriod to DiagnosticReport From OBR.7/8
Change source of status in ServiceRequest to ORC.5
OBR.22 creates a DiagnosticReport.issued
OBR.6 creates ServiceRequest.authoredOn
Test that a ServiceRequest is not created for VXU_V04
Foundational service classes for getting objects from lists for refactoring.  (Only used in files I touched this delivery)