### PR TITLE
Hardening of RDE support and increase unit test - phase one

### DIFF
--- a/src/main/resources/hl7/message/RDE_O11.yml
+++ b/src/main/resources/hl7/message/RDE_O11.yml
@@ -14,14 +14,14 @@ resources:
     additionalSegments:
 
   - resourceName: Patient
-    segment: PATIENT.PID
+    segment: .PID
+    group: PATIENT
     resourcePath: resource/Patient
     isReferenced: true
     repeats: false
     additionalSegments:
       - .PD1
       - MSH
-      - ORDER.OBSERVATION.OBX
 
   - resourceName: Encounter
     segment: .PATIENT_VISIT.PV1

--- a/src/main/resources/hl7/message/RDE_O25.yml
+++ b/src/main/resources/hl7/message/RDE_O25.yml
@@ -13,7 +13,8 @@ resources:
     isReferenced: false
 
   - resourceName: Patient
-    segment: PATIENT.PID
+    segment: .PID
+    group: PATIENT
     resourcePath: resource/Patient
     isReferenced: true
     repeats: false

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7RDEMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7RDEMessageTest.java
@@ -40,6 +40,7 @@ public class Hl7RDEMessageTest {
 		        + "RXA|0|23|20210407191342|20210407191342|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|||||12345^LNAME^FNAME|BN6T3|100^mL/hr||||||||RateChange||20210407191342\n"
 		        + "ZXC||00409-7335-03^CEFTRIAXONE SODIUM 2 G IJ SOLR^REPNDC\n"
 		        + "ZCL|hcm-prod1862018998731\n";
+                        // TODO: RXA, ZXC, ZCL are not in RDE_o11.
 
       HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
       String json = ftv.convert(hl7message, OPTIONS);
@@ -48,6 +49,7 @@ public class Hl7RDEMessageTest {
       assertThat(bundleResource).isNotNull();
       Bundle b = (Bundle) bundleResource;
       List<BundleEntryComponent> e = b.getEntry();
+      
       List<Resource> patientResource = e.stream()
               .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
@@ -57,6 +59,8 @@ public class Hl7RDEMessageTest {
               .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
       assertThat(encounterResource).hasSize(1);
+
+      // TODO: Add check for Medication Request
 
   }
 
@@ -71,6 +75,8 @@ public class Hl7RDEMessageTest {
 		        + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||12345^LNAME^FNAME\n"
 		        + "RXA|0|23|20210407191342|20210407191342|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|||||12345^LNAME^FNAME|BN6T3|100^mL/hr||||||||RateChange||20210407191342\n"
 		        + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
+                        // TODO: RXA is not in RDE_o11 messages
+                        // TODO: Add check for MedicationRequest, ORC and RXE are required, and RXO is optional.  ORC + RXE is repeatable
 		        
       HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
       String json = ftv.convert(hl7message, OPTIONS);
@@ -79,6 +85,7 @@ public class Hl7RDEMessageTest {
       assertThat(bundleResource).isNotNull();
       Bundle b = (Bundle) bundleResource;
       List<BundleEntryComponent> e = b.getEntry();
+
       List<Resource> patientResource = e.stream()
               .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
               .map(BundleEntryComponent::getResource).collect(Collectors.toList());
@@ -90,6 +97,29 @@ public class Hl7RDEMessageTest {
       assertThat(observationResource).hasSize(1);
   }
 
+  @Test
+  public void test_RDEO11_medrequest_present() throws IOException {
+	  String hl7message =
+		        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\n"
+		        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+		        + "ORC|RE|ACCESSION_62fd10ea-522a-4261-837a-30381a5aa04a|ACCESSION_62fd10ea-522a-4261-837a-30381a5aa04a|3200|||^Every 24 hours&1500^^20210330150000^^ROU||20210407191342|2739^BY^ENTERED|2799^BY^VERIFIED|3122^PROVIDER^ORDERING||(696)901-1300|20210407191342||||||ORDERING FAC NAME|ADDR^^CITY^STATE^ZIP^USA|(515)-290-8888|9999^^CITY^STATE^ZIP^CAN|||||I\n"
+		        + "RXO|DEFAULTMED\n"
+		        + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||12345^LNAME^FNAME\n";
+
+      HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+      String json = ftv.convert(hl7message, OPTIONS);
+      assertThat(json).isNotBlank();
+      IBaseResource bundleResource = context.getParser().parseResource(json);
+      assertThat(bundleResource).isNotNull();
+      Bundle b = (Bundle) bundleResource;
+      List<BundleEntryComponent> e = b.getEntry();
+
+      List<Resource> resourceList = e.stream()
+              .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+              .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+      assertThat(resourceList).hasSize(1);
+
+  }
 
   @Test
   public void test_RDEO25_patient_encounter_present() throws IOException {
@@ -120,31 +150,6 @@ public class Hl7RDEMessageTest {
       assertThat(encounterResource).hasSize(1);
 
   }
-
-  @Test
-  public void test_RDEO11_medrequest_present() throws IOException {
-	  String hl7message =
-		        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\n"
-		        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-		        + "ORC|RE|ACCESSION_62fd10ea-522a-4261-837a-30381a5aa04a|ACCESSION_62fd10ea-522a-4261-837a-30381a5aa04a|3200|||^Every 24 hours&1500^^20210330150000^^ROU||20210407191342|2739^BY^ENTERED|2799^BY^VERIFIED|3122^PROVIDER^ORDERING||(696)901-1300|20210407191342||||||ORDERING FAC NAME|ADDR^^CITY^STATE^ZIP^USA|(515)-290-8888|9999^^CITY^STATE^ZIP^CAN|||||I\n"
-		        + "RXO|DEFAULTMED\n"
-		        + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||12345^LNAME^FNAME\n";
-
-      HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-      String json = ftv.convert(hl7message, OPTIONS);
-      assertThat(json).isNotBlank();
-      IBaseResource bundleResource = context.getParser().parseResource(json);
-      assertThat(bundleResource).isNotNull();
-      Bundle b = (Bundle) bundleResource;
-      List<BundleEntryComponent> e = b.getEntry();
-
-      List<Resource> resourceList = e.stream()
-              .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-              .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(resourceList).hasSize(1);
-
-  }
-
 
   @Test
   public void test_RDEO25_medrequest_present() throws IOException {

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
@@ -433,10 +433,8 @@ public class Hl7ObservationFHIRConversionTest {
         "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC1|||2.6||||||||2.6\r",
         //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC2|||2.6||||||||2.6\r",
         //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC3|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|RDE^O11|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|RDE^O25|||2.6||||||||2.6\r"
     })
-    public void extendedObservationCWEtest(String msh) throws IOException {
+    public void extendedObservationTestMostMessages(String msh) throws IOException {
         String hl7message = msh
                 + "OBX|1|CWE|DQW^Some text 1^SNM3|100|DQW^Other text 2^SNM3|mm^Text 3^SNM3|56-98|IND|25|ST|F|20210322153839|LKJ|20210320153850|N56|1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567^mySystem|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
 
@@ -614,6 +612,128 @@ public class Hl7ObservationFHIRConversionTest {
         DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getCategoryFirstRep(), "laboratory", "Laboratory",
                 "http://terminology.hl7.org/CodeSystem/observation-category", null);
 
+    }
+
+    // Tests resources created for Observations from RDE messages
+    @ParameterizedTest
+    @ValueSource(strings = { 
+        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
+    public void extendedObservationTestForRDEMessages(String msh) throws IOException {
+
+        String hl7message = msh
+        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+        + "ORC|RE|111|111|3200|||^Every 24 hours&1500^^20210330150000^^ROU||20210407191342|2739^BY^ENTERED|2799^BY^VERIFIED|3122^PROVIDER^ORDERING||(696)901-1300|20210407191342||||||ORDERING FAC NAME|ADDR^^CITY^STATE^ZIP^USA|(515)-290-8888|9999^^CITY^STATE^ZIP^CAN|||||I\n"
+        + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||12345^LNAME^FNAME\n"
+        + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg||IND||||||20210320153850||1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567^mySystem|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+          
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+
+        Observation obs = (Observation) obsResource.get(0);
+
+        // Check the coding  (OBX.3)
+        assertThat(obs.hasCode()).isTrue();
+        DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getCode(), "Most Current Weight", "Most current measured weight (actual)",
+                null, "Most current measured weight (actual)");
+    
+        // Check the value  (OBX.5)
+        assertNotNull(obs.getValueQuantity());
+        Quantity q = obs.getValueQuantity();
+        assertNull(q.getCode()); //code for unit
+        assertEquals("kg", q.getUnit()); //unit units to OBX.6.1
+        assertNull(q.getSystem());  //system for unit
+        assertEquals(90f, q.getValue().floatValue());
+        assertNull(q.getComparator()); // = is not put in comparator
+
+        // Check that there is no reference range, OBX.6 and OBX.7
+        assertThat(obs.hasReferenceRange()).isFalse();
+
+        // Check interpretation (OBX.8)
+        assertThat(obs.hasInterpretation()).isTrue();
+        assertThat(obs.getInterpretation()).hasSize(1);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getInterpretationFirstRep(), "IND", "Indeterminate",
+                "http://terminology.hl7.org/CodeSystem/v2-0078", null);
+        
+        // Check the effective Date Time  (OBX.14)
+        assertThat(obs.hasEffective()).isTrue();
+        assertThat(obs.hasEffectiveDateTimeType()).isTrue();
+        assertThat(obs.getEffectiveDateTimeType().asStringValue()).isEqualTo("2021-03-20T15:38:50+08:00");
+        
+        // Check performer  (OBX.16 Practictioner + OBX.23/OBX.24/OBX.25 Organization)
+        assertThat(obs.hasPerformer()).isTrue();
+        assertThat(obs.getPerformer()).hasSize(2); // Practioner and Organization
+        // Get Practitioner and see that it is populated with OBX.16 information
+        assertThat(obs.getPerformer().get(0).hasReference()).isTrue();
+        List<Resource> practitionerResource = e.stream()
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(practitionerResource).hasSize(1);
+        Practitioner doctor = getResourcePractitioner(practitionerResource.get(0));
+        assertThat(doctor.getName().get(0).getFamily()).isEqualTo("ClinicianLastName");
+        // Get Organization and see that it is populated with OBX.23/OBX.24/OBX.25 information
+        assertThat(obs.getPerformer().get(1).hasReference()).isTrue();
+        List<Resource> organizationResource = e.stream()
+                .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(organizationResource).hasSize(1);
+        Organization org = getResourceOrganization(organizationResource.get(0));
+        assertThat(org.getName()).isEqualTo("Radiology"); // from OBX.23
+        assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString())
+                .isEqualTo("467 Albany Hospital"); // from OBX.24
+        assertThat(org.getAddress().get(0).getCity()).isEqualTo("Albany"); // from OBX.24
+        assertThat(org.getAddress().get(0).getState()).isEqualTo("NY"); // from OBX.24
+        assertThat(org.getContact().get(0).getName().getFamily()).isEqualTo("ContactLastName"); // from OBX.25
+        assertThat(org.getContact().get(0).getName().getGiven().get(0).getValueAsString()).isEqualTo("Jane"); // from OBX.25
+        assertThat(org.getContact().get(0).getName().getSuffix()).hasSize(0); // There should be no suffix, currently not putting degree 'Title' in suffix
+        assertThat(org.getContact().get(0).getName().getText()).isEqualTo("Dr. Jane Q ContactLastName"); // from OBX.25
+        assertThat(org.getContact().get(0).hasPurpose()).isTrue(); // purpose added because of OBX.25
+        DatatypeUtils.checkCommonCodeableConceptAssertions(org.getContact().get(0).getPurpose(), "ADMIN",
+                "Administrative",
+                "http://terminology.hl7.org/CodeSystem/contactentity-type",
+                "Organization Medical Director");
+
+        // Check method  (OBX.17)
+        assertThat(obs.hasMethod()).isTrue();
+        DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getMethod(), "Manual", "Text the 4th",
+                "http://terminology.hl7.org/CodeSystem/SNM3", "Text the 4th");
+
+        // Check device  (OBX.18)
+        assertThat(obs.hasDevice()).isTrue();
+        assertThat(obs.getDevice().hasReference()).isTrue();
+        List<Resource> deviceResource = e.stream()
+                .filter(v -> ResourceType.Device == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(deviceResource).hasSize(1);
+        Device device = getResourceDevice(deviceResource.get(0));
+        assertThat(device.getIdentifier().get(0).getValue()).isEqualTo("Device_1234567");
+        assertThat(device.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:mySystem");
+
+        // Check bodySite  (OBX.20)
+        assertThat(obs.hasBodySite()).isTrue();
+        DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getBodySite(), "Observation Site", "Text 5",
+                "http://terminology.hl7.org/CodeSystem/SNM3", "Text 5");
+
+        // Check identifier  (OBX.21)
+        assertThat(obs.hasIdentifier()).isTrue();
+        assertThat(obs.getIdentifier()).hasSize(2);
+        assertThat(obs.getIdentifier().get(1).getValue()).isEqualTo("INST");
+        assertThat(obs.getIdentifier().get(1).getSystem()).isEqualTo("urn:id:Instance_Identifier_System");
+
+        // OBX.23/OBX.24/OBX.25 went into Performer: Organization.  Checked above.
+
+        // Check for ABSENCE of category (because no SPM)  Presence of category tested in extendedObservationUnusualRangesAndOtherTest
+        assertThat(obs.hasCategory()).isFalse();
     }
     
     private static Practitioner getResourcePractitioner(Resource resource) {

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -55,8 +55,8 @@ public class Hl7PatientFHIRConversionTest {
     // "MSH|^~\\&|hl7Integration|hl7Integration|||||OMP^O09|||2.6|\r",
     // "MSH|^~\\&|hl7Integration|hl7Integration|||||ORM^O01|||2.6|\r",
     // "MSH|^~\\&|hl7Integration|hl7Integration|||||ORU^R01|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O11|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O25|||2.6|\r",
+    "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O11|||2.6|\r",
+    "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O25|||2.6|\r",
     // "MSH|^~\\&|hl7Integration|hl7Integration|||||VXU^V04|||2.6|\r",
     })
   public void test_patient_additional_demographics(String msh) {

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -10,8 +10,8 @@
 	</appender>
 	
 
-	<logger name="io.github.linuxforhealth" level="error" />
-	<root level="error">
+	<logger name="io.github.linuxforhealth" level="info" />
+	<root level="info">
 		<appender-ref ref="Console" />
 	</root>
 


### PR DESCRIPTION
Signed-off-by: Lisa Dierkhising <lisadier@us.ibm.com>

I want to get these fixes delivered so they are available for others, even though I'm not done with all of RDE yet:
- Removed unused OBX from RDE-o11-> Patient
- Fixed problem that generalPractitioners were not created for RDE-o11
- Fixed problem that generalPractitioners were not created for RDE-O25
- Added tests for Observations in RDE messages, including coverage of sub-resources Practitioner, Organization, and Device