### PR TITLE
add reason code based on specs which is one reason code with backup 

### DIFF
--- a/src/main/resources/hl7/resource/MedicationRequest.yml
+++ b/src/main/resources/hl7/resource/MedicationRequest.yml
@@ -124,4 +124,4 @@ reasonCode:
   valueOf: datatype/CodeableConcept
   generateList: true
   expressionType: resource
-  specs: RXE.27 | RXO.20 | RXA.19 | ORC.16 #not sure what message type uses RXA?
+  specs: RXE.27 | RXO.20 | ORC.16

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
@@ -598,6 +598,8 @@ public class Hl7MedicationRequestFHIRConversionTest {
         assertThat(medicationRequestList).hasSize(1);
         MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
 
+        assertThat(medicationRequest.getReasonCode()).hasSize(1);
+        assertThat(medicationRequest.getReasonCodeFirstRep().getCoding()).hasSize(1);
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getCode()).isEqualTo("Wheezing");
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getDisplay()).isEqualTo("Wheezing");
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getSystem()).isEqualTo("urn:id:PRN");
@@ -627,6 +629,8 @@ public class Hl7MedicationRequestFHIRConversionTest {
         assertThat(medicationRequestList).hasSize(1);
         medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
 
+        assertThat(medicationRequest.getReasonCode()).hasSize(1);
+        assertThat(medicationRequest.getReasonCodeFirstRep().getCoding()).hasSize(1);
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getCode()).isEqualTo("134006");
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getDisplay()).isNull();
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getSystem()).isNull();
@@ -653,6 +657,8 @@ public class Hl7MedicationRequestFHIRConversionTest {
         assertThat(medicationRequestList).hasSize(1);
         medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequestList.get(0), context);
 
+        assertThat(medicationRequest.getReasonCode()).hasSize(1);
+        assertThat(medicationRequest.getReasonCodeFirstRep().getCoding()).hasSize(1);
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getCode()).isEqualTo("4338008");
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getDisplay()).isEqualTo("Wheezing");
         assertThat(medicationRequest.getReasonCodeFirstRep().getCodingFirstRep().getSystem()).isEqualTo("urn:id:PRN");


### PR DESCRIPTION
 MedicationRequest.reasonCode should be set based on these fields, this is a precedence order: RXE-27, RXO-20, RXA-19, ORC-16. Note that although reasonCode is an array, 10/15/21 Elena said she prefers we chose on (and they will likely all match)