### PR TITLE
Fix ServiceReqs OBR only; ref display; PGN text

### DIFF
--- a/src/main/resources/hl7/resource/DiagnosticReport.yml
+++ b/src/main/resources/hl7/resource/DiagnosticReport.yml
@@ -108,13 +108,13 @@ resultsInterpreter:
       interpreter: OBR.32
 
 basedOn:
-   condition: $basedOnORC NOT_NULL
+   condition: $basedOnORCOBR NOT_NULL
    valueOf: resource/ServiceRequest
    generateList: true
    expressionType: reference
-   specs: ORC
+   specs: ORC | OBR
    vars:
-      basedOnORC: ORC      
+      basedOnORCOBR: ORC | OBR     
 
 specimen:
    valueOf: datatype/Reference

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -74,7 +74,6 @@ requisition:
       valueIn: ORC.4.1
       systemCX:  ORC.4.2
    constants:   
-      text: "Placer Group Number"
       # Base URL doesn't find the code, but the versioned system does
       system: "http://terminology.hl7.org/2.1.0/CodeSystem/v2-0203"
       code: "PGN"
@@ -97,7 +96,7 @@ requester:
    specs: ORC.12 | OBR.16
    vars:
       request: ORC.12 | OBR.16
-      referenceDisplay: PERSON_DISPLAY_NAME, ORC.12
+      referenceDisplay: PERSON_DISPLAY_NAME, ORC.12 | OBR.16
 
 reasonCode:
    condition: $reasonCWE NOT_NULL 


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Fixes three problems:
1.  ServiceRequests _should_ be created (example for ORU_R01) even if there is only a (valid) OBR segment and the ORC is missing.  ORC is optional.
2.  Display should be present for ServiceRequest requester reference
3.  Remove text from ServiceRequest requisition

Add tests to check for successful fixes.