### PR TITLE
Remove OBR.7, 8, 24 from DocumentReference.context

### DIFF
--- a/src/main/resources/hl7/resource/DocumentReference.yml
+++ b/src/main/resources/hl7/resource/DocumentReference.yml
@@ -187,8 +187,7 @@ context:
    valueOf: secondary/Context
    expressionType: resource
    vars:
-      practiceSettingIn: OBR.24
-      timestamp: TXA.4 | OBR.7
+      timestamp: TXA.4 
       providerCode: TXA.5
       serviceRequestRef: $ServiceRequest
       encounterRef: $Encounter

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
@@ -85,7 +85,6 @@ public class Hl7PPRMessageTest {
             + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\n"
             + "NTE|1|P|Problem Comments\n"
             + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\n"
-            // OBR.7 is used for the timestamp (because no TXA in a PPR_PC1 message)
             + "OBR|1|TESTID|TESTID|||201801180346|201801180347||||||||||||||||||F||||||WEAKNESS||||||||||||\n"
             // Next three lines create an attachment because OBX type TX
             + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\n"
@@ -129,7 +128,7 @@ public class Hl7PPRMessageTest {
 
     DocumentReference documentRef = ResourceUtils.getResourceDocumentReference(documentRefResource.get(0), context);
     DocumentReference.DocumentReferenceContextComponent drContext = documentRef.getContext();
-    assertThat(drContext.getPeriod().getStartElement().toString()).containsPattern("2018-01-18T03:47:00"); // OBR.7
+    assertThat(drContext.hasPeriod()).isFalse();
     DocumentReference.DocumentReferenceContentComponent content = documentRef.getContentFirstRep();
     assertThat(content.getAttachment().getContentType()).isEqualTo("text/plain"); // Currently always defaults to text/plain
     assertThat(content.getAttachment().getCreation()).isNull(); // No TXA.7 in message

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
@@ -189,8 +189,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
                 // ORC required for ServiceRequest test
                 // All three practitioner id's are provided (ORC.2, ORC.3, ORC.456)
                 + "ORC|NW|P1005|F1005|PGN001|SC|D|1|||MS|MS|||||\n"
-                // OBR.24 converts to DocumentReference.practiceSetting
                 + "OBR|1||||||20170825010500|||||||||||||002||||CUS|F||||||||\n"
+                // TXA.4 used for context start
                 + "TXA|1||TEXT|20180117144200|5566^PAPLast^PAPFirst^J^^MD||201801180346||<PHYSID1>||||||||||AV|||<PHYSID2>||\n"
                 // OBX is type ST so an observation will be created
                 + "OBX|1|ST|100||This is content|||||||X\n";
@@ -215,10 +215,9 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         Practitioner practBundle = ResourceUtils.getSpecificPractitionerFromBundle(bundle, requesterRef);
 
         DocumentReference.DocumentReferenceContextComponent refContext = documentReference.getContext();
-        assertThat(refContext.getPeriod().getStartElement().toString()).containsPattern("2018-01-17T14:42:00");
+        assertThat(refContext.getPeriod().getStartElement().toString()).containsPattern("2018-01-17T14:42:00");  // TXA.4
         assertThat(refContext.hasRelated()).isTrue();
-        assertThat(refContext.hasPracticeSetting()).isTrue();  // OBR.24
-        DatatypeUtils.checkCommonCodeableConceptAssertions(refContext.getPracticeSetting(), "CUS", "Cardiac Ultrasound", "http://terminology.hl7.org/CodeSystem/v2-0074", "CUS");
+        assertThat(refContext.hasPracticeSetting()).isFalse(); 
 
         assertThat(practBundle.getIdentifierFirstRep().getValue()).isEqualTo("5566");
         // Value passed to Context(TXA.5) is used as Identifier value in practitioner


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

We decided to no longer map OBR.24 to DocumentReference.context.practiceSetting because there can be only one in FHIR but the MDM_T02 messages allow multiple Order (ORC+OBR groups)"
Similarly, we decided not to map OBR.7,8 to DocumentReference.context.period for the same reason. 

This PR implements that change and updates tests.