### PR TITLE
Message hardening

### DIFF
--- a/src/main/resources/hl7/message/ADT_A08.yml
+++ b/src/main/resources/hl7/message/ADT_A08.yml
@@ -12,7 +12,7 @@ resources:
       repeats: false
       isReferenced: false
       additionalSegments: 
-             - EVN
+        - EVN
    
     - resourceName: Patient
       segment: PID
@@ -20,8 +20,8 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PD1
-             - MSH
+        - PD1
+        - MSH
 
     - resourceName: Encounter
       segment: PV1
@@ -29,9 +29,10 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PV2
-             - EVN
-             - MSH
+        - PV2
+        - EVN
+        - MSH
+        - DG1
 
     - resourceName: Condition
       segment: DG1
@@ -39,9 +40,9 @@ resources:
       isReferenced: true
       repeats: true
       additionalSegments:
-             - MSH
-             - PID
-             - PV1
+        - MSH
+        - PID
+        - PV1
              
     - resourceName: Observation
       segment: OBX
@@ -49,11 +50,22 @@ resources:
       repeats: true
       isReferenced: true
       additionalSegments:
-             - MSH
+        - MSH
 
     - resourceName: AllergyIntolerance
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
       additionalSegments:
-             - MSH
+        - MSH
+
+    - resourceName: Procedure
+      segment: .PR1
+      group: PROCEDURE
+      resourcePath: resource/Procedure
+      repeats: true
+      additionalSegments:
+        - .ROL
+        - MSH
+        - PID
+        - PV1

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -118,39 +118,7 @@ public class FHIRConverterTest {
         ftv.convert(hl7message);
     });
   }
-
-  @Test
-  public void test_ORU_r01_without_status() throws IOException {
-    String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
-        + "PID|1||PATID5421^^^NISTMPI^MR||Wilson^Patrice^Natasha^^^^L||19820304|F||2106-3^White^HL70005|144 East 12th Street^^Los Angeles^CA^90012^^H||^PRN^PH^^^203^2290210|||||||||N^Not Hispanic or Latino^HL70189\r"
-        + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
-        + "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
-        + "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
-        + "OBX|2|CWE|20575-7^Hepatitis A virus Ab [Presence] in Serum^LN^HAVAB^Hepatitis A antibodies (anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
-        + "OBX|3|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(ORU_r01, OPTIONS);
-
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> diagnosticReport = e.stream()
-        .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(diagnosticReport).hasSize(1);
-
-    String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));
-    Class<? extends IBaseResource> klass = DiagnosticReport.class;
-    DiagnosticReport expectStatusUnknown = (DiagnosticReport) context.getParser().parseResource(klass, s);
-    DiagnosticReport.DiagnosticReportStatus status = expectStatusUnknown.getStatus();
-
-    assertThat(expectStatusUnknown.hasStatus()).isTrue();
-    assertThat(status).isEqualTo(DiagnosticReport.DiagnosticReportStatus.UNKNOWN);
-  }
-
+  
   @Test
   public void test_dosage_output() throws  IOException {
 String hl7message =
@@ -206,6 +174,7 @@ String hl7message =
   }
 
   @Test
