### PR TITLE
Support multiple XCNs for Encounter participants

### DIFF
--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -159,9 +159,9 @@ participant_1:
    valueOf: secondary/Participant
    generateList: true
    expressionType: resource
+   specs: PV1.7
    vars:
       practionerSpec: PV1.7
-      referenceDisplay: PERSON_DISPLAY_NAME, PV1.7
    constants:
       codeableConceptCode: 'ATND'
       codeableConceptText: 'attender'
@@ -170,10 +170,10 @@ participant_2:
    condition: $practionerSpec NOT_NULL
    valueOf: secondary/Participant
    generateList: true
+   specs: PV1.8
    expressionType: resource
    vars:
       practionerSpec: PV1.8
-      referenceDisplay: PERSON_DISPLAY_NAME, PV1.8
    constants:
       codeableConceptCode: 'REF'
       codeableConceptText: 'referrer'
@@ -182,10 +182,10 @@ participant_3:
    condition: $practionerSpec NOT_NULL
    valueOf: secondary/Participant
    generateList: true
+   specs: PV1.9
    expressionType: resource
    vars:
       practionerSpec: PV1.9
-      referenceDisplay: PERSON_DISPLAY_NAME, PV1.9
    constants:
       codeableConceptCode: 'CON'
       codeableConceptText: 'consultant'
@@ -194,10 +194,10 @@ participant_4:
    condition: $practionerSpec NOT_NULL
    valueOf: secondary/Participant
    generateList: true
+   specs: PV1.17
    expressionType: resource
    vars:
       practionerSpec: PV1.17
-      referenceDisplay: PERSON_DISPLAY_NAME, PV1.17
    constants:
       codeableConceptCode: 'ADM'
       codeableConceptText: 'admitter'

--- a/src/main/resources/hl7/secondary/Participant.yml
+++ b/src/main/resources/hl7/secondary/Participant.yml
@@ -19,5 +19,8 @@ type:
 individual:
    valueOf: resource/Practitioner
    expressionType: reference
-   specs: $practionerSpec
+   specs: XCN
    required: true
+   vars: 
+      referenceDisplay: PERSON_DISPLAY_NAME, XCN
+


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

The spec for PV1.7 had to be at the top level to work.
Tests needed rework because the key could no longer be the Code (because more than one could have the Code.)