### PR TITLE
Use non-greedy mode of HAPI parser

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,13 +12,17 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Bundle;
+
 import com.google.common.base.Preconditions;
+
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.parser.GenericParser;
 import ca.uhn.hl7v2.util.Hl7InputStreamMessageStringIterator;
 import io.github.linuxforhealth.core.terminology.TerminologyLookup;
 import io.github.linuxforhealth.core.terminology.UrlLookup;
@@ -32,140 +36,137 @@ import io.github.linuxforhealth.hl7.resource.ResourceReader;
 /**
  * Converts HL7 message to FHIR bundle resource based on the customizable templates.
  * 
- *
  * @author pbhallam
  */
 public class HL7ToFHIRConverter {
-  private Map<String, HL7MessageModel> messagetemplates = new HashMap<>();
+    private Map<String, HL7MessageModel> messagetemplates = new HashMap<>();
 
-  /**
-   * Constructor initialized all the templates used for converting the HL7 to FHIR bundle resource.
-   * 
-   * @throws IllegalStateException - If any issues are encountered when loading the templates.
-   */
-  public HL7ToFHIRConverter() {
-
-    try {
-      messagetemplates.putAll(ResourceReader.getInstance().getMessageTemplates());
-      TerminologyLookup.init();
-      UrlLookup.init();
-    } catch (IllegalArgumentException e) {
-      throw new IllegalStateException("Failure to initialize the templates for the converter.", e);
-    }
-  }
-
-
-
-  /**
-   * Converts the input HL7 file (.hl7) into FHIR bundle resource.
-   * 
-   * @param hl7MessageFile - Single message only
-   * @return JSON representation of FHIR {@link Bundle} resource. If bundle type if not specified
-   *         then the default bundle type is used BundleType.COLLECTION
-   * @throws IOException
-   * @throws UnsupportedOperationException - if message type is not supported
-   * @throws IllegalArgumentException
-   */
-  public String convert(File hl7MessageFile) throws IOException {
-    Preconditions.checkArgument(hl7MessageFile != null, "Input HL7 message file cannot be null.");
-    return convert(hl7MessageFile, ConverterOptions.SIMPLE_OPTIONS);
-
-  }
-
-  /**
-   * Converts the input HL7 file (.hl7) into FHIR bundle resource.
-   * 
-   * @param hl7MessageFile
-   * @param options
-   * 
-   * @return JSON representation of FHIR {@link Bundle} resource.
-   * @throws IOException
-   * @throws UnsupportedOperationException - if message type is not supported
-   */
-  public String convert(File hl7MessageFile, ConverterOptions options) throws IOException {
-    Preconditions.checkArgument(hl7MessageFile != null, "Input HL7 message file cannot be null.");
-    return convert(FileUtils.readFileToString(hl7MessageFile, StandardCharsets.UTF_8), options);
-
-  }
-
-
-  /**
-   * Converts the input HL7 message (String data) into FHIR bundle resource.
-   * 
-   * @param hl7MessageData
-   * @return JSON representation of FHIR {@link Bundle} resource. If bundle type if not specified
-   *         then the default bundle type is used BundleType.COLLECTION
-   * @throws UnsupportedOperationException - if message type is not supported
-   */
-
-  public String convert(String hl7MessageData) {
-    return convert(hl7MessageData, ConverterOptions.SIMPLE_OPTIONS);
-
-  }
-
-  /**
-   * Converts the input HL7 message (String data) into FHIR bundle resource.
-   * 
-   * @param hl7MessageData
-   * @param options
-   * 
-   * @return JSON representation of FHIR {@link Bundle} resource.
-   * @throws UnsupportedOperationException - if message type is not supported
-   */
-  public String convert(String hl7MessageData, ConverterOptions options) {
-    Preconditions.checkArgument(StringUtils.isNotBlank(hl7MessageData),
-        "Input HL7 message cannot be blank");
-    Preconditions.checkArgument(options != null, "options cannot be null.");
-    FHIRContext context = new FHIRContext(options.isPrettyPrint(), options.isValidateResource());
-    HL7MessageEngine engine = new HL7MessageEngine(context, options.getBundleType());
-
-    Message hl7message = getHl7Message(hl7MessageData);
-    if (hl7message != null) {
-      String messageType = HL7DataExtractor.getMessageType(hl7message);
-      HL7MessageModel hl7MessageTemplateModel = messagetemplates.get(messageType);
-      if (hl7MessageTemplateModel != null) {
-        return hl7MessageTemplateModel.convert(hl7message, engine);
-      } else {
-        throw new UnsupportedOperationException("Message type not yet supported " + messageType);
-      }
-    } else {
-      throw new IllegalArgumentException("Parsed HL7 message was null.");
-    }
-  }
-
-
-  private static Message getHl7Message(String data) {
-
-    HL7HapiParser hparser = null;
-    Message hl7message = null;
-    try (InputStream ins = IOUtils.toInputStream(data, StandardCharsets.UTF_8)) {
-      Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
-      // only supports single message conversion.
-      if (iterator.hasNext()) {
-        hparser = new HL7HapiParser();
-        hl7message = hparser.getParser().parse(iterator.next());
-      }
-    } catch (HL7Exception e) {
-      throw new IllegalArgumentException("Cannot parse the message.", e);
-    } catch (IOException ioe) {
-      throw new IllegalArgumentException("IOException encountered.", ioe);
-    } finally {
-      close(hparser);
+    /**
+     * Constructor initialized all the templates used for converting the HL7 to FHIR bundle resource.
+     * 
+     * @throws IllegalStateException - If any issues are encountered when loading the templates.
+     */
+    public HL7ToFHIRConverter() {
+        try {
+            messagetemplates.putAll(ResourceReader.getInstance().getMessageTemplates());
+            TerminologyLookup.init();
+            UrlLookup.init();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Failure to initialize the templates for the converter.", e);
+        }
     }
 
-    return hl7message;
-  }
-
-
-
-  private static void close(HL7HapiParser hparser) {
-    if (hparser != null) {
-      try {
-        hparser.getContext().close();
-      } catch (IOException e) {
-        throw new IllegalStateException("Failure to close HL7 parser.", e);
-      }
+    /**
+     * Converts the input HL7 file (.hl7) into FHIR bundle resource.
+     * 
+     * @param hl7MessageFile - Single message only
+     * @return JSON representation of FHIR {@link Bundle} resource. If bundle type if not specified
+     *         then the default bundle type is used BundleType.COLLECTION
+     * @throws IOException
+     * @throws UnsupportedOperationException - if message type is not supported
+     * @throws IllegalArgumentException
+     */
+    public String convert(File hl7MessageFile) throws IOException {
+        Preconditions.checkArgument(hl7MessageFile != null, "Input HL7 message file cannot be null.");
+        return convert(hl7MessageFile, ConverterOptions.SIMPLE_OPTIONS);
     }
-  }
+
+    /**
+     * Converts the input HL7 file (.hl7) into FHIR bundle resource.
+     * 
+     * @param hl7MessageFile
+     * @param options
+     * 
+     * @return JSON representation of FHIR {@link Bundle} resource.
+     * @throws IOException
+     * @throws UnsupportedOperationException - if message type is not supported
+     */
+    public String convert(File hl7MessageFile, ConverterOptions options) throws IOException {
+        Preconditions.checkArgument(hl7MessageFile != null, "Input HL7 message file cannot be null.");
+        return convert(FileUtils.readFileToString(hl7MessageFile, StandardCharsets.UTF_8), options);
+    }
+
+    /**
+     * Converts the input HL7 message (String data) into FHIR bundle resource.
+     * 
+     * @param hl7MessageData
+     * @return JSON representation of FHIR {@link Bundle} resource. If bundle type if not specified
+     *         then the default bundle type is used BundleType.COLLECTION
+     * @throws UnsupportedOperationException - if message type is not supported
+     */
+    public String convert(String hl7MessageData) {
+        return convert(hl7MessageData, ConverterOptions.SIMPLE_OPTIONS);
+    }
+
+    /**
+     * Converts the input HL7 message (String data) into FHIR bundle resource.
+     * 
+     * @param hl7MessageData
+     * @param options
+     * 
+     * @return JSON representation of FHIR {@link Bundle} resource.
+     * @throws UnsupportedOperationException - if message type is not supported
+     */
+    public String convert(String hl7MessageData, ConverterOptions options) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(hl7MessageData),
+                "Input HL7 message cannot be blank");
+        Preconditions.checkArgument(options != null, "options cannot be null.");
+        FHIRContext context = new FHIRContext(options.isPrettyPrint(), options.isValidateResource());
+        HL7MessageEngine engine = new HL7MessageEngine(context, options.getBundleType());
+
+        Message hl7message = getHl7Message(hl7MessageData);
+        if (hl7message != null) {
+            String messageType = HL7DataExtractor.getMessageType(hl7message);
+            HL7MessageModel hl7MessageTemplateModel = messagetemplates.get(messageType);
+            if (hl7MessageTemplateModel != null) {
+                return hl7MessageTemplateModel.convert(hl7message, engine);
+            } else {
+                throw new UnsupportedOperationException("Message type not yet supported " + messageType);
+            }
+        } else {
+            throw new IllegalArgumentException("Parsed HL7 message was null.");
+        }
+    }
+
+    private static Message getHl7Message(String data) {
+        HL7HapiParser hparser = null;
+        Message hl7message = null;
+        try (InputStream ins = IOUtils.toInputStream(data, StandardCharsets.UTF_8)) {
+            Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
+            // only supports single message conversion.
+            if (iterator.hasNext()) {
+                String msgstr = iterator.next();
+                hparser = new HL7HapiParser();
+                GenericParser parser = hparser.getParser();
+                // greedy mode needed for multiple ORDER groups in OML_O21
+                parser.getParserConfiguration().setNonGreedyMode(true);
+                try {
+                    hl7message = parser.parse(msgstr);
+                } catch (HL7Exception | ArrayIndexOutOfBoundsException e) {
+                    // try again with non-greedy mode, some messages such as ORU_R01 fail with greedy mode
+                    parser.getParserConfiguration().setNonGreedyMode(false);
+                    try {
+                        hl7message = parser.parse(msgstr);
+                    } catch (HL7Exception e2) {
+                        throw new IllegalArgumentException("Cannot parse the message.", e2);
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            throw new IllegalArgumentException("IOException encountered.", ioe);
+        } finally {
+            close(hparser);
+        }
+        return hl7message;
+    }
+
+    private static void close(HL7HapiParser hparser) {
+        if (hparser != null) {
+            try {
+                hparser.getContext().close();
+            } catch (IOException e) {
+                throw new IllegalStateException("Failure to close HL7 parser.", e);
+            }
+        }
+    }
 }
-

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
@@ -6,9 +6,11 @@
 package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -17,158 +19,29 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Hl7PPRMessageTest {
-  private static FHIRContext context = new FHIRContext();
-  private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
-  private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PPRMessageTest.class);
+    private static FHIRContext context = new FHIRContext();
+    private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
+    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PPRMessageTest.class);
 
+    @Test
+    public void test_ppr_pc1() throws IOException {
+        String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+                + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
+                + "OBX|1|TX|^Type of protein feed^L||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+                + "OBX|2|TX|^SOMEd^L||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930165100|||";
 
-  @Test
-  public void test_ppr_pc1() throws IOException {
-    String hl7message =
-        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-            + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
-            + "OBX|1|TX|^Type of protein feed^L||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-            + "OBX|2|TX|^SOMEd^L||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930165100|||";
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
-
-    assertThat(json).isNotBlank();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(1);
-
-    List<Resource> obsResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(2);
-
-    List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(encounterResource).hasSize(1);
-
-    List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(conditionresource).hasSize(1);
-  }
-
-  @Test
-  public void test_ppr_pc1_service_request_present() throws IOException {
-    String hl7message =
-        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
-    		+ "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
-            + "PV1||I|6N^1234^A^GENHOS|||||||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\n"
-            + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
-            + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\n"
-            + "NTE|1|P|Problem Comments\n"
-            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
-            + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
-            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
-            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n"
-            + "OBX|3|TX|||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F|||202101010000|||\n";
-    
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
-    assertThat(json).isNotBlank();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(1);
-    
-    //OBX under PRB (the PROBLEM.PROBLEM_OBSERVATION.OBSERVATION) creates an Observation resource
-    List<Resource> obsResource =
-            e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(1);
-
-    List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(encounterResource).hasSize(1);
-
-    List<Resource> serviceRequestResource =
-            e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(serviceRequestResource).hasSize(1);
-
-    //TODO: uncomment once documentRef is enabled for PPR
-    //    List<Resource> documentRefResource =
-    //		e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-    //            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    //    assertThat(documentRefResource).hasSize(1);
-
-  }
-  
-  
-  @Test
-  @Disabled("PPR_PC2 not supported yet")
-  public void test_ppr_pc2_patient_encounter_present() throws IOException {
-	  String hl7message =
-		        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC2|1|P^I|2.6||||||ASCII||\r"
-		            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-		            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-		            + "PRB|UP|200603150625|aortic stenosis|53692||2||200603150625\r"
-		            + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
-		            + "OBX|1|TX|^Type of protein feed^L||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-		            + "OBX|2|TX|^SOMEd^L||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930165100|||";
-
-      HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-      String json = ftv.convert(hl7message, OPTIONS);
-      assertThat(json).isNotBlank();
-      LOGGER.info("FHIR json result:\n" + json);
-      IBaseResource bundleResource = context.getParser().parseResource(json);
-      assertThat(bundleResource).isNotNull();
-      Bundle b = (Bundle) bundleResource;
-      List<BundleEntryComponent> e = b.getEntry();
-      List<Resource> patientResource = e.stream()
-              .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-              .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(patientResource).hasSize(1);
-
-      List<Resource> encounterResource = e.stream()
-              .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-              .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(encounterResource).hasSize(1);
-
-  }
-
-
-  @Test
-  @Disabled("PPR_PC2 not supported yet")
-  public void test_ppr_pc2_service_request_present() throws IOException {
-    String hl7message =
-            "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC2^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
-        		+ "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
-                + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
-                + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
-                + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
-                + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
-                + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n";
-        
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
 
@@ -178,78 +51,197 @@ public class Hl7PPRMessageTest {
         Bundle b = (Bundle) bundleResource;
         assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
         List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> patientResource =
-            e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> documentRefResource =
-        	e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(documentRefResource).hasSize(1);
-      
-        List<Resource> obsResource =
-                e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(obsResource).hasSize(0);
+        assertThat(obsResource).hasSize(1);
 
-        List<Resource> encounterResource =
-            e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-            e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+        List<Resource> conditionresource = e.stream()
+                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(conditionresource).hasSize(1);
+    }
+
+    @Test
+    public void test_ppr_pc1_service_request_present() throws IOException {
+        String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
+                + "PV1||I|6N^1234^A^GENHOS|||||||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\n"
+                + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
+                + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\n"
+                + "NTE|1|P|Problem Comments\n"
+                + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
+                + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
+                + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
+                + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n"
+                + "OBX|3|TX|||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F|||202101010000|||\n";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+        assertThat(json).isNotBlank();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
+
+        //OBX under PRB (the PROBLEM.PROBLEM_OBSERVATION.OBSERVATION) creates an Observation resource
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
+
+        List<Resource> serviceRequestResource = e.stream()
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(serviceRequestResource).hasSize(1);
-      }
 
+        // TODO: uncomment once documentRef is enabled for PPR
+        //    List<Resource> documentRefResource =
+        //		e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+        //            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        //    assertThat(documentRefResource).hasSize(1);
+    }
 
-  @Test
-  @Disabled("PPR_PC3 not supported yet")
-  public void test_ppr_pc3_service_request_present() throws IOException {
-	    String hl7message =
-	        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC3^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
-	    		+ "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
-	            + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
-	            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
-	            + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
-	            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
-	            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n";
-	    
-		    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-		    String json = ftv.convert(hl7message, OPTIONS);
+    @Test
+    @Disabled("PPR_PC2 not supported yet") // TODO
+    public void test_ppr_pc2_patient_encounter_present() throws IOException {
+        String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC2|1|P^I|2.6||||||ASCII||\r"
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|UP|200603150625|aortic stenosis|53692||2||200603150625\r"
+                + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
+                + "OBX|1|TX|^Type of protein feed^L||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+                + "OBX|2|TX|^SOMEd^L||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930165100|||";
 
-		    assertThat(json).isNotBlank();
-		    IBaseResource bundleResource = context.getParser().parseResource(json);
-		    assertThat(bundleResource).isNotNull();
-		    Bundle b = (Bundle) bundleResource;
-		    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-		    List<BundleEntryComponent> e = b.getEntry();
-		    List<Resource> patientResource =
-		        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-		            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-		    assertThat(patientResource).hasSize(1);
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+        assertThat(json).isNotBlank();
+        LOGGER.info("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
 
-		    List<Resource> documentRefResource =
-		    	e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-		        	.map(BundleEntryComponent::getResource).collect(Collectors.toList());
-		    assertThat(documentRefResource).hasSize(1);
-		  
-		    List<Resource> obsResource =
-		            e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-		                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-		    assertThat(obsResource).hasSize(0);
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
+    }
 
-		    List<Resource> encounterResource =
-		        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-		            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-		    assertThat(encounterResource).hasSize(1);
+    @Test
+    @Disabled("PPR_PC2 not supported yet") // TODO
+    public void test_ppr_pc2_service_request_present() throws IOException {
+        String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC2^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
+                + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
+                + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
+                + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
+                + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
+                + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n";
 
-		    List<Resource> serviceRequestResource =
-		            e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-		                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-		    assertThat(serviceRequestResource).hasSize(1);
-		  }
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+
+        assertThat(json).isNotBlank();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
+
+        List<Resource> documentRefResource = e.stream()
+                .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(documentRefResource).hasSize(1);
+
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(0);
+
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
+
+        List<Resource> serviceRequestResource = e.stream()
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(serviceRequestResource).hasSize(1);
+    }
+
+    @Test
+    @Disabled("PPR_PC3 not supported yet") // TODO
+    public void test_ppr_pc3_service_request_present() throws IOException {
+        String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC3^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
+                + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\n"
+                + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
+                + "OBR|1|TESTID|TESTID|||202101010000|202101010000||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
+                + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
+                + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\n";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+
+        assertThat(json).isNotBlank();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
+
+        List<Resource> documentRefResource = e.stream()
+                .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(documentRefResource).hasSize(1);
+
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(0);
+
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
+
+        List<Resource> serviceRequestResource = e.stream()
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(serviceRequestResource).hasSize(1);
+    }
 
 }


### PR DESCRIPTION
The issue being seen in https://github.com/LinuxForHealth/hl7v2-fhir-converter/pull/257 can be fixed by using the parser configuration setting _non-greedy mode_  , see [https://github.com/nHapiNET/nHapi/issues/65](https://github.com/nHapiNET/nHapi/issues/65)
However, this causes issues in other messages, in particular ORU_R01.

Signed-off-by: Lisa S. Wellman <peace@us.ibm.com>