+  // Test an example of a message with message structure specified
   public void test_adt_40_message_with_adt_a39_structure_specified() throws Exception {
     Message hl7message = null;
     // Test that an ADT A40 message with MSH-9.3 of 'ADT_A39' is successfully parsed and converted as an ADT A40 message.
@@ -245,102 +214,6 @@ String hl7message =
         .map(BundleEntryComponent::getResource).collect(Collectors.toList());
     assertThat(patientResource).hasSize(2);
 
-  }
-
-  @Test
-  public void test_adt_40_message() throws Exception {
-    Message hl7message = null;
-    // Test that an ADT A40 message with no MSH-9.3 is successfully parsed and converted.
-    String hl7messageString =
-            "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40|00000003|P|2.6\n" +
-            "PID|||MR1^^^XYZ||MAIDENNAME^EVE\n" +
-            "MRG|MR2^^^XYZ\n";
-
-    InputStream ins = IOUtils.toInputStream(hl7messageString, StandardCharsets.UTF_8);
-    Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
-
-    if (iterator.hasNext()) {
-      HL7HapiParser hparser = new HL7HapiParser();
-      hl7message = hparser.getParser().parse(iterator.next());
-    }
-
-    String messageType = HL7DataExtractor.getMessageType(hl7message);
-
-    assertThat(messageType).isEqualTo("ADT_A40");
-
-    // Convert and check for a patient resource
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7messageString, ConverterOptions.SIMPLE_OPTIONS);
-
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource = e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(2);
-
-  }
-
-  @Test
-  public void test_VXU_V04_message() {
-    String hl7VUXmessageRep = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
-        + "EVN|A01|20130617154644||01\r"
-        + "PID|1||432155^^^ANF^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
-        + "PV1|1|B|yyy|E|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
-
-        + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-        + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
-        + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
-        + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
-        + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
-        + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
-        + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r";
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-
-    String json = ftv.convert(hl7VUXmessageRep, OPTIONS);
-
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource = e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(1);
-    List<Resource> messageHeader = e.stream()
-        .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(messageHeader).hasSize(1);
-
-    List<Resource> encounterResource = e.stream()
-        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType()).map(BundleEntryComponent::getResource)
-        .collect(Collectors.toList());
-    assertThat(encounterResource).hasSize(1);
-    List<Resource> obsResource = e.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-    List<Resource> pracResource = e.stream().filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(pracResource).hasSize(6);
-
-    List<Resource> organizationRes = e.stream()
-        .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    // Patient organizations use a system urn:id reference for the organization, 
-    // so we only expect the manufacturer to have an organization.    
-    assertThat(organizationRes).hasSize(1);
   }
 
   @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
