### PR TITLE
Bjc  participant display and reference

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -60,7 +60,7 @@ public enum SimpleDataTypeMapper {
   BUILD_IDENTIFIER_FROM_CWE(SimpleDataValueResolver.BUILD_IDENTIFIER_FROM_CWE),
   MEDREQ_STATUS(SimpleDataValueResolver.MEDREQ_STATUS_CODE_FHIR),
   ACT_ENCOUNTER(SimpleDataValueResolver.ACT_ENCOUNTER_CODE_FHIR),
-  DISPLAY_NAME(SimpleDataValueResolver.DISPLAY_NAME),
+  PERSON_DISPLAY_NAME(SimpleDataValueResolver.PERSON_DISPLAY_NAME),
   ENCOUNTER_MODE_ARRIVAL_DISPLAY(SimpleDataValueResolver.ENCOUNTER_MODE_ARRIVAL_DISPLAY);
 
   private ValueExtractor<Object, ?> valueResolver;

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -60,6 +60,7 @@ public enum SimpleDataTypeMapper {
   BUILD_IDENTIFIER_FROM_CWE(SimpleDataValueResolver.BUILD_IDENTIFIER_FROM_CWE),
   MEDREQ_STATUS(SimpleDataValueResolver.MEDREQ_STATUS_CODE_FHIR),
   ACT_ENCOUNTER(SimpleDataValueResolver.ACT_ENCOUNTER_CODE_FHIR),
+  DISPLAY_NAME(SimpleDataValueResolver.DISPLAY_NAME),
   ENCOUNTER_MODE_ARRIVAL_DISPLAY(SimpleDataValueResolver.ENCOUNTER_MODE_ARRIVAL_DISPLAY);
 
   private ValueExtractor<Object, ?> valueResolver;

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
+import ca.uhn.hl7v2.model.v26.datatype.XCN;
 import ca.uhn.hl7v2.model.Varies;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -99,6 +100,46 @@ public class SimpleDataValueResolver {
             LOGGER.warn("Value not valid URI, value: {}", value, e);
             return null;
         }
+    };
+
+    // Creates a display name; currently only handles XCN as input
+    public static final ValueExtractor<Object, String> DISPLAY_NAME = (Object value) -> {
+        if (value instanceof XCN) {
+            XCN xcn = (XCN) value;
+            StringBuilder sb = new StringBuilder();
+            String valprefix = Hl7DataHandlerUtil.getStringValue(xcn.getPrefixEgDR());
+            String valfirst = Hl7DataHandlerUtil.getStringValue(xcn.getGivenName());
+            String valmiddle = Hl7DataHandlerUtil.getStringValue(xcn.getSecondAndFurtherGivenNamesOrInitialsThereof());
+            String valfamily = Hl7DataHandlerUtil.getStringValue(xcn.getFamilyName());
+            String valsuffix = Hl7DataHandlerUtil.getStringValue(xcn.getSuffixEgJRorIII());
+            String valdegree = Hl7DataHandlerUtil.getStringValue(xcn.getDegreeEgMD());
+
+            if (valprefix != null) {
+                sb.append(valprefix).append(" ");
+            }
+            if (valfirst != null) {
+                sb.append(valfirst).append(" ");
+            }
+            if (valmiddle != null) {
+                sb.append(valmiddle).append(" ");
+            }
+            if (valfamily != null) {
+                sb.append(valfamily).append(" ");
+            }
+            if (valsuffix != null) {
+                sb.append(valsuffix).append(" ");
+            }
+            if (valdegree != null) {
+                sb.append(valdegree).append(" ");
+            }
+            String name = sb.toString();
+            if (StringUtils.isNotBlank(name)) {
+                return name.trim();
+            } else {
+                return null;
+            }
+        } 
+        return null;
     };
 
     public static final ValueExtractor<Object, String> ADMINISTRATIVE_GENDER_CODE_FHIR = (Object value) -> {

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -103,7 +103,7 @@ public class SimpleDataValueResolver {
     };
 
     // Creates a display name; currently only handles XCN as input
-    public static final ValueExtractor<Object, String> DISPLAY_NAME = (Object value) -> {
+    public static final ValueExtractor<Object, String> PERSON_DISPLAY_NAME = (Object value) -> {
         if (value instanceof XCN) {
             XCN xcn = (XCN) value;
             StringBuilder sb = new StringBuilder();
@@ -112,7 +112,6 @@ public class SimpleDataValueResolver {
             String valmiddle = Hl7DataHandlerUtil.getStringValue(xcn.getSecondAndFurtherGivenNamesOrInitialsThereof());
             String valfamily = Hl7DataHandlerUtil.getStringValue(xcn.getFamilyName());
             String valsuffix = Hl7DataHandlerUtil.getStringValue(xcn.getSuffixEgJRorIII());
-            String valdegree = Hl7DataHandlerUtil.getStringValue(xcn.getDegreeEgMD());
 
             if (valprefix != null) {
                 sb.append(valprefix).append(" ");
@@ -129,15 +128,10 @@ public class SimpleDataValueResolver {
             if (valsuffix != null) {
                 sb.append(valsuffix).append(" ");
             }
-            if (valdegree != null) {
-                sb.append(valdegree).append(" ");
-            }
             String name = sb.toString();
             if (StringUtils.isNotBlank(name)) {
                 return name.trim();
-            } else {
-                return null;
-            }
+            } 
         } 
         return null;
     };

--- a/src/main/resources/hl7/datatype/Reference.yml
+++ b/src/main/resources/hl7/datatype/Reference.yml
@@ -7,3 +7,12 @@
 reference:
     type: RELATIVE_REFERENCE
     valueOf:  $BASE_VALUE
+    required: true
+
+
+# Some references have an associated display. (Example Encounter.participant.individual)
+# Optionally provide a value to have display added.    
+display:
+    condition: $referenceDisplay NOT_NULL
+    type: STRING
+    valueOf:  $referenceDisplay

--- a/src/main/resources/hl7/datatype/Reference.yml
+++ b/src/main/resources/hl7/datatype/Reference.yml
@@ -1,18 +1,17 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
 reference:
-    type: RELATIVE_REFERENCE
-    valueOf:  $BASE_VALUE
-    required: true
-
+  type: RELATIVE_REFERENCE
+  valueOf: $BASE_VALUE
+  required: true
 
 # Some references have an associated display. (Example Encounter.participant.individual)
-# Optionally provide a value to have display added.    
+# Optionally provide a value to have display added.
 display:
-    condition: $referenceDisplay NOT_NULL
-    type: STRING
-    valueOf:  $referenceDisplay
+  condition: $referenceDisplay NOT_NULL
+  type: STRING
+  valueOf: $referenceDisplay

--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -162,7 +162,7 @@ participant_1:
    expressionType: resource
    vars:
       practionerSpec: PV1.7
-      referenceDisplay: String, PV1.7.1
+      referenceDisplay: DISPLAY_NAME, PV1.7
    constants:
       codeableConceptCode: 'ATND'
       codeableConceptText: 'attender'
@@ -174,7 +174,7 @@ participant_2:
    expressionType: resource
    vars:
       practionerSpec: PV1.8
-      referenceDisplay: String, PV1.8.1
+      referenceDisplay: DISPLAY_NAME, PV1.8
    constants:
       codeableConceptCode: 'REF'
       codeableConceptText: 'referrer'
@@ -186,7 +186,7 @@ participant_3:
    expressionType: resource
    vars:
       practionerSpec: PV1.9
-      referenceDisplay: String, PV1.9.1
+      referenceDisplay: DISPLAY_NAME, PV1.9
    constants:
       codeableConceptCode: 'CON'
       codeableConceptText: 'consultant'
@@ -198,7 +198,7 @@ participant_4:
    expressionType: resource
    vars:
       practionerSpec: PV1.17
-      referenceDisplay: String, PV1.17.1
+      referenceDisplay: DISPLAY_NAME, PV1.17
    constants:
       codeableConceptCode: 'ADM'
       codeableConceptText: 'admitter'

--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -162,6 +162,7 @@ participant_1:
    expressionType: resource
    vars:
       practionerSpec: PV1.7
+      referenceDisplay: String, PV1.7.1
    constants:
       codeableConceptCode: 'ATND'
       codeableConceptText: 'attender'
@@ -173,6 +174,7 @@ participant_2:
    expressionType: resource
    vars:
       practionerSpec: PV1.8
+      referenceDisplay: String, PV1.8.1
    constants:
       codeableConceptCode: 'REF'
       codeableConceptText: 'referrer'
@@ -184,6 +186,7 @@ participant_3:
    expressionType: resource
    vars:
       practionerSpec: PV1.9
+      referenceDisplay: String, PV1.9.1
    constants:
       codeableConceptCode: 'CON'
       codeableConceptText: 'consultant'
@@ -195,6 +198,7 @@ participant_4:
    expressionType: resource
    vars:
       practionerSpec: PV1.17
+      referenceDisplay: String, PV1.17.1
    constants:
       codeableConceptCode: 'ADM'
       codeableConceptText: 'admitter'

--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -162,7 +162,7 @@ participant_1:
    expressionType: resource
    vars:
       practionerSpec: PV1.7
-      referenceDisplay: DISPLAY_NAME, PV1.7
+      referenceDisplay: PERSON_DISPLAY_NAME, PV1.7
    constants:
       codeableConceptCode: 'ATND'
       codeableConceptText: 'attender'
@@ -174,7 +174,7 @@ participant_2:
    expressionType: resource
    vars:
       practionerSpec: PV1.8
-      referenceDisplay: DISPLAY_NAME, PV1.8
+      referenceDisplay: PERSON_DISPLAY_NAME, PV1.8
    constants:
       codeableConceptCode: 'REF'
       codeableConceptText: 'referrer'
@@ -186,7 +186,7 @@ participant_3:
    expressionType: resource
    vars:
       practionerSpec: PV1.9
-      referenceDisplay: DISPLAY_NAME, PV1.9
+      referenceDisplay: PERSON_DISPLAY_NAME, PV1.9
    constants:
       codeableConceptCode: 'CON'
       codeableConceptText: 'consultant'
@@ -198,7 +198,7 @@ participant_4:
    expressionType: resource
    vars:
       practionerSpec: PV1.17
-      referenceDisplay: DISPLAY_NAME, PV1.17
+      referenceDisplay: PERSON_DISPLAY_NAME, PV1.17
    constants:
       codeableConceptCode: 'ADM'
       codeableConceptText: 'admitter'

--- a/src/main/resources/hl7/secondary/Participant.yml
+++ b/src/main/resources/hl7/secondary/Participant.yml
@@ -16,8 +16,27 @@ type:
    constants:
       system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType'
       
+# individual:
+#    valueOf: resource/Practitioner
+#    expressionType: reference
+#    specs: $practionerSpec
+#    required: true
+
+
 individual:
-   valueOf: resource/Practitioner
-   expressionType: reference
-   specs: $practionerSpec
-   required: true
+   # generateList: true
+   # evaluateLater: true
+   expressionType: nested
+   vars: 
+      bjc: String, $practionerSpec
+      specLike: $practionerSpec
+   expressionsMap:
+      display:
+         type: STRING
+         valueOf: $bjc
+      reference:
+         required: true
+         valueOf: resource/Practitioner
+         expressionType: reference 
+         specs: $specLike 
+

--- a/src/main/resources/hl7/secondary/Participant.yml
+++ b/src/main/resources/hl7/secondary/Participant.yml
@@ -16,27 +16,8 @@ type:
    constants:
       system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType'
       
-# individual:
-#    valueOf: resource/Practitioner
-#    expressionType: reference
-#    specs: $practionerSpec
-#    required: true
-
-
 individual:
-   # generateList: true
-   # evaluateLater: true
-   expressionType: nested
-   vars: 
-      bjc: String, $practionerSpec
-      specLike: $practionerSpec
-   expressionsMap:
-      display:
-         type: STRING
-         valueOf: $bjc
-      reference:
-         required: true
-         valueOf: resource/Practitioner
-         expressionType: reference 
-         specs: $specLike 
-
+   valueOf: resource/Practitioner
+   expressionType: reference
+   specs: $practionerSpec
+   required: true

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.r4.model.codesystems.V3ReligiousAffiliation;
 import org.junit.jupiter.api.Test;
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
+import ca.uhn.hl7v2.model.v26.datatype.XCN;
 import ca.uhn.hl7v2.model.v26.datatype.TX;
 import ca.uhn.hl7v2.model.v26.message.ORU_R01;
 import io.github.linuxforhealth.core.terminology.SimpleCode;
@@ -270,6 +271,33 @@ public class SimpleDataValueResolverTest {
     assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("A B C")).isEqualTo("urn:id:A_B_C");
     assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("")).isNull();
     assertThat(SimpleDataValueResolver.SYSTEM_ID.apply(null)).isNull();
+  }
+
+  @Test
+  public void getDisplayNameValid() throws DataTypeException {
+    XCN xcn = new XCN(null);
+    xcn.getPrefixEgDR().setValue("Dr");
+    xcn.getGivenName().setValue("Joe");
+    xcn.getSecondAndFurtherGivenNamesOrInitialsThereof().setValue("Q");
+    xcn.getFamilyName().getSurname().setValue("Johnson");
+    xcn.getSuffixEgJRorIII().setValue("III");
+    xcn.getDegreeEgMD().setValue("MD");
+ 
+    assertThat(SimpleDataValueResolver.DISPLAY_NAME.apply(xcn)).isEqualTo("Dr Joe Q Johnson III MD");
+  }
+
+  @Test
+  public void getDisplayNameNotValid() throws DataTypeException {
+    CWE cwe = new CWE(null);
+    cwe.getCwe3_NameOfCodingSystem().setValue("HL70005");
+    cwe.getCwe1_Identifier().setValue("2028-9");
+    cwe.getCwe2_Text().setValue("Asian");
+  
+    // CWE is not a valid input and should return null
+    assertThat(SimpleDataValueResolver.DISPLAY_NAME.apply(cwe)).isNull();
+    // String is not a valid input and should return null
+    assertThat(SimpleDataValueResolver.DISPLAY_NAME.apply("Bogus String")).isNull();
+
   }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -281,9 +281,8 @@ public class SimpleDataValueResolverTest {
     xcn.getSecondAndFurtherGivenNamesOrInitialsThereof().setValue("Q");
     xcn.getFamilyName().getSurname().setValue("Johnson");
     xcn.getSuffixEgJRorIII().setValue("III");
-    xcn.getDegreeEgMD().setValue("MD");
  
-    assertThat(SimpleDataValueResolver.DISPLAY_NAME.apply(xcn)).isEqualTo("Dr Joe Q Johnson III MD");
+    assertThat(SimpleDataValueResolver.PERSON_DISPLAY_NAME.apply(xcn)).isEqualTo("Dr Joe Q Johnson III");
   }
 
   @Test
@@ -294,9 +293,9 @@ public class SimpleDataValueResolverTest {
     cwe.getCwe2_Text().setValue("Asian");
   
     // CWE is not a valid input and should return null
-    assertThat(SimpleDataValueResolver.DISPLAY_NAME.apply(cwe)).isNull();
+    assertThat(SimpleDataValueResolver.PERSON_DISPLAY_NAME.apply(cwe)).isNull();
     // String is not a valid input and should return null
-    assertThat(SimpleDataValueResolver.DISPLAY_NAME.apply("Bogus String")).isNull();
+    assertThat(SimpleDataValueResolver.PERSON_DISPLAY_NAME.apply("Bogus String")).isNull();
 
   }
 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -661,7 +662,7 @@ public class Hl7EncounterFHIRConversionTest {
                 + "EVN||20210330144208||||\n"
                 + "PID|1||ABC12345^^^MRN||DOE^JANE|||||||||||||||\n"
                 // Key fields are PV1.7, PV1.8, PV1.9, and PV1.17
-                + "PV1||I|||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting|||||||||||||||||||||||||||\n";
+                + "PV1||I|||||2905^Doctor^Attending^M^IV^^MD|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^^Jr||||||||59367^Doctor^Admitting|||||||||||||||||||||||||||\n";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
@@ -699,18 +700,23 @@ public class Hl7EncounterFHIRConversionTest {
             String value = p.getIdentifier().get(0).getValue();
             assertThat(practionerIds).contains(value);
             // In map, first value is Participant Id, second is Participant Value
-            List<String> values = Arrays.asList(p.getId(), value);
+            List<String> values = new ArrayList<String>();
+            values.add(p.getId());
             switch (value) {
                 case "2905":
+                    values.add("Attending M Doctor IV MD");
                     practionerMap.put("ATND", values);
                     break;
                 case "5755":
+                    values.add("Referring Doctor Sr");
                     practionerMap.put("REF", values);
                     break;
                 case "770542":
+                    values.add("Consulting Doctor Jr");
                     practionerMap.put("CON", values);
                     break;
                 case "59367":
+                    values.add("Admitting Doctor");
                     practionerMap.put("ADM", values);
                     break;
             }
@@ -774,18 +780,23 @@ public class Hl7EncounterFHIRConversionTest {
             String value = p.getIdentifier().get(0).getValue();
             assertThat(practionerIds).contains(value);
             // In map, first value is Participant Id, second is Participant Value
-            List<String> values = Arrays.asList(p.getId(), value);
+            List<String> values = new ArrayList<String>();
+            values.add(p.getId());
             switch (value) {
                 case "2905":
+                    values.add("Attending M Doctor IV MD");
                     practionerMap.put("ATND", values);
                     break;
                 case "5755":
+                    values.add("Referring Doctor Sr");
                     practionerMap.put("REF", values);
                     break;
                 case "770542":
+                    values.add("Consulting Doctor Jr");
                     practionerMap.put("CON", values);
                     break;
                 case "59367":
+                    values.add("Admitting Doctor");
                     practionerMap.put("ADM", values);
                     break;
             }
@@ -800,7 +811,6 @@ public class Hl7EncounterFHIRConversionTest {
             assertEquals(practionerMap.get(code).get(1), component.getIndividual().getDisplay());
         }
     }
-
     /**
      * Testing Encounter correctly references Observation
      * 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -704,7 +704,7 @@ public class Hl7EncounterFHIRConversionTest {
             values.add(p.getId());
             switch (value) {
                 case "2905":
-                    values.add("Attending M Doctor IV MD");
+                    values.add("Attending M Doctor IV");
                     practionerMap.put("ATND", values);
                     break;
                 case "5755":
@@ -784,7 +784,7 @@ public class Hl7EncounterFHIRConversionTest {
             values.add(p.getId());
             switch (value) {
                 case "2905":
-                    values.add("Attending M Doctor IV MD");
+                    values.add("Attending M Doctor IV");
                     practionerMap.put("ATND", values);
                     break;
                 case "5755":

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -358,6 +358,39 @@ public class Hl7EncounterFHIRConversionTest {
 
     }
 
+//     For following test, Participant members should look like this:
+//     {
+//         "type": [ {
+//           "coding": [ {
+//             "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+//             "code": "REF",
+//             "display": "referrer"
+//           } ]
+//         } ],
+//         "individual": {
+//           "reference": "Practitioner/f3b6242c-8964-48ab-bc8c-ddbe2e4bd4c7",
+//           "display": "2913"
+//         }
+
+    @Test
+    public void test_encounter_participant_individual_reference_and_display() {
+        // PV1.2 has mapped value and should returned fhir value
+        String hl7message = "MSH|^~\\&|PROSOLV|SENTARA|WHIA|IBM|20151008111200|S1|ADT^A01^ADT_A01|MSGID000001|T|2.6|10092|PRPA008|AL|AL|100|8859/1|ENGLISH|ARM|ARM5007\n"
+                + "EVN|A04|20151008111200|20171013152901|O|OID1006|20171013153621|EVN1009\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1|1|E|SAN JOSE|A|10089|MILPITAS|2740^Torres^Callie|2913^Grey^Meredith^F|3065^Sloan^Mark^J|CAR|FOSTER CITY|AD|R|1|A4|VI|9052^Shepeard^Derek^|AH|10019181|FIC1002|IC|CC|CR|CO|20161012034052|60000|6|AC|GHBR|20160926054052|AC5678|45000|15000|D|20161016154413|DCD|SAN FRANCISCO|VEG|RE|O|AV|FREMONT|CALIFORNIA|20161013154626|20161014154634|10000|14000|2000|4000|POL8009|V|PHY6007\n";
+        Encounter encounter = ResourceUtils.getEncounter(hl7message);
+
+        assertThat(encounter.hasParticipant()).isTrue();
+        EncounterParticipantComponent epc = encounter.getParticipantFirstRep();
+        assertThat(epc.hasType()).isTrue();
+        assertThat(epc.hasIndividual()).isTrue();
+        Reference indv = epc.getIndividual();
+        assertThat(indv.hasDisplay()).isTrue();
+        assertThat(indv.hasReference()).isTrue();  // This is the problem
+
+    }
+
     @Test
     public void test_encounter_reason_code() {
         // EVN.4 for reasonCode

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -699,7 +699,7 @@ public class Hl7EncounterFHIRConversionTest {
             String value = p.getIdentifier().get(0).getValue();
             assertThat(practionerIds).contains(value);
             // In map, first value is Participant Id, second is Participant Value
-            List<String> values = List.of(p.getId(), value);
+            List<String> values = Arrays.asList(p.getId(), value);
             switch (value) {
                 case "2905":
                     practionerMap.put("ATND", values);
@@ -774,7 +774,7 @@ public class Hl7EncounterFHIRConversionTest {
             String value = p.getIdentifier().get(0).getValue();
             assertThat(practionerIds).contains(value);
             // In map, first value is Participant Id, second is Participant Value
-            List<String> values = List.of(p.getId(), value);
+            List<String> values = Arrays.asList(p.getId(), value);
             switch (value) {
                 case "2905":
                     practionerMap.put("ATND", values);


### PR DESCRIPTION
Add Display to the Encounter Participant reference.
Created formatted name utility to create display name.
Adapted existing tests for Encounter Participant reference by adding an additional check for the Display value.

(Note first commit was not working.  @pbhallam advised method used in second commit)