### PR TITLE
Force Organization IDs to be lowercase

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -208,12 +208,18 @@ public class Hl7RelatedGeneralUtils {
 
         return result;
     }
+
+
     public static String formatAsId(Object input)
     {
-        // This replaces any special character (letters, numbers, dashes, or periods) with a period
-        String stringValue = Hl7DataHandlerUtil.getStringValue(input).trim();
-        stringValue = stringValue.replaceAll("[^a-zA-Z0-9\\-\\.]", ".");
-        return StringUtils.left(stringValue, 64);
+        if (input != null){
+            // This replaces any special character (letters, numbers, dashes, or periods) with a period
+            // Then lower-cases
+            String stringValue = Hl7DataHandlerUtil.getStringValue(input).trim();
+            stringValue = stringValue.replaceAll("[^a-zA-Z0-9\\-\\.]", ".").toLowerCase();
+            return StringUtils.left(stringValue, 64);
+        }
+        return null;
     }
 
     public static String getAddressUse(String xad7Type, String xad16Temp, String xad17Bad) {

--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -213,8 +213,8 @@ public class Hl7RelatedGeneralUtils {
     public static String formatAsId(Object input)
     {
         if (input != null){
-            // This replaces any special character (letters, numbers, dashes, or periods) with a period
-            // Then lower-cases
+            // This replaces any special character (other than letters, numbers, dashes, or periods) with a period
+            // Then lower-cases, and truncates to 64 characters.
             String stringValue = Hl7DataHandlerUtil.getStringValue(input).trim();
             stringValue = stringValue.replaceAll("[^a-zA-Z0-9\\-\\.]", ".").toLowerCase();
             return StringUtils.left(stringValue, 64);

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -311,4 +311,21 @@ public class Hl7RelatedGeneralUtilsTest {
     assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","4444444","","112")).isEqualTo("444 4444");  // Same rule without extension
   }
 
+  @Test
+  public void test_getFormatAsId() {
+   
+    // Inputs are any string
+    assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");
+    assertThat(Hl7RelatedGeneralUtils.formatAsId("OMC")).isEqualTo("omc");
+    assertThat(Hl7RelatedGeneralUtils.formatAsId("   4 5 6  ")).isEqualTo("4.5.6");
+
+    // Edge cases (if these occur we might have name space collisions)
+    // The input is trimmed so totally blank input becomes empty
+    assertThat(Hl7RelatedGeneralUtils.formatAsId(" ")).isEmpty();
+    assertThat(Hl7RelatedGeneralUtils.formatAsId("")).isEmpty();
+    // Null in becomes null out
+    assertThat(Hl7RelatedGeneralUtils.formatAsId(null)).isNull();
+
+  }
+
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -312,7 +312,7 @@ public class Hl7RelatedGeneralUtilsTest {
   }
 
   @Test
-  public void test_getFormatAsId() {
+  public void testGetFormatAsId() {
    
     // Inputs are any string
     assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -275,7 +275,7 @@ public class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/toronto.west"); // Also verify underscore replacement for Utility.formatAsId
+        assertThat(providerString).isEqualTo("Organization/toronto.west"); // Also verify use of Utility.formatAsId
 
         List<Resource> organizations = e.stream()
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -156,7 +156,7 @@ public class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/SSH.WEYMOUTH");
+        assertThat(providerString).isEqualTo("Organization/ssh.weymouth");
 
         List<Resource> organizations = e.stream()
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
@@ -195,7 +195,7 @@ public class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/SSH.WEYMOUTH.WEST.BUILD-7.F");
+        assertThat(providerString).isEqualTo("Organization/ssh.weymouth.west.build-7.f");
 
         List<Resource> organizations = e.stream()
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
@@ -235,7 +235,7 @@ public class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/Toronto.East"); // Also verify underscore replacement for Utility.formatAsId
+        assertThat(providerString).isEqualTo("Organization/toronto.east"); // Also verify use of Utility.formatAsId
 
         List<Resource> organizations = e.stream()
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
@@ -275,7 +275,7 @@ public class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/Toronto.West"); // Also verify underscore replacement for Utility.formatAsId
+        assertThat(providerString).isEqualTo("Organization/toronto.west"); // Also verify underscore replacement for Utility.formatAsId
 
         List<Resource> organizations = e.stream()
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
@@ -315,7 +315,7 @@ public class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/Toronto");
+        assertThat(providerString).isEqualTo("Organization/toronto");
 
         List<Resource> organizations = e.stream()
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Organization IDs  (Urls) are created from HL7 field content.    Anything that is not:   a-z A-Z 0-9 dash or period  is replaced by a period. 

This PR also lower-cases everything, adds missing tests, and checks for null values. 