@@ -19,6 +19,8 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
@@ -28,403 +30,525 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HL7ADTMessageTest {
-        private static FHIRContext context = new FHIRContext();
-        private static final Logger LOGGER = LoggerFactory.getLogger(HL7ADTMessageTest.class);
-        private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
-        private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
-                        .withValidateResource().withPrettyPrint().build();
-
-        @Test
-        public void test_adt_a01_basic_resources_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A01|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 resources: 1 Encounter, 1 Patient
-                assertThat(e.size()).isEqualTo(2);
-
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-        }
-
-        @Test
-        public void test_adt_a01_full_resources_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A01|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
-                                + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
-                                + "OBX|1|TX|1234^some text^SCT||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\n"
-                                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
-                                + "DG1|1||B45678|||A|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 4 resources: Encounter, Patient, AllergyIntolerance, and Condition
-                assertThat(e.size()).isEqualTo(4);
-
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-                List<Resource> observationResource = e.stream()
-                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                // No Observation resource because OBX.2 is type TX                        
-                assertThat(observationResource).isEmpty();
-
-                List<Resource> allergyIntoleranceResource = e.stream()
-                                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(allergyIntoleranceResource).hasSize(1);
-
-                List<Resource> conditionResource = e.stream()
-                                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(conditionResource).hasSize(1);
-        }
-
-        @Test@Disabled("adt-a02 not yet supported")
-        public void test_adta02_patient_encounter_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
-                                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-        }
-
-        @Test@Disabled("adt-a03 not yet supported")
-        public void test_adta03_patient_encounter_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;                
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-        }
-
-
-
-        @Test@Disabled("adt-a04 not yet supported")
-        public void test_adta04_patient_encounter_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A04|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-        }
-
-        @Test
-        public void test_adta08_basic_resources_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A08|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 resources: Patient and Encounter
-                assertThat(e.size()).isEqualTo(2);
-                
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-        }
-
-        @Test
-        public void test_adta08_full_resources_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A08|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
-                                + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
-                                + "OBX|1|TX|1234^some text^SCT||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\n"
-                                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\n" 
-                                + "DG1|1||B45678|||A|\r";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 4 total resources.  Not expecting an Observation
-                assertThat(e.size()).isEqualTo(4);
-                
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-                List<Resource> observationResource = e.stream()
-                                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                // No Observation resource because OBX.2 is type TX        
-                assertThat(observationResource).isEmpty();
-
-                List<Resource> allergyIntoleranceResource = e.stream()
-                                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(allergyIntoleranceResource).hasSize(1);
-
-                List<Resource> conditionResource = e.stream()
-                                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(conditionResource).hasSize(1);
-
-        }
-
-        @Test@Disabled("adt-a28 not yet supported")
-        public void test_adta28_patient_encounter_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-                                
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-        }
-
-        @Test@Disabled("adt-a31 not yet supported")
-        public void test_adta31_patient_encounter_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\n"
-                                + "EVN|A01|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-                
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-                                
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(1);
-
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).hasSize(1);
-
-        }
-
-        @Test
-        public void test_adta34_basic_resources_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A34|controlID|P|2.6\n"
-                                + "EVN|A40|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "MRG|456||||||\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-                                
-                // There should be two patient resources, the PID patient and the MRG patient.
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(2);
-
-                // We currently do not support Encounters for merging, in ADT_A34 merge
-                // messages, so no Encounter should be created.
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).isEmpty();
-
-        }
-
-        @Test
-        public void test_adta40_basic_resources_present() throws IOException {
-                String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A40|controlID|P|2.6\n"
-                                + "EVN|A40|20150502090000|\n"
-                                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                                + "MRG|456||||||\n";
-
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-                String json = ftv.convert(hl7message, OPTIONS);
-                assertThat(json).isNotBlank();
-                LOGGER.info("FHIR json result:\n" + json);
-                IBaseResource bundleResource = context.getParser().parseResource(json);
-                assertThat(bundleResource).isNotNull();
-                Bundle b = (Bundle) bundleResource;
-                List<BundleEntryComponent> e = b.getEntry();
-
-                // Expecting 2 total resources
-                assertThat(e.size()).isEqualTo(2);
-                                
-                // There should be two patient resources, the PID patient and the MRG patient.
-                List<Resource> patientResource = e.stream()
-                                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(patientResource).hasSize(2);
-
-                // We currently do not support Encounters for merging, in ADT_A40 merge
-                // messages, so no Encounter should be created.
-                List<Resource> encounterResource = e.stream()
-                                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-                assertThat(encounterResource).isEmpty();
-
-        }
+    private static FHIRContext context = new FHIRContext();
+    private static final Logger LOGGER = LoggerFactory.getLogger(HL7ADTMessageTest.class);
+    private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
+    private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
+        .withValidateResource().withPrettyPrint().build();
+
+    @ParameterizedTest
+    // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
+    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    public void test_adt_a01_mininum_segments(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        List<Resource> patientResource = e.stream()
+                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = e.stream()
+                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(2);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
+    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    public void test_adt_a01_minimum_plus_PROCEDURE_group(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+            ;
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        List<Resource> patientResource = e.stream()
+                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = e.stream()
+                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> procedureResource = e.stream()
+                        .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(procedureResource).hasSize(1); // from PR1
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(3);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
+    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    public void test_adt_a01_full_with_OBXtypeTX_and_no_groups(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+            + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
+            + "OBX|1|TX|1234^some text^SCT||First line||||||F||\n"
+            + "OBX|2|TX|1234^some text^SCT||Second line||||||F||\n"
+            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
+            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
+            + "DG1|1||B45678|||A|\r"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        List<Resource> patientResource = e.stream()
+                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1); // from PID, PD1
+
+        List<Resource> encounterResource = e.stream()
+                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1, PV2
+
+        List<Resource> observationResource = e.stream()
+                        .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(observationResource).hasSize(0); // from OBX
+
+        List<Resource> allergyIntoleranceResource = e.stream()
+                        .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(allergyIntoleranceResource).hasSize(2); // from AL1
+
+        List<Resource> conditionResource = e.stream()
+                        .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(conditionResource).hasSize(1); // from DG1
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(5);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
+    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    public void test_adt_a01_full_plus_multiple_PROCEDURE_group(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+            + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
+            + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r" 
+            + "OBX|2|ST|100||Observation content|||||||X\r"
+            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
+            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
+            + "DG1|1||B45678|||A|\r"
+            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        List<Resource> patientResource = e.stream()
+                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1); // from PID, PD1
+
+        List<Resource> encounterResource = e.stream()
+                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1, PV2
+
+        List<Resource> observationResource = e.stream()
+                        .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(observationResource).hasSize(2); // from OBX
+
+        List<Resource> allergyIntoleranceResource = e.stream()
+                        .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(allergyIntoleranceResource).hasSize(2); // from AL1
+
+        List<Resource> conditionResource = e.stream()
+                        .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(conditionResource).hasSize(1); // from DG1
+
+        List<Resource> procedureResource = e.stream()
+                        .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(procedureResource).hasSize(4); //from PROCEDURE.PR1
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(11);
+
+    }
+
+    @Test@Disabled("adt-a02 not yet supported")
+    public void test_adta02_patient_encounter_present() throws IOException {
+            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\n"
+                            + "EVN|A01|20150502090000|\n"
+                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+                            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r";
+
+            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+            String json = ftv.convert(hl7message, OPTIONS);
+            assertThat(json).isNotBlank();
+            LOGGER.info("FHIR json result:\n" + json);
+            IBaseResource bundleResource = context.getParser().parseResource(json);
+            assertThat(bundleResource).isNotNull();
+            Bundle b = (Bundle) bundleResource;
+            List<BundleEntryComponent> e = b.getEntry();
+
+            // Expecting 2 total resources
+            assertThat(e.size()).isEqualTo(2);
+
+            List<Resource> patientResource = e.stream()
+                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(patientResource).hasSize(1);
+
+            List<Resource> encounterResource = e.stream()
+                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(encounterResource).hasSize(1);
+
+    }
+
+    @Test@Disabled("adt-a03 not yet supported")
+    public void test_adta03_patient_encounter_present() throws IOException {
+            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\n"
+                            + "EVN|A01|20150502090000|\n"
+                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+
+            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+            String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+            assertThat(json).isNotBlank();
+            LOGGER.info("FHIR json result:\n" + json);
+            IBaseResource bundleResource = context.getParser().parseResource(json);
+            assertThat(bundleResource).isNotNull();
+            Bundle b = (Bundle) bundleResource;                
+            List<BundleEntryComponent> e = b.getEntry();
+
+            // Expecting 2 total resources
+            assertThat(e.size()).isEqualTo(2);
+
+            List<Resource> patientResource = e.stream()
+                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(patientResource).hasSize(1);
+
+            List<Resource> encounterResource = e.stream()
+                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(encounterResource).hasSize(1);
+
+    }
+
+    @Test@Disabled("adt-a28 not yet supported")
+    //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
+    public void test_adta28_patient_encounter_present() throws IOException {
+            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\n"
+                            + "EVN|A01|20150502090000|\n"
+                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+
+            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+            String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+            assertThat(json).isNotBlank();
+            LOGGER.info("FHIR json result:\n" + json);
+            IBaseResource bundleResource = context.getParser().parseResource(json);
+            assertThat(bundleResource).isNotNull();
+            Bundle b = (Bundle) bundleResource;
+            List<BundleEntryComponent> e = b.getEntry();
+
+            // Expecting 2 total resources
+            assertThat(e.size()).isEqualTo(2);
+                            
+            List<Resource> patientResource = e.stream()
+                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(patientResource).hasSize(1);
+
+            List<Resource> encounterResource = e.stream()
+                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(encounterResource).hasSize(1);
+
+    }
+
+    @Test@Disabled("adt-a31 not yet supported")
+    //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
+    public void test_adta31_patient_encounter_present() throws IOException {
+            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\n"
+                            + "EVN|A01|20150502090000|\n"
+                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+
+            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+            String json = ftv.convert(hl7message, OPTIONS);
+            assertThat(json).isNotBlank();
+            LOGGER.info("FHIR json result:\n" + json);
+            IBaseResource bundleResource = context.getParser().parseResource(json);
+            assertThat(bundleResource).isNotNull();
+            Bundle b = (Bundle) bundleResource;
+            List<BundleEntryComponent> e = b.getEntry();
+            
+            // Expecting 2 total resources
+            assertThat(e.size()).isEqualTo(2);
+                            
+            List<Resource> patientResource = e.stream()
+                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(patientResource).hasSize(1);
+
+            List<Resource> encounterResource = e.stream()
+                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+            assertThat(encounterResource).hasSize(1);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A30 structure is also used by ADT_A34, ADT_A35, ADT_A36, ADT_A46, ADT_A47, ADT_A48, ADT_A49.  We can reuse this for those messages if we choose to support them in the future.
+    @ValueSource(strings = { /*"ADT^A30",*/ "ADT^A34"/*, "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48", "ADT^A49"*/ })
+    public void test_adt_a30_mininum_segments(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "MRG|456||||||\n"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        // There should be two patient resources, the PID patient and the MRG patient.
+        List<Resource> patientResource = e.stream()
+            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(2); // from PID and MRG
+
+        // We currently do not support Encounters for merging, in ADT_A34 merge
+        // messages, so no Encounter should be created from EVN.
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(2);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A30 structure is also used by ADT_A34, ADT_A35, ADT_A36, ADT_A46, ADT_A47, ADT_A48, ADT_A49.  We can reuse this for those messages if we choose to support them in the future.
+    @ValueSource(strings = { /*"ADT^A30",*/ "ADT^A34"/*, "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48", "ADT^A49"*/ })
+    public void test_adt_a30_full(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "MRG|456||||||\n"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        // There should be two patient resources, the PID patient and the MRG patient.
+        List<Resource> patientResource = e.stream()
+            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(2); // from PID and MRG
+
+        // We currently do not support Encounters for merging, in ADT_A34 merge
+        // messages, so no Encounter should be created from EVN.
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(2);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
+    @ValueSource(strings = { /*"ADT^A39",*/ "ADT^A40"/*, "ADT^A41", "ADT^A42"*/ })
+    public void test_adt_a39_min_segments(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "MRG|456||||||\n"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        // There should be two patient resources, the PID patient and the MRG patient.
+        List<Resource> patientResource = e.stream()
+            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(2); // 1st from PID; 2nd from MRG
+
+        // We currently do not support Encounters for merging,
+        // so no Encounter should be created from EVN.
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(2);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
+    @ValueSource(strings = { /*"ADT^A39",*/ "ADT^A40"/*, "ADT^A41", "ADT^A42"*/ })
+    public void test_adt_a39_min_with_multiple_PATIENT_groups(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1111^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "MRG|123||||||\n"
+            + "PID|||2222^^^^MR||DOE^Joe^|||F||||||||||||||||||||||\r"
+            + "MRG|456||||||\n"
+            + "PID|||3333^^^^MR||DOE^Larry^|||F||||||||||||||||||||||\r"
+            + "MRG|789||||||\n"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        // There should be six patient resources from the PID segments and MRG segments.
+        List<Resource> patientResource = e.stream()
+            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(6); // from PIDs and MRGs
+
+        // We currently do not support Encounters for merging,
+        // so no Encounter should be created from EVN.
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(6);
+
+    }
+
+    @ParameterizedTest
+    // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
+    @ValueSource(strings = { /*"ADT^A39",*/ "ADT^A40"/*, "ADT^A41", "ADT^A42"*/ })
+    public void test_adt_a39_full_with_multiple_PATIENT_groups(String message) throws IOException {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN|A01|20150502090000|\r"
+            + "PID|||1111^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "MRG|123||||||\n"
+            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+            + "PID|||2222^^^^MR||DOE^Joe^|||F||||||||||||||||||||||\r"
+            + "PD1|||||||||||01|N||||A\r"
+            + "MRG|456||||||\n"
+            + "PID|||3333^^^^MR||DOE^Larry^|||F||||||||||||||||||||||\r"
+            + "MRG|789||||||\n"
+            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+            + "PID|||4444^^^^MR||DOE^Elizabeth^|||F||||||||||||||||||||||\r"
+            ;
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+
+        // There should be patient resources from the PID and the MRG segments.
+        List<Resource> patientResource = e.stream()
+            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(7); // from PID and MRG
+
+        // We currently do not support Encounters for merging, in ADT_A34 merge
+        // messages, so no Encounter should be created from EVN and PV1.
+
+        // Confirm that there are no extra resources
+        assertThat(e.size()).isEqualTo(7);
+
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
@@ -163,8 +163,13 @@ public class HL7ADTMessageTest {
                         .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(conditionResource).hasSize(1); // from DG1
 
+        List<Resource> documentReferenceResource = e.stream()
+                        .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(documentReferenceResource).hasSize(0); // from OBX of type TX; TODO: this should be 1 when card 855 is implemented
+
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(5);
+        assertThat(e.size()).isEqualTo(5); //TODO: this should be 6 when card 855 is implemented
 
     }
 

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -866,4 +866,36 @@ public class Hl7ORUMessageTest {
             assertThat(obs.getSubject().getReference().substring(0, 8)).isEqualTo("Patient/");
         }
     }
+
+    @Test
+    public void test_ORU_r01_without_status() throws IOException {
+      String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
+          + "PID|1||PATID5421^^^NISTMPI^MR||Wilson^Patrice^Natasha^^^^L||19820304|F||2106-3^White^HL70005|144 East 12th Street^^Los Angeles^CA^90012^^H||^PRN^PH^^^203^2290210|||||||||N^Not Hispanic or Latino^HL70189\r"
+          + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
+          + "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
+          + "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
+          + "OBX|2|CWE|20575-7^Hepatitis A virus Ab [Presence] in Serum^LN^HAVAB^Hepatitis A antibodies (anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
+          + "OBX|3|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
+  
+      HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+      String json = ftv.convert(ORU_r01, OPTIONS);
+  
+      FHIRContext context = new FHIRContext();
+      IBaseResource bundleResource = context.getParser().parseResource(json);
+      assertThat(bundleResource).isNotNull();
+      Bundle b = (Bundle) bundleResource;
+      List<BundleEntryComponent> e = b.getEntry();
+      List<Resource> diagnosticReport = e.stream()
+          .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+          .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+      assertThat(diagnosticReport).hasSize(1);
+  
+      String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));
+      Class<? extends IBaseResource> klass = DiagnosticReport.class;
+      DiagnosticReport expectStatusUnknown = (DiagnosticReport) context.getParser().parseResource(klass, s);
+      DiagnosticReport.DiagnosticReportStatus status = expectStatusUnknown.getStatus();
+  
+      assertThat(expectStatusUnknown.hasStatus()).isTrue();
+      assertThat(status).isEqualTo(DiagnosticReport.DiagnosticReportStatus.UNKNOWN);
+    }
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -34,7 +34,6 @@ import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -55,9 +54,8 @@ public class Hl7EncounterFHIRConversionTest {
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
 
     @Test
-    @Disabled
     public void test_encounter_visitdescription_present() {
-        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A02|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
                 + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n"
@@ -94,9 +92,8 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    @Disabled
     public void test_encounter_visitdescription_missing() {
-        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A02|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
                 + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n"
@@ -125,25 +122,23 @@ public class Hl7EncounterFHIRConversionTest {
     // Test for serviceProvider reference in messages with both PV1 and PV2 segments
     // Part 1: use serviceProvider from PV2.23 subfields
     @ParameterizedTest
-    @ValueSource(strings = { "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A01|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A04|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A08|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\r"
-     // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O11|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O25|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ORU^R01|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||VXU^V04|controlID|P|2.6\r",
+    @ValueSource(strings = { 
+        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
+        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+        // MDM messages are not tested here because they do not have PV2 segments
+        "OMP^O09",
+        "ORU^R01",
+        "RDE^O11","RDE^O25",
+        "VXU^V04"
     })
-    public void test_encounter_with_serviceProvider_from_PV2(String msh) {
-        String hl7message = msh
-                + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
-                + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
-                + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n"
-                + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth^SSHW^^^^^^SSH_WEYMOUTH|||||||||N||||||\n";
+    public void test_encounter_with_serviceProvider_from_PV2(String message) {
+        String hl7message = 
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
+            + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
+            + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
+            + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth^SSHW^^^^^^SSH_WEYMOUTH|||||||||N||||||\r"
+            ;
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
@@ -175,25 +170,22 @@ public class Hl7EncounterFHIRConversionTest {
     // Test for serviceProvider reference in messages with both PV1 and PV2 segments
     // Part 2: Field PV2.23 is provided but no PV2.23.8; serviceProvider id should use backup field PV1.3.4.1
     @ParameterizedTest
-    @ValueSource(strings = { "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A01|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A04|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A08|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\r",
-     // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O11|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O25|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ORU^R01|controlID|P|2.6\r",     
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||VXU^V04|controlID|P|2.6\r",
+    @ValueSource(strings = { 
+        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
+        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+        // MDM messages are not tested here because they do not have PV2 segments
+        "OMP^O09",
+        "ORU^R01",
+        "RDE^O11","RDE^O25",
+        "VXU^V04"
     })
-    public void test_encounter_PV1_serviceProvider(String msh) {
-        String hl7message = msh
-                + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
-                + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
-                + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
-                + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth|||||||||N||||||\r";
+    public void test_encounter_PV1_serviceProvider(String message) {
+        String hl7message =
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
+            + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
+            + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
+            + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth|||||||||N||||||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
@@ -224,25 +216,22 @@ public class Hl7EncounterFHIRConversionTest {
     // Test for serviceProvider reference in messages with PV1 segment and no PV2 segment
     // Use serviceProvider from PV1-3.4.1
     @ParameterizedTest
-    @ValueSource(strings = { "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A01|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A04|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A08|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\r"
-     // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O11|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O25|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ORU^R01|controlID|P|2.6\r", 
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||VXU^V04|controlID|P|2.6\r",    
+    @ValueSource(strings = {
+        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
+        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+        // MDM messages are not tested here because they do not have PV2 segments
+        "OMP^O09",
+        "ORU^R01",
+        "RDE^O11","RDE^O25",
+        "VXU^V04"
     })
-    public void test_encounter_with_serviceProvider_from_PV1_3_4(String msh) {
-        String hl7message =  msh
-                +"EVN|A01|20150502090000|\r"
-                +"PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-                // PV1-3.4 used for serviceProvider reference; used for both id and name
-                +"PV1||I|INT^0001^02^Toronto East|||||||SUR||||||||S|VisitNumber^^^Toronto North|A|||||||||||||||||||Toronto West||||||\r";
+    public void test_encounter_with_serviceProvider_from_PV1_3_4(String message) {
+        String hl7message =
+            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
+            +"EVN|A01|20150502090000|\r"
+            +"PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+            // PV1-3.4 used for serviceProvider reference; used for both id and name
+            +"PV1||I|INT^0001^02^Toronto East|||||||SUR||||||||S|VisitNumber^^^Toronto North|A|||||||||||||||||||Toronto West||||||\r";
  
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
@@ -466,9 +455,8 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    @Disabled
     public void test_encounter_modeOfarrival_invalid_singlevalue() {
-        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A02|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
                 + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n"
@@ -494,9 +482,8 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    @Disabled
     public void test_encounter_modeOfarrival_invalid_with_codeAndDisplay() {
-        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A02|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
                 + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n"
@@ -521,9 +508,8 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    @Disabled
     public void test_encounter_modeOfarrival_invalid_with_system() {
-        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A02|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
                 + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n"
@@ -550,24 +536,21 @@ public class Hl7EncounterFHIRConversionTest {
     // Test messages with PV1 segment and no PV2 segment, and no serviceProvider provided
     // Extension list should be empty and serviceProvider should be null
     @ParameterizedTest
-    @ValueSource(strings = { "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A01|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A04|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A08|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\r",
-     //"MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\r"
-     // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O11|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||RDE^O25|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ORU^R01|controlID|P|2.6\r",
-     "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||VXU^V04|controlID|P|2.6\r",
+    @ValueSource(strings = {
+        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
+        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+        // MDM messages are not tested here because they do not have PV2 segments
+        "OMP^O09",
+        "ORU^R01",
+        "RDE^O11","RDE^O25",
+        "VXU^V04"
     })
-    public void test_encounter_PV2segment_missing(String msh) {
-        String hl7message = msh //"MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A02|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
-                + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
-                + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
-                + "PV1||I|^^^^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n";
+    public void test_encounter_PV2segment_missing(String message) {
+        String hl7message =
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|" + message + "|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+            + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
+            + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
+            + "PV1||I|^^^^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n";
         Encounter encounter = ResourceUtils.getEncounter(hl7message);
         Narrative encText = encounter.getText();
         assertNull(encText.getStatus());

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
@@ -434,6 +434,7 @@ public class Hl7ObservationFHIRConversionTest {
         "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC1|||2.6||||||||2.6\r",
         //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC2|||2.6||||||||2.6\r",
         //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC3|||2.6||||||||2.6\r",
+        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|VXU^V04|||2.6||||||||2.6\r",
     })
     public void extendedObservationTestMostMessages(String msh) throws IOException {
         String hl7message = msh

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -52,7 +52,8 @@ public class Hl7PatientFHIRConversionTest {
     // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A31|||2.6|\r",
     "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A34|||2.6|\r",
     "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A40|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||OMP^O09|||2.6|\r",
+    // MDM messages are not tested here because they do not contain PD1 segments
+    "MSH|^~\\&|hl7Integration|hl7Integration|||||OMP^O09|||2.6|\r",
     // "MSH|^~\\&|hl7Integration|hl7Integration|||||ORM^O01|||2.6|\r",
     "MSH|^~\\&|hl7Integration|hl7Integration|||||ORU^R01|||2.6|\r",
     "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O11|||2.6|\r",
@@ -61,8 +62,9 @@ public class Hl7PatientFHIRConversionTest {
     })
     public void test_patient_additional_demographics(String msh) {
         String hl7message = msh
-                + "PID|1||1234^^^AssigningAuthority^MR||TEST^PATIENT|\n"
-                + "PD1|||Sample Family Practice^^2222|1111^LastName^ClinicianFirstName^^^^Title||||||||||||A|";
+                + "PID|1||1234^^^AssigningAuthority^MR||TEST^PATIENT|\r"
+                + "PD1|||Sample Family Practice^^2222|1111^LastName^ClinicianFirstName^^^^Title||||||||||||A|\r"
+                ;
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, PatientUtils.OPTIONS);


### PR DESCRIPTION
Updates made to clean up FHIRConverterTest, and other hardening to remove disabled tests and some TODOs that could be updated, as well as additional coverage.