### PR TITLE
Add missing PPR_PC1 Order Observations

### DIFF
--- a/src/main/resources/hl7/message/PPR_PC1.yml
+++ b/src/main/resources/hl7/message/PPR_PC1.yml
@@ -58,49 +58,49 @@ resources:
       - .NTE
 
   - resourceName: ServiceRequest
-    segment: .ORDER.ORC
-    group: PROBLEM
+    segment: .ORC
+    group: PROBLEM.ORDER
     resourcePath: resource/ServiceRequest
     repeats: true
     isReferenced: true
     additionalSegments:
-      - .ORDER.ORDER_DETAIL.OBR
-      - .ORDER.ORDER_DETAIL.ORDER_OBSERVATION.OBX
+      - .ORDER_DETAIL.OBR
+      - .ORDER_DETAIL.ORDER_OBSERVATION.OBX
       - PATIENT_VISIT.PV1
       - MSH
       - PID
 
   # This OBX is for the Order Observation
   - resourceName: Observation
-    segment: .ORDER.ORDER_DETAIL.ORDER_OBSERVATION.OBX
-    group: PROBLEM
+    segment: .ORDER_DETAIL.ORDER_OBSERVATION.OBX
+    group: PROBLEM.ORDER
     resourcePath: resource/Observation
     repeats: true
     isReferenced: true
     additionalSegments:
-      - .ORDER.ORC
-      - .ORDER.ORDER_DETAIL.OBR
+      - .ORC
+      - .ORDER_DETAIL.OBR
       - MSH
-      - .ORDER.ORDER_DETAIL.ORDER_OBSERVATION.NTE    
+      - .ORDER_DETAIL.ORDER_OBSERVATION.NTE    
 
   - resourceName: MedicationRequest
-    segment: .ORDER.ORDER_DETAIL.RXO
-    group: PROBLEM
+    segment: .ORDER_DETAIL.RXO
+    group: PROBLEM.ORDER
     resourcePath: resource/MedicationRequest
     repeats: true
     additionalSegments:
       - MSH
       - PID
-      - .ORDER.ORC
+      - .ORC
       - PATIENT_VISIT.PV1
 
   - resourceName: DocumentReference
-    segment: .ORDER.ORC
-    group: PROBLEM
+    segment: .ORC
+    group: PROBLEM.ORDER
     resourcePath: resource/DocumentReference
     additionalSegments:
-      - .ORDER.ORDER_DETAIL.OBR
-      - .ORDER.ORDER_DETAIL.ORDER_OBSERVATION.OBX
+      - .ORDER_DETAIL.OBR
+      - .ORDER_DETAIL.ORDER_OBSERVATION.OBX
       - PATIENT_VISIT.PV1
       - MSH
       - PID

--- a/src/main/resources/hl7/message/PPR_PC1.yml
+++ b/src/main/resources/hl7/message/PPR_PC1.yml
@@ -33,6 +33,7 @@ resources:
             - PID
             - PROBLEM.PROBLEM_OBSERVATION.OBX
     
+  # This OBX is for the Problem Observation
   - resourceName: Observation
     segment: .PROBLEM_OBSERVATION.OBX
     group: PROBLEM
@@ -68,6 +69,19 @@ resources:
       - PATIENT_VISIT.PV1
       - MSH
       - PID
