### PR TITLE
Segment NTE support - initial drop; test refactor

### DIFF
--- a/src/main/resources/hl7/datatype/Annotation.yml
+++ b/src/main/resources/hl7/datatype/Annotation.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,6 +23,6 @@ time:
    expressionType: HL7Spec
 text:
    type: STRING
-   valueOf: NTE.3 |$text
+   valueOf: $text | NTE.3
    required: true
    expressionType: HL7Spec

--- a/src/main/resources/hl7/message/PPR_PC1.yml
+++ b/src/main/resources/hl7/message/PPR_PC1.yml
@@ -43,6 +43,7 @@ resources:
       - .ORDER.ORC
       - .ORDER.ORDER_DETAIL.OBR
       - MSH
+      - .PROBLEM_OBSERVATION.NTE
 
   - resourceName: Condition
     segment: .PRB
@@ -53,6 +54,7 @@ resources:
       - MSH
       - PID
       - PATIENT_VISIT.PV1
+      - .NTE
 
   - resourceName: ServiceRequest
     segment: .ORDER.ORC

--- a/src/main/resources/hl7/resource/Condition.yml
+++ b/src/main/resources/hl7/resource/Condition.yml
@@ -183,3 +183,11 @@ clinicalStatus:
   vars:
     coding: CONDITION_CLINICAL_STATUS_FHIR, PRB.14
     text: String, PRB.14.2
+
+note:
+   valueOf: datatype/Annotation
+   condition: $text NOT_NULL
+   expressionType: resource
+   # Note on separator: Must double back-slashes to create single backslash in string.
+   vars:
+      text: NTE.3 *&, GeneralUtils.concatenateWithChar(text, '  \\n')            

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -192,10 +192,11 @@ note_1:
 
 note_2:
    valueOf: datatype/Annotation
-   generateList: true
-   condition: NTE NOT_NULL
+   condition: $text NOT_NULL
    expressionType: resource
-   specs: NTE
+   # Note on separator: Must double back-slashes to create single backslash in string.
+   vars:
+      text: NTE.3 *&, GeneralUtils.concatenateWithChar(text, '  \\n')
 
 bodySite:
    valueOf: datatype/CodeableConcept

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -103,4 +103,12 @@ code:
    expressionType: resource
    specs: OBR.4
    vars:
-      codeCWE: OBR.4       
+      codeCWE: OBR.4 
+
+note:
+   valueOf: datatype/Annotation
+   condition: $text NOT_NULL
+   expressionType: resource
+   # Note on separator: Must double back-slashes to create single backslash in string.
+   vars:
+      text: NTE.3 *&, GeneralUtils.concatenateWithChar(text, '  \\n')            

--- a/src/main/resources/hl7/resource/Specimen.yml
+++ b/src/main/resources/hl7/resource/Specimen.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright Mubashir Kazia. 2021
+# (C) Copyright IBM Corp. 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -43,7 +43,7 @@ condition:
    expressionType: resource
    specs: SPM.24
 
-note_1:
+note:
    valueOf: datatype/Annotation
    expressionType: resource
    condition: $obx3 EQUALS 48767-8
@@ -52,8 +52,3 @@ note_1:
       obx3: STRING, OBX.3.1
       text: STRING, OBX.5
 
-note_2:
-   valueOf: datatype/Annotation
-   generateList: true
-   expressionType: resource
-   specs: NTE

