### PR TITLE
Whitespace fix in ORM message

### DIFF
--- a/src/main/resources/hl7/message/ORM_O01.yml
+++ b/src/main/resources/hl7/message/ORM_O01.yml
@@ -71,7 +71,7 @@ resources:
       - PATIENT.PATIENT_VISIT.PV1
       - PATIENT.PID
 
- - resourceName: DocumentReference
+  - resourceName: DocumentReference
     segment: ORDER.ORC
     resourcePath: resource/DocumentReference
     additionalSegments:


### PR DESCRIPTION
Signed-off-by: Lisa Dierkhising <lisadier@us.ibm.com>

One-line update to add a necessary space so that message yaml doesn't cause the converter to err out.