### PR TITLE
Remove assigner from Identifier

### DIFF
--- a/src/main/resources/hl7/datatype/Identifier.yml
+++ b/src/main/resources/hl7/datatype/Identifier.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -28,11 +28,3 @@ period:
        start: CX.7 | CWE.7
        end: CX.8 | CWE.8
 
-assigner:
-   valueOf: resource/Organization_ServiceProvider
-   expressionType: reference
-   vars:
-     name: $assigningAuth
-     id: CX.4| CWE.4
-   constants:
-      assigningAuth: 'Assigning Authority'

--- a/src/main/resources/hl7/datatype/Identifier_Gen.yml
+++ b/src/main/resources/hl7/datatype/Identifier_Gen.yml
@@ -21,11 +21,5 @@ period:
     vars: 
        start: $start
        end: $end
-       
-assigner:
-   valueOf: resource/Organization_ServiceProvider
-   expressionType: reference
-   vars:
-     name: 'Assigning Authority'
-     id: $assigner
+
 


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

We are no longer using assigner in Identifier.  This removes stale code.