--- a/src/test/java/io/github/linuxforhealth/IssueFixTest.java
+++ b/src/test/java/io/github/linuxforhealth/IssueFixTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,83 +8,18 @@ package io.github.linuxforhealth;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
+
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.DiagnosticReport;
-import org.hl7.fhir.r4.model.HumanName;
-import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
-import io.github.linuxforhealth.fhir.FHIRContext;
-import io.github.linuxforhealth.hl7.ConverterOptions;
-import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
-import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class IssueFixTest {
-  private static FHIRContext context = new FHIRContext();
-  private static final ConverterOptions OPTIONS =
-      new Builder().withValidateResource().withPrettyPrint().build();
 
-  @Test
-  public void oru_issue_81() {
-    String hl7ORU =
-        "MSH|^~\\&|Epic|ATRIUS|||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.3.1|||||||||PHLabReport-Ack^^2.16.840.1.114222.4.10.3^ISO||\n"
-            + "SFT|Epic Systems Corporation^L^^^^ANSI&1.2.840&ISO^XX^^^1.2.840.114350|Epic 2015 |Bridges|8.2.2.0||20160605043244\n"
-            + "PID|1|788840^^^^HVMA|788840||OLIVER^BETTY^J^^^||19481112|F||BLACK|75 MARK TERRACE^^RANDOLPH^MA^02368^USA^^^NORFOLK||(781)767-1274^^7^^^781^7671274~^NET^Internet^bettyo10@verizon.net|||||||||BLACK||||||||N|||20130320045252|1|\n"
-            + "NTE|1|O|BHDNK75 4-14-15.|\n" + "NTE|2|O|BWH# 074-08-20-6       |\n"
-            + "PD1|||BRAINTREE-ATRIUS HEALTH^^06|1457352338^TEITLEMAN^CHRISTOPHER^A MD^^^^^^^^^NPISER||||||||||||||\n"
-            + "NK1|1|TILLMAN^FRANCES^^|SISTER||(617)436-7319^^7^^^617^4367319|||||||||||||||||||||||||||\n"
-            + "NK1|2|EDWARDS^SOYINI^^|DAUGHTER||(213)270-3770^^7^^^213^2703770|||||||||||||||||||||||||||\n"
-            + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
-            + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker||||||||1457352338^TEITLEMAN^CHRISTOPHER^A MD^^^^^^^^^NPISER||(781)849-2400^^^^^781^8492400|||||||ATRIUS HEALTH, INC^D^^^^POCFULL^XX^^^1020|P.O. BOX 415432^^BOSTON^MA^02241-5432^^B|898-7980^^8^^^800^8987980|111 GROSSMAN DRIVE^^BRAINTREE^MA^02184^USA^C^^NORFOLK|||||||\n"
-            + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||20180924152700||||NORM||E11.9^Type 2 diabetes mellitus without complications^ICD-10-CM^^^^^^Type 2 diabetes mellitus without complications|||1457352338^TEITLEMAN^CHRISTOPHER^A MD^^^^^^^^^NPISER|(781)849-2400^^^^^781^8492400|||||20180924152900|||F|||||||&Roache&Gerard&&||||||||||||||||||\n"
-            + "TQ1|1||||||20180924152721|20180924235959|R\n"
-            + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
-            + "NTE|1|L||\n" + "NTE|2|L|Non-Diabetic Reference range <6.0%|\n" + "NTE|3|L||\n"
-            + "NTE|4|L|The American Diabetes Association recommends that the |\n"
-            + "NTE|5|L|goal of therapy should be a hemoglobin A1C of <7.0 % |\n"
-            + "NTE|6|L|and that physicians should reevaluate the treatment |\n"
-            + "NTE|7|L|regimen in patients with hemoglobin A1C      |\n"
-            + "NTE|8|L|values consistently >8.0 %|\n"
-            + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F|||20180924152700||9548^ROACHE^GERARD^^|||20180924152903||||HVMA DEPARTMENT OF PATHOLOGY AND LAB MEDICINE^D|152 SECOND AVE^^NEEDHAM^MA^02494-2809^^B|\n"
-            + "NTE|1|L||\n" + "NTE|2|L|Estimated Average Glucose |\n" + "NTE|3|L||\n"
-            + "NTE|4|L|A1C(%)   mg/dl   (95% CI)|\n" + "NTE|5|L|5         97     (76-120) |\n"
-            + "NTE|6|L|6         126    (100-152) |\n" + "NTE|7|L|7         154    (123-185) |\n"
-            + "NTE|8|L|8         183    (147-217) |\n" + "NTE|9|L|9         212    (170-249) |\n"
-            + "NTE|10|L|10        240    (193-282) |\n" + "NTE|11|L|11        269    (217-314) |\n"
-            + "NTE|12|L|12        298    (240-347)  |\n" + "NTE|13|L||\n"
-            + "NTE|14|L|Based on the ADAG formula: eAG = (28.7 X A1c) - 46.7|\n"
-            + "NTE|15|L|with the 95% confidence interval as reported in:|\n"
-            + "NTE|16|L|Nathan DM et al, Diabetes Care, 2008, 31(8);1476|\n"
-            + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||";
-
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7ORU, OPTIONS);
-
-    assertThat(json).isNotBlank();
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> diagnosticReport =
-        e.stream().filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(diagnosticReport).hasSize(1);
-    DiagnosticReport diag = getDiagnosticReport(diagnosticReport.get(0));
-    assertThat(diag.getIssued().toInstant().toString()).contains("2018-09-24T07:29:00Z");
-  }
-
+  // Note: test oru_issue_81 has been removed. It is superceded by testBroadORCPlusOBRFields which specifically tests that 
+  // DiagnosticReport.issued instant comes from OBR.22    
 
   /**
    * In order to generate messageHeader resource, MSH should have MSH.24.2 as this is required
@@ -95,125 +30,40 @@ public class IssueFixTest {
   @Test
   public void message_header_issue_76() throws IOException {
 
-    String hl7message =
-        "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||\r"
-            + "EVN||201209122222\r"
-            + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
-            + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
-            + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r"
-            + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
-            + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
-            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
+    String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||\r"
+        + "EVN||201209122222\r"
+        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+        + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F||||||\r"
+        + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
+        + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    Bundle b = (Bundle) bundleResource;
-
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> messageHeader =
-        e.stream().filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(messageHeader).isEmpty();
+    List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+    List<Resource> messageHeaders = ResourceUtils.getResourceList(e, ResourceType.MessageHeader);
+    assertThat(messageHeaders).isEmpty();
   }
-
-
 
   @Test
   public void vxu_issue_75() {
-    String hl7vxu =
-        "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-            + "PID|1||12345678^^^^MR||Mouse^Mickey^J^III^^^|cat^martha|20060504|M||2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053||^PRN^^^PH^555^5555555|||||||||2186-5^not Hispanic or Latino^CDCREC||N||||||N\n"
-            + "PD1|||||||||||02|N|20170513|||A|20170513|20170513\n"
-            + "NK1|1|cat^martha|MTH^Mother^HL70063|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|^PRN^PH^^^555^5555555\n"
-            + "ORC|RE||IZ-783278^NDA||||||||||||||MIIC^MIIC clinic^HL70362\n"
-            + "RXA|0|1|201501011|20150101|141^Influenza^CVX|1|mL||00^NEW IMMUNIZATIONRECORD^NIP001||^^^MIICSHORTCODE||||ABC1234|20211201|SKB^GlaxoSmithKline^MVX|||CP|A\n"
-            + "OBX|4|CE|31044-1^reaction^LN|4|VXC12^fever of >40.5C within 48 hrs.^CDCPHINVS||||||F\n"
-            + "ORC|RE||IZ-783280^NDA|||||||||||||||MIIC^MIIC clinic^HL70362\n"
-            + "RXA|0|1|20170512||998^No vaccine given^CVX|999||||||||||||||CP|\n"
-            + "OBX|1|CE|30945-0^contraindication^LN|1|M4^Medical exemption: Influenza^NIP||||||F|||20120916  \n"
-    ;
+    String hl7vxu = "MSH|^~\\&|||||201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+        + "ORC|RE||IZ-783278^NDA||||||||||||||MIIC^MIIC clinic^HL70362\n"
+        // Purposely incorrect date in RXA.3 (see below)
+        + "RXA|0|1|201501011|20150101|141^Influenza^CVX|1|mL||00^NEW IMMUNIZATIONRECORD^NIP001||^^^MIICSHORTCODE||||ABC1234|20211201|SKB^GlaxoSmithKline^MVX|||CP|A\n"
+        + "OBX|4|CE|31044-1^reaction^LN|4|||||||F\n"
+        + "ORC|RE||IZ-783280^NDA|||||||||||||||\n"
+        // Purposely correct date in RXA.3 (see below)
+        + "RXA|0|1|20170512||998^No vaccine given^CVX|999||||||||||||||CP|\n"
+        + "OBX|1|CE|30945-0^contraindication^LN|1|M4^Medical exemption: Influenza^NIP||||||F|||20120916  \n";
 
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7vxu, OPTIONS);
-
-    assertThat(json).isNotBlank();
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> immunization =
-        e.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7vxu);
+    List<Resource> immunizations = ResourceUtils.getResourceList(e, ResourceType.Immunization);
     // Since "RXA|0|1|201501011| " RXA.3 has incorrect date, no immunization resource is generated
     // as occurrenceDateTime is required field and is extracted from RXA.3
-    assertThat(immunization).hasSize(1);
+    // But the second RXA.3 is correctly processed
+    assertThat(immunizations).hasSize(1);
 
   }
 
-  private static DiagnosticReport getDiagnosticReport(Resource resource) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = DiagnosticReport.class;
-    return (DiagnosticReport) context.getParser().parseResource(klass, s);
-  }
-
-
-  @Test
-  public void name_issue_92() {
-    String hl7message =
-        "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-            + "PID|1||12345678^^^^MR||Mouse^Mickey^J^III^Mr^^|cat^martha|20060504|M||2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053||^PRN^^^PH^555^5555555|||||||||2186-5^not Hispanic or Latino^CDCREC||N||||||N\n"
-    ;
-
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
-
-    assertThat(json).isNotBlank();
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patients =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    assertThat(patients).hasSize(1);
-    Patient patient = getPatientFromResource(patients.get(0));
-    HumanName name = patient.getNameFirstRep();
-    
-    // Check prefix
-    assertThat(name.hasPrefix()).isTrue();
-    List<StringType> prefixes = name.getPrefix();
-    assertThat(prefixes).hasSize(1);;
-    String prefix = prefixes.get(0).getValueNotNull();
-    assertThat(prefix).isEqualTo("Mr");
-
-    // Check suffix
-    assertThat(name.hasSuffix()).isTrue();
-    List<StringType> suffixes = name.getSuffix();
-    assertThat(suffixes).hasSize(1);;
-    String suffix = suffixes.get(0).getValueNotNull();
-    assertThat(suffix).isEqualTo("III");
-
-  }
-
-  private static Patient getPatientFromResource(Resource resource) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Patient.class;
-    return (Patient) context.getParser().parseResource(klass, s);
-  }
+  // NOTE:  name_issue_92 was superceded by testing in patientNameTest, and is removed.
 
 }

--- a/src/test/java/io/github/linuxforhealth/MedicationFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/MedicationFHIRConverterTest.java
@@ -49,7 +49,7 @@ public class MedicationFHIRConverterTest {
         + "OBX|3|TS|29768-9^DATE VACCINE INFORMATION STATEMENT PUBLISHED^LN|1|20010711||||||F|||20120720101321\r"
         + "OBX|4|TS|29769-7^DATE VACCINE INFORMATION STATEMENT PRESENTED^LN|1|19901207||||||F|||20140701041038\r";
 
-        List<BundleEntryComponent> e =ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e =ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the practitioner from the FHIR bundle.
         List<Resource> practitionerResource = e.stream()

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
@@ -47,7 +47,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I|||||||||||||||||1400|||||||||||||||||||||||||\r"
                 + "DG1|1|ICD10|C56.9^Ovarian Cancer^I10|Test|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|V45|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // --- CONDITION TESTS ---
 
@@ -178,7 +178,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PID||||||||||||||||||||||||||||||\r"
                 + "DG1|1|ICD10|B45678|Broken Arm|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|one^https://terminology.hl7.org/CodeSystem/two^three^https://terminology.hl7.org/CodeSystem/four|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -230,7 +230,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "DG1|3|D3|R06.02^Shortness of breath^ICD-10^^^|Shortness of breath||A\r"
                 + "DG1|7|D8|J45.909^Unspecified asthma, uncomplicated^ICD-10^^^|Unspecified asthma, uncomplicated||A";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -305,7 +305,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "DG1|6|D7|I05.9^Mitral valve disorder in childbirth^ICD-10^^^|Mitral valve disorder in childbirth||A|||||||||8|\r"
                 + "DG1|7|D8|J45.909^Unspecified asthma, uncomplicated^ICD-10^^^|Unspecified asthma, uncomplicated||A|||||||||8|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the conditions from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -375,7 +375,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I|||||||||||||||||1492|||||||||||||||||||||||||\r"
                 + "DG1|1|ICD-10-CM|M54.5^Low back pain^ICD-10-CM|Low back pain|20210407191342|A\r";
         
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the conditions from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -406,7 +406,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|20180310074000||||confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status|remission^Remission^http://terminology.hl7.org/CodeSystem/condition-clinical|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
         
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -487,7 +487,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|20180310074000||||confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status|remission^Remission^http://terminology.hl7.org/CodeSystem/condition-clinical|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -532,7 +532,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||BAD^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status|INVALID^Remission^http://terminology.hl7.org/CodeSystem/condition-clinical|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -562,7 +562,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PID||||||||||||||||||||||||||||||\r" + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||confirmed|remission|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -608,7 +608,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||C^Confirmed^Confirmation Status List||textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -637,7 +637,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||confirmed^Confirmed^Confirmation Status List||textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -672,7 +672,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||BAD|INVALID|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -700,7 +700,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|20180310074000||||confirmed^Confirmed^BADCLINCALSTATUSSYSTEM|remission^Remission^BADVERIFICATIONSTATUSSYSTEM|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -758,7 +758,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PID||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20210101000000|G47.31^Primary central sleep apnea^ICD-10-CM|28827016|||20210101000000|20210101000000|||||confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status||20210101000000|20210101000000\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -791,7 +791,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PRB|AD|20170110074000|N39.0^Urinary Tract Infection^I9|53957|E2|1|20090907175347|20150907175347||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|C56.9^Ovarian Cancer^I10|53958|E3|2|20110907175347|20160907175347||||||||||||||||||\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -812,7 +812,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PID||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||||20180310074000|20180310074000||1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()
@@ -837,7 +837,7 @@ public class HL7ConditionFHIRConversionTest {
                 + "PID||||||||||||||||||||||||||||||\r"
                 + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||||20180310074000||textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
 
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = e.stream()

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7MergeFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7MergeFHIRConversionTest.java
@@ -38,7 +38,7 @@ public class HL7MergeFHIRConversionTest {
                 + "MRG|456||||||\r";
 
         // Convert hl7 message
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the patient resources in the FHIR bundle.
         List<Resource> patientResources = e.stream()
@@ -190,7 +190,7 @@ public class HL7MergeFHIRConversionTest {
                 + "MRG|MR2^^^XYZ\r";
 
         // Convert hl7 message
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the patient resources in the FHIR bundle.
         List<Resource> patientResources = e.stream()
@@ -289,7 +289,7 @@ public class HL7MergeFHIRConversionTest {
                 + "MRG|MR4^^^XYZ^MR||\r";
 
         // Convert hl7 message
-        List<BundleEntryComponent> e = ResourceUtils.createHl7Segment(hl7message);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the patient resources in the FHIR bundle.
         List<Resource> patientResources = e.stream()

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -6,9 +6,15 @@
 package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import java.util.List;
-import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Condition.ConditionEvidenceComponent;
+import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -19,59 +25,167 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class Hl7NoteFHIRConverterTest {
 
-  // Tests NTE creation for OBX (Observations) and ORC/OBRs (ServiceRequests)
-  @Test
-  public void testNoteCreationMutiple() {
-    String hl7ORU = "MSH|^~\\&|||||20180924152907||ORU^R01^ORU_R01|213|T|2.3.1|||||||||||\n"
-        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-        // TODO: Future work, handle NTE's on PID
-        // "NTE|1|O|TEST NOTE DD line 1|\n" + "NTE|2|O|TEST NOTE DD line 2 |\n" + "NTE|3|O|TEST NOTE D line 3|\n"  
-        + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
-        + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||||||||||||||||||||||||\n"
-        + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||\n"
-        + "NTE|1|O|TEST ORC/OBR NOTE AA line 1|\n" + "NTE|2|O|TEST NOTE AA line 2|\n" + "NTE|3|O|TEST NOTE AA line 3|\n"
-        + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
-        + "NTE|1|L|TEST OBXa NOTE BB line 1|\n" + "NTE|2|L|TEST NOTE BB line 2|\n" + "NTE|3|L|TEST NOTE BB line 3|\n"
-        + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
-        + "NTE|1|L|TEST OBXb NOTE CC line 1|\n" + "NTE|2|L|TEST NOTE CC line 2|\n" + "NTE|3|L|TEST NOTE CC line 3|\n"
-        + "NTE|4|L|TEST NOTE CC line 4|\n"
-        + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||";
+    // Tests NTE creation for OBX (Observations) and ORC/OBRs (ServiceRequests)
+    @Test
+    public void testNoteCreationMutipleORU() {
+        String hl7ORU = "MSH|^~\\&|||||20180924152907||ORU^R01^ORU_R01|213|T|2.3.1|||||||||||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                // TODO: Future work, handle NTE's on PID
+                // "NTE|1|O|TEST NOTE DD line 1|\n" + "NTE|2|O|TEST NOTE DD line 2 |\n" + "NTE|3|O|TEST NOTE D line 3|\n"  
+                + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
+                + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||||||||||||||||||||||||\n"
+                + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||\n"
+                + "NTE|1|O|TEST ORC/OBR NOTE AA line 1|\n" + "NTE|2|O|TEST NOTE AA line 2|\n"
+                + "NTE|3|O|TEST NOTE AA line 3|\n"
+                + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
+                + "NTE|1|L|TEST OBXa NOTE BB line 1|\n" + "NTE|2|L|TEST NOTE BB line 2|\n"
+                + "NTE|3|L|TEST NOTE BB line 3|\n"
+                + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
+                + "NTE|1|L|TEST OBXb NOTE CC line 1|\n" + "NTE|2|L|TEST NOTE CC line 2|\n"
+                + "NTE|3|L|TEST NOTE CC line 3|\n"
+                + "NTE|4|L|TEST NOTE CC line 4|\n"
+                + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||";
 
-    List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7ORU);
-    List<Resource> diagnosticReports = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
-    assertThat(diagnosticReports).hasSize(1);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7ORU);
+        List<Resource> diagnosticReports = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
+        assertThat(diagnosticReports).hasSize(1);
 
-    // Two observations.  One has GLYCOHEMOGLOBIN and notes BB, One has GLUCOSE and notes CC
-    List<Resource> observations = ResourceUtils.getResourceList(e, ResourceType.Observation);
-    assertThat(observations).hasSize(2);
-    Observation ObsGlucose = ResourceUtils.getResourceObservation(observations.get(0), ResourceUtils.context);
-    Observation ObsHemoglobin = ResourceUtils.getResourceObservation(observations.get(1), ResourceUtils.context);
-    // Figure out which is first and reassign if needed for testing
-    if (ObsGlucose.getCode().getText() != "MEAN BLOOD GLUCOSE") {
-      Observation temp = ObsGlucose;
-      ObsGlucose = ObsHemoglobin;
-      ObsHemoglobin = temp;
+        // One ServiceRequest contains NTE for ORC/OBR
+        List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
+        assertThat(serviceRequests).hasSize(1);
+        ServiceRequest serviceRequest = ResourceUtils.getResourceServiceRequest(serviceRequests.get(0),
+                ResourceUtils.context);
+        assertThat(serviceRequest.hasNote()).isTrue();
+        assertThat(serviceRequest.getNote()).hasSize(1);
+        assertThat(serviceRequest.getNote().get(0).getText())
+                .isEqualTo("TEST ORC/OBR NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+
+        // Two observations.  One has GLYCOHEMOGLOBIN and notes BB, One has GLUCOSE and notes CC
+        List<Resource> observations = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observations).hasSize(2);
+        Observation ObsGlucose = ResourceUtils.getResourceObservation(observations.get(0), ResourceUtils.context);
+        Observation ObsHemoglobin = ResourceUtils.getResourceObservation(observations.get(1), ResourceUtils.context);
+        // Figure out which is first and reassign if needed for testing
+        if (ObsGlucose.getCode().getText() != "MEAN BLOOD GLUCOSE") {
+            Observation temp = ObsGlucose;
+            ObsGlucose = ObsHemoglobin;
+            ObsHemoglobin = temp;
+        }
+        assertThat(ObsGlucose.hasNote()).isTrue();
+        assertThat(ObsGlucose.getNote()).hasSize(1);
+        // Processing adds "  \n" two spaces and a line feed
+        // Note on test strings. Must double back-slashes to create single backslash in string.
+        assertThat(ObsGlucose.getNote().get(0).getText()).isEqualTo(
+                "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\nTEST NOTE CC line 4  \\n");
+        assertThat(ObsHemoglobin.hasNote()).isTrue();
+        assertThat(ObsHemoglobin.getNote()).hasSize(1);
+        assertThat(ObsHemoglobin.getNote().get(0).getText())
+                .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+
     }
-    assertThat(ObsGlucose.hasNote()).isTrue();
-    assertThat(ObsGlucose.getNote()).hasSize(1);
-    // Processing adds "  \n" two spaces and a line feed
-    // Note on test strings. Must double back-slashes to create single backslash in string.
-    assertThat(ObsGlucose.getNote().get(0).getText()).isEqualTo(
-        "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\nTEST NOTE CC line 4  \\n");
-    assertThat(ObsHemoglobin.hasNote()).isTrue();
-    assertThat(ObsHemoglobin.getNote()).hasSize(1);
-    assertThat(ObsHemoglobin.getNote().get(0).getText())
-        .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
 
-    // One ServiceRequest contains NTE for ORC/OBR
-    List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
-    assertThat(serviceRequests).hasSize(1);
-    ServiceRequest serviceRequest = ResourceUtils.getResourceServiceRequest(serviceRequests.get(0),
-        ResourceUtils.context);
-    assertThat(serviceRequest.hasNote()).isTrue();
-    assertThat(serviceRequest.getNote()).hasSize(1);
-    assertThat(serviceRequest.getNote().get(0).getText())
-        .isEqualTo("TEST ORC/OBR NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
-  }
+    // Test that multiple problems (PRB) each with multiple notes (NTE) are associated with the correct NTE / PRB 
+    // and that there is no "bleed"
+    @Test
+    public void testNoteCreationMutiplePPR()
+            throws IOException {
+        String message = "PPR^PC1";
+        String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message
+                + "|1|P^I|2.6||||||ASCII||\n"
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\n"
+                + "PV1||I|||||||||||||||||1400|||||||||||||||||||||||||199501102300\n"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n"
+                + "NTE|1|O|TEST PRBa NOTE AA line 1|\n" + "NTE|2|O|TEST NOTE AA line 2|\n"
+                + "NTE|3|O|TEST NOTE AA line 3|\n"
+                + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
+                + "NTE|1|L|TEST OBXb NOTE BB line 1|\n" + "NTE|2|L|TEST NOTE BB line 2|\n"
+                + "NTE|3|L|TEST NOTE BB line 3|\n"
+                + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
+                + "NTE|1|L|TEST OBXc NOTE CC line 1|\n" + "NTE|2|L|TEST NOTE CC line 2|\n"
+                + "NTE|3|L|TEST NOTE CC line 3|\n"
+                + "PRB|AD|200603150625|I47.2^Ventricular tachycardia^ICD-10-CM|53692||2||200603150625\n"
+                + "NTE|1|O|TEST PRBd NOTE DD line 1|\n" + "NTE|2|O|TEST NOTE DD line 2|\n"
+                + "NTE|3|O|TEST NOTE DD line 3|\n"
+                + "OBX|1|NM|8595^BP Mean|1|88|MM HG|||||F|||20180520230000|||\n"
+                + "NTE|1|L|TEST OBXe NOTE EE line 1|\n" + "NTE|2|L|TEST NOTE EE line 2|\n"
+                + "NTE|3|L|TEST NOTE EE line 3|\n"
+                + "OBX|2|NM|7302^Resp Rate|1|19||||||F|||20180520230000|||\n"
+                + "NTE|1|L|TEST OBXf NOTE FF line 1|\n" + "NTE|2|L|TEST NOTE FF line 2|\n"
+                + "NTE|3|L|TEST NOTE FF line 3|\n";
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+        List<Resource> patients = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patients).hasSize(1);
+
+        // Two Conditions from two PRBs. One has "... stenosis" and notes AA, One has "... Tachycardia" and notes DD
+        List<Resource> conditions = ResourceUtils.getResourceList(e, ResourceType.Condition);
+        assertThat(conditions).hasSize(2);
+        Condition condStenosis = ResourceUtils.getResourceCondition(conditions.get(0),
+                ResourceUtils.context);
+        Condition condTachy = ResourceUtils.getResourceCondition(conditions.get(1),
+                ResourceUtils.context);
+        // Figure out which is first and reassign if needed for testing        
+        if (!condStenosis.getCode().getCodingFirstRep().getCode().contains("aortic stenosis")) {
+            Condition temp = condStenosis;
+            condStenosis = condTachy;
+            condTachy = temp;
+        }
+        // Test 
+        assertThat(condStenosis.hasNote()).isTrue();
+        assertThat(condStenosis.getNote()).hasSize(1);
+        assertThat(condStenosis.getNote().get(0).getText())
+                .isEqualTo("TEST PRBa NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+        assertThat(condTachy.hasNote()).isTrue();
+        assertThat(condTachy.getNote()).hasSize(1);
+        assertThat(condTachy.getNote().get(0).getText())
+                .isEqualTo("TEST PRBd NOTE DD line 1  \\nTEST NOTE DD line 2  \\nTEST NOTE DD line 3  \\n");        
+
+        // Four observations.  Two associated with the first problem and two with the second
+        // This map tells us what Annotation text is associated with an Observation code
+        Map<String, String> matchObsCodeToNotes = new HashMap<>();
+        matchObsCodeToNotes.put("17985", "TEST OBXb NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+        matchObsCodeToNotes.put("17853", "TEST OBXc NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\n");
+        matchObsCodeToNotes.put("8595", "TEST OBXe NOTE EE line 1  \\nTEST NOTE EE line 2  \\nTEST NOTE EE line 3  \\n");
+        matchObsCodeToNotes.put("7302", "TEST OBXf NOTE FF line 1  \\nTEST NOTE FF line 2  \\nTEST NOTE FF line 3  \\n");
+
+        // This map tells us what Parent should be associated with an Observation code
+        Map<String, String> matchObsCodeToParent = new HashMap<>();
+        matchObsCodeToParent.put("17985", "aortic stenosis");
+        matchObsCodeToParent.put("17853", "aortic stenosis");
+        matchObsCodeToParent.put("8595", "I47.2");
+        matchObsCodeToParent.put("7302", "I47.2");
+
+        List<Resource> observations = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observations).hasSize(4);
+        int observationsVerified = 0;
+        // Dig through the Conditions, find the referenced Observations, find the matching Observation resource
+        // and ensure it has the expected Notes and referenced parent.
+        // For the list of Conditions
+        for(int cDex=0; cDex < conditions.size(); cDex++) {
+            // Get the list of Observation references
+            Condition cond = ResourceUtils.getResourceCondition(conditions.get(cDex), ResourceUtils.context);
+            List<ConditionEvidenceComponent> evidences = cond.getEvidence();
+            for(int eDex=0; eDex < evidences.size(); eDex++) {
+                // Get the evidence Observation reference
+                String obsReferenceId = evidences.get(eDex).getDetailFirstRep().getReference();
+                // Find the referenced observation
+                for(int oDex=0; oDex < observations.size(); oDex++) {
+                    // If the Id's match
+                    if (obsReferenceId.contains(observations.get(oDex).getId())) {
+                        // Check the contents and the parent
+                        Observation obs = ResourceUtils.getResourceObservation(observations.get(oDex),ResourceUtils.context);
+                        String code = obs.getCode().getCodingFirstRep().getCode().toString();
+                        // The Annotation text should match the mapped text for this key
+                        assertThat(obs.getNoteFirstRep().getText()).hasToString(matchObsCodeToNotes.get(code));
+                        // The parent Condition code.coding.code should match the expected mapped code for this key
+                        assertThat(cond.getCode().getCodingFirstRep().getCode()).hasToString(matchObsCodeToParent.get(code));
+                        observationsVerified++;
+                        break;
+                    }
+                }
+            }    
+        }
+        assertThat(observationsVerified).isEqualTo(4);
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.segments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.junit.jupiter.api.Test;
+
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
+public class Hl7NoteFHIRConverterTest {
+
+  // Tests NTE creation for OBX (Observations) and ORC/OBRs (ServiceRequests)
+  @Test
+  public void testNoteCreationMutiple() {
+    String hl7ORU = "MSH|^~\\&|||||20180924152907||ORU^R01^ORU_R01|213|T|2.3.1|||||||||||\n"
+        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+        // TODO: Future work, handle NTE's on PID
+        // "NTE|1|O|TEST NOTE DD line 1|\n" + "NTE|2|O|TEST NOTE DD line 2 |\n" + "NTE|3|O|TEST NOTE D line 3|\n"  
+        + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||20180924152707|\n"
+        + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||||||||||||||||||||||||\n"
+        + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||\n"
+        + "NTE|1|O|TEST ORC/OBR NOTE AA line 1|\n" + "NTE|2|O|TEST NOTE AA line 2|\n" + "NTE|3|O|TEST NOTE AA line 3|\n"
+        + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
+        + "NTE|1|L|TEST OBXa NOTE BB line 1|\n" + "NTE|2|L|TEST NOTE BB line 2|\n" + "NTE|3|L|TEST NOTE BB line 3|\n"
+        + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
+        + "NTE|1|L|TEST OBXb NOTE CC line 1|\n" + "NTE|2|L|TEST NOTE CC line 2|\n" + "NTE|3|L|TEST NOTE CC line 3|\n"
+        + "NTE|4|L|TEST NOTE CC line 4|\n"
+        + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||";
+
+    List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7ORU);
+    List<Resource> diagnosticReports = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
+    assertThat(diagnosticReports).hasSize(1);
+
+    // Two observations.  One has GLYCOHEMOGLOBIN and notes BB, One has GLUCOSE and notes CC
+    List<Resource> observations = ResourceUtils.getResourceList(e, ResourceType.Observation);
+    assertThat(observations).hasSize(2);
+    Observation ObsGlucose = ResourceUtils.getResourceObservation(observations.get(0), ResourceUtils.context);
+    Observation ObsHemoglobin = ResourceUtils.getResourceObservation(observations.get(1), ResourceUtils.context);
+    // Figure out which is first and reassign if needed for testing
+    if (ObsGlucose.getCode().getText() != "MEAN BLOOD GLUCOSE") {
+      Observation temp = ObsGlucose;
+      ObsGlucose = ObsHemoglobin;
+      ObsHemoglobin = temp;
+    }
+    assertThat(ObsGlucose.hasNote()).isTrue();
+    assertThat(ObsGlucose.getNote()).hasSize(1);
+    // Processing adds "  \n" two spaces and a line feed
+    // Note on test strings. Must double back-slashes to create single backslash in string.
+    assertThat(ObsGlucose.getNote().get(0).getText()).isEqualTo(
+        "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\nTEST NOTE CC line 4  \\n");
+    assertThat(ObsHemoglobin.hasNote()).isTrue();
+    assertThat(ObsHemoglobin.getNote()).hasSize(1);
+    assertThat(ObsHemoglobin.getNote().get(0).getText())
+        .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+
+    // One ServiceRequest contains NTE for ORC/OBR
+    List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
+    assertThat(serviceRequests).hasSize(1);
+    ServiceRequest serviceRequest = ResourceUtils.getResourceServiceRequest(serviceRequests.get(0),
+        ResourceUtils.context);
+    assertThat(serviceRequest.hasNote()).isTrue();
+    assertThat(serviceRequest.getNote()).hasSize(1);
+    assertThat(serviceRequest.getNote().get(0).getText())
+        .isEqualTo("TEST ORC/OBR NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+  }
+
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -244,21 +244,25 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patient_name_test() {
+    public void patientNameTest() {
         String patientHasMiddleName = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
-                +
-                "PID|1||PA123456^^^MYEMR^MR||JONES^GEORGE^M^JR^^^B|MILLER^MARTHA^G^^^^M|20140227|M||2106-3^WHITE^CDCREC|1234 W FIRST ST^^BEVERLY HILLS^CA^90210^^H||^PRN^PH^^^555^5555555||ENG^English^HL70296|||||||2186-5^ not Hispanic or Latino^CDCREC||Y|2\r";
+                // PID 5 fields (name) are extracted and tested
+                + "PID|1||PA123456^^^MYEMR^MR||JONES^GEORGE^Q^III^MR^^B||||||||||||||||||||\r";
 
         Patient patientObjUsualName = PatientUtils.createPatientFromHl7Segment(patientHasMiddleName);
 
         java.util.List<org.hl7.fhir.r4.model.HumanName> name = patientObjUsualName.getName();
-        List givenName = name.get(0).getGiven();
-        List<StringType> suffix = name.get(0).getSuffix();
+        List<StringType> givenName = name.get(0).getGiven();
+        List<StringType> suffixes = name.get(0).getSuffix();
+        assertThat(suffixes).hasSize(1);
+        List<StringType> prefixes = name.get(0).getPrefix();
+        assertThat(prefixes).hasSize(1);
         String fullName = name.get(0).getText();
-        assertThat(givenName.get(0).toString()).isEqualTo("GEORGE");
-        assertThat(givenName.get(1).toString()).isEqualTo("M");
-        assertThat(suffix.get(0).toString()).isEqualTo("JR");
-        assertThat(fullName).isEqualTo("GEORGE M JONES JR");
+        assertThat(prefixes.get(0).toString()).hasToString("MR");
+        assertThat(givenName.get(0).toString()).hasToString("GEORGE");
+        assertThat(givenName.get(1).toString()).hasToString("Q");
+        assertThat(suffixes.get(0).toString()).hasToString("III");
+        assertThat(fullName).isEqualTo("MR GEORGE Q JONES III");
 
     }
 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -23,12 +23,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResourceUtils {
 
-  private static FHIRContext context = new FHIRContext();
+  public static FHIRContext context = new FHIRContext();
   private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtils.class);
   private static final ConverterOptions OPTIONS =
     new Builder().withValidateResource().withPrettyPrint().build();
 
-  public static List<BundleEntryComponent> createHl7Segment(String inputSegment){
+  public static List<BundleEntryComponent> createFHIRBundleFromHL7MessageReturnEntryList(String inputSegment){
     HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
     String json = ftv.convert(inputSegment, OPTIONS);
     assertThat(json).isNotBlank();
@@ -37,9 +37,7 @@ public class ResourceUtils {
     IBaseResource bundleResource = context.getParser().parseResource(json);
     assertThat(bundleResource).isNotNull();
     Bundle b = (Bundle) bundleResource;
-
     List<BundleEntryComponent> e = b.getEntry();
-
     return e;
   }
 
@@ -56,7 +54,7 @@ public class ResourceUtils {
   }
 
   public static AllergyIntolerance getAllergyResource(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> allergy =
             resource.stream().filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
@@ -68,7 +66,7 @@ public class ResourceUtils {
   }
 
   public static Condition getCondition(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> condition =
             resource.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
@@ -81,7 +79,7 @@ public class ResourceUtils {
   }
 
   public static DiagnosticReport getDiagnosticReport(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> diagnosticReport =
             resource.stream().filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
@@ -94,7 +92,7 @@ public class ResourceUtils {
   }
 
   public static DocumentReference getDocumentReference(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> documentReference =
             resource.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
@@ -107,7 +105,7 @@ public class ResourceUtils {
   }
 
   public static Encounter getEncounter(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> encounter =
             resource.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
@@ -120,7 +118,7 @@ public class ResourceUtils {
   }
 
   public static Immunization getImmunization(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> immunization =
             resource.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
@@ -133,7 +131,7 @@ public class ResourceUtils {
   }
 
   public static Observation getObservation(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> observation =
             resource.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
@@ -146,7 +144,7 @@ public class ResourceUtils {
   }
 
   public static Procedure getProcedure(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> procedure =
             resource.stream().filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
@@ -159,7 +157,7 @@ public class ResourceUtils {
   }
 
   public static ServiceRequest getServiceRequest(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> serviceRequest =
             resource.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
@@ -172,7 +170,7 @@ public class ResourceUtils {
   }
 
   public static Patient getPatient(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> patient =
             resource.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
@@ -186,7 +184,7 @@ public class ResourceUtils {
   }
 
   public static MedicationRequest getMedicationRequest(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> medicationRequest =
             resource.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
@@ -199,7 +197,7 @@ public class ResourceUtils {
   }
 
   public static MedicationAdministration getMedicationAdministration(String inputSegment) {
-    List<BundleEntryComponent> resource = createHl7Segment(inputSegment);
+    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
     List<Resource> medicationAdministration =
             resource.stream().filter(v -> ResourceType.MedicationAdministration == v.getResource().getResourceType())
@@ -296,6 +294,12 @@ public class ResourceUtils {
     String s = context.getParser().encodeResourceToString(resource);
     Class<? extends IBaseResource> klass = Condition.class;
     return (Condition) context.getParser().parseResource(klass, s);
+  }
+
+  public static Observation getResourceObservation(Resource resource, FHIRContext context) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = Observation.class;
+    return (Observation) context.getParser().parseResource(klass, s);
   }
 
   public static List<Resource> getResourceList(List<BundleEntryComponent> e, ResourceType resourceType){


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Corrects formatting for NTE's.  Now groups sequential NTE's into one Annotation text, separated by "   \n" (two spaces, line feed).
Removes incorrect creation of NTE for Specimen
Adds Annotation to Observations when NTE's follow OBX's. 
Adds Annotation to ServiceRequest when NTE's follow ORC/ORB sets.
Adds Annotation to Condition when NTE's follow PRB's

Also added common bundle creation code, renamed for better understanding.
Also removed two tests that were superseded by other more complete tests.   Documented.
Added tests for multiple NTE's within multiple OBX's within multiple PRB's, which cross checks references in each.

Initial drop for this work.  Foundation for next steps.