+
+  # This OBX is for the Order Observation
+  - resourceName: Observation
+    segment: .ORDER.ORDER_DETAIL.ORDER_OBSERVATION.OBX
+    group: PROBLEM
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - .ORDER.ORC
+      - .ORDER.ORDER_DETAIL.OBR
+      - MSH
+      - .ORDER.ORDER_DETAIL.ORDER_OBSERVATION.NTE    
 
   - resourceName: MedicationRequest
     segment: .ORDER.ORDER_DETAIL.RXO

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
@@ -7,35 +7,23 @@ package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
-import java.util.Base64;
+
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.DocumentReference;
+
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.Bundle.BundleType;
+
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.junit.jupiter.api.Disabled;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.github.linuxforhealth.fhir.FHIRContext;
-import io.github.linuxforhealth.hl7.ConverterOptions;
-import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
-import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
+
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Hl7PPRMessageTest {
-    private static FHIRContext context = new FHIRContext();
-    private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
-    private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
-        .withValidateResource().withPrettyPrint().build();
-    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PPRMessageTest.class);
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
@@ -45,26 +33,13 @@ public class Hl7PPRMessageTest {
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
             + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
         // Confirm that no extra resources are created
@@ -83,36 +58,19 @@ public class Hl7PPRMessageTest {
             + "OBX|1|ST|100||First Problem Observation|||||||X\r"
             + "OBX|2|ST|101||Second Problem Observation|||||||X\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionResource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionResource).hasSize(1);
 
-        List<Resource> observationResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(observationResource).hasSize(2);
 
         // Confirm that no extra resources are created
@@ -131,36 +89,19 @@ public class Hl7PPRMessageTest {
             + "OBX|1|TX|||Report line 1|||||||X\r"
             + "OBX|2|TX|||Report line 2|||||||X\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionResource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionResource).hasSize(1);
 
-        List<Resource> docRefResource =
-        e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
         assertThat(docRefResource).hasSize(0); //TODO: Expect this to be 1 when card #855 is completed
 
         // Confirm that no extra resources are created
@@ -178,36 +119,19 @@ public class Hl7PPRMessageTest {
             + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
             + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceRequestResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequestResource).hasSize(1);
 
         // Confirm that no extra resources are created
@@ -231,31 +155,16 @@ public class Hl7PPRMessageTest {
             // start 3rd PROBLEM group, with no ORDER group
             + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(3);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceRequestResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequestResource).hasSize(3);
 
         // Confirm that no extra resources are created
@@ -266,7 +175,7 @@ public class Hl7PPRMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
     public void test_ppr_pc1_with_VISIT_and_PROBLEM_with_ORDER_group_with_OBXnonTX(String message) throws IOException {
-        String hl7message =
+        String hl7message = 
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
             + "PV1||I|||||||||||||||||1400|||||||||||||||||||||||||199501102300\r"
@@ -279,45 +188,30 @@ public class Hl7PPRMessageTest {
             + "OBX|2|ST|100||An order Observation|||||||X\n"
             ;
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(serviceRequestResource).hasSize(1);
+        List<Resource> serviceRequestResources = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
+        assertThat(serviceRequestResources).hasSize(1);
 
-        List<Resource> observationResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(observationResource).hasSize(0); //TODO: This should be 2, when card 849 is completed
+        // TODO: This should work when card 849 is completed
+        // List<Resource> documentReferences = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
+        // assertThat(documentReferences).isEmpty(); 
+
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observationResource).hasSize(2); 
         
         // Confirm that no extra resources are created
-        assertThat(e.size()).isEqualTo(5); //TODO: This should be 6 when the Observations are created correctly and the DocRef is removed in card 849
+        assertThat(e.size()).isEqualTo(7); //TODO: This should be 6 when the DocRef is removed in card 849
     }
 
     @ParameterizedTest
@@ -339,46 +233,25 @@ public class Hl7PPRMessageTest {
             + "OBX|2|TX|12345||Second line||||||F||||||\r"
             ;
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceRequestResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequestResource).hasSize(1);
 
-        List<Resource> medRequestResource =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medRequestResource).hasSize(1);
         
-        List<Resource> docRefResource =
-        e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
         assertThat(docRefResource).hasSize(1);
 
         // Confirm that no extra resources are created
@@ -410,46 +283,25 @@ public class Hl7PPRMessageTest {
             + "OBX|2|TX|12345||2nd group - Second line||||||F||||||\r"
             ;
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceRequestResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequestResource).hasSize(2);
 
-        List<Resource> docRefResource =
-        e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
         assertThat(docRefResource).hasSize(1); //TODO: This should be 2 when card 859 is completed
 
-        List<Resource> medReqResource =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medReqResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medReqResource).hasSize(1);
 
         // Confirm that no extra resources are created
@@ -481,21 +333,10 @@ public class Hl7PPRMessageTest {
             + "OBX|2|ST|102||2nd group - Second Order Observation|||||||X\r"
             ;
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource =
@@ -503,28 +344,20 @@ public class Hl7PPRMessageTest {
         .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceRequestResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequestResource).hasSize(2);
 
-        List<Resource> observationResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(observationResource).hasSize(0); //TODO: This should be 4 when card 849 is completed
-
-        List<Resource> medReqResource =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observationResource).hasSize(4); 
+    
+        List<Resource> medReqResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medReqResource).hasSize(1);
 
         // Confirm that no extra resources are created
-        assertThat(e.size()).isEqualTo(7); //TODO: This should be 10 when card 849 is completed which will remove the unwanted docref and add the 4 observations
+        assertThat(e.size()).isEqualTo(11);  //TODO: This should be 10 when card 849 is completed which will remove the unwanted docref 
     }
 
     @ParameterizedTest
@@ -540,7 +373,7 @@ public class Hl7PPRMessageTest {
             // + "NTE|2|P|Problem Comments Two\r"
 
                 // 1st PROBLEM_OBSERVATION group - Observation
-                + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r" 
+                + "OBX|1|NM|111^TotalProtein||7.1|gm/dl|5.9-8.4||||F\r" 
                 // + "NTE|1|P|First Observation Comments One\r"
                 // + "NTE|2|P|First Observation Comments Two\r"
             
@@ -553,9 +386,9 @@ public class Hl7PPRMessageTest {
                 //+ "NTE|1|P|Order Comments One\r"
                 //+ "NTE|2|P|Order Comments Two\r"
                 //+ "NTE|3|P|Order Comments Three\r"
-                    + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r"
+                    + "OBX|1|NM|111^TotalProtein||7.2|gm/dl|5.9-8.4||||F\r"
                     //+ "NTE|1|P|Observation Comments\r"
-                    + "OBX|2|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r"
+                    + "OBX|2|NM|111^TotalProtein||7.3|gm/dl|5.9-8.4||||F\r"
                     //+ "NTE|1|P|Observation Comments\r"
             
                 //2nd ORDER group - ServReq, MedReq, DocRef
@@ -567,54 +400,31 @@ public class Hl7PPRMessageTest {
                     + "OBX|2|TX|12345||Second line||||||F||||||\r"
             ;
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Check for the expected resources
-        List<Resource> patientResource =
-        e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource =
-        e.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> conditionresource =
-        e.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1);
 
-        List<Resource> serviceRequestResource =
-        e.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceRequestResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequestResource).hasSize(2);
 
-        List<Resource> observationResource =
-        e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(observationResource).hasSize(2); //TODO: Should be 4 when card 849 is completed
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observationResource).hasSize(4);
         
-        List<Resource> medReqResource =
-        e.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medReqResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medReqResource).hasSize(1);
 
-        List<Resource> docRefResource =
-        e.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
         assertThat(docRefResource).hasSize(1);
 
         // Confirm that no extra resources are created
-        assertThat(e.size()).isEqualTo(9); //TODO: Should be 11 when card 849 is completed
+        assertThat(e.size()).isEqualTo(11); 
     }
 }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This solves the problem of missing Observations for PPR_PC1 Order OBX's.
It does not yet solve the issue of the unneeded DocumentationReference.
Hl7PPRMessageTest has been updated for the expected counts.  Comments are also updated to match current capability.

Used opportunity to refactor and streamline Hl7PPRMessageTest using common ResourceUtils methods.  Sorry for the noise.