### PR TITLE
Fix part of  multiple service requests mixing id values

### DIFF
--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -16,10 +16,10 @@ value:
 
 system_1:
    type: STRING
-   valueOf: $systemId 
+   valueOf: $systemId
 
 system_2:
-   condition: $systemCX NOT_NULL
+   condition: $valueIn NOT_NULL && $systemCX NOT_NULL 
    valueOf: $join
    vars:
       join: $systemCX, GeneralUtils.noWhiteSpace(join)

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -19,7 +19,7 @@ system_1:
    valueOf: $systemId
 
 system_2:
-   condition: $valueIn NOT_NULL && $systemCX NOT_NULL 
+   condition: $systemCX NOT_NULL 
    valueOf: $join
    vars:
       join: $systemCX, GeneralUtils.noWhiteSpace(join)

--- a/src/main/resources/hl7/resource/DocumentReference.yml
+++ b/src/main/resources/hl7/resource/DocumentReference.yml
@@ -35,27 +35,99 @@ identifier_1:
    constants:
       sys: "urn:id:extID"
 
-identifier_2:
+# The logic for Filler appears it should be:     
+#  valueIn: ORC.3.1 | OBR.3.1 | TXA.15.1
+#  systemCX: ORC.3.2 | OBR.3.2 | TXA.15.2 
+# But if ORC.3.1 has a value and ORC.3.2 is empty but OBR.3.2 has a value,
+# it results in mismatched code and system values.  Similarly for values in TXA.
+# The code below forces the value and the system to be of the same pair.
+# Similar settings for Placer.
+
+identifier_2a:
    condition: $valueIn NOT_NULL
    valueOf: datatype/Identifier_var
    generateList: true
+   useGroup: true
    expressionType: resource
    vars:
-      valueIn: ORC.3.1 | OBR.3.1 | TXA.15.1
-      systemCX: ORC.3.2 | OBR.3.2 | TXA.15.2
+      valueIn: ORC.3.1
+      systemCX: ORC.3.2 
    constants:
       system: "http://terminology.hl7.org/CodeSystem/v2-0203"
       code: "FILL"
       display: "Filler Identifier"
 
-identifier_3:
+identifier_2b:
+   condition: $valueInORC NULL && $valueIn NOT_NULL 
+   valueOf: datatype/Identifier_var
+   generateList: true
+   useGroup: true
+   expressionType: resource
+   vars:
+      valueIn: OBR.3.1
+      systemCX: OBR.3.2 
+      valueInORC: ORC.3.1
+   constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "FILL"
+      display: "Filler Identifier" 
+      
+identifier_2c:
+   condition: $valueInORC NULL && $valueInOBR NULL && $valueIn NOT_NULL 
+   valueOf: datatype/Identifier_var
+   generateList: true
+   useGroup: true
+   expressionType: resource
+   vars:
+      valueIn: TXA.15.1
+      systemCX: TXA.15.2 
+      valueInORC: ORC.3.1
+      valueInOBR: OBR.3.1
+   constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "FILL"
+      display: "Filler Identifier"
+
+identifier_3a:
    condition: $valueIn NOT_NULL
    valueOf: datatype/Identifier_var
    generateList: true
+   useGroup: true
    expressionType: resource
    vars:
-      valueIn: ORC.2.1 | OBR.2.1 | TXA.14.1
-      systemCX: ORC.2.2 | OBR.2.2 | TXA.14.2
+      valueIn: ORC.2.1
+      systemCX: ORC.2.2 
+   constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "PLAC"
+      display: "Placer Identifier"
+
+identifier_3b:
+   condition: $valueInORC NULL && $valueIn NOT_NULL 
+   valueOf: datatype/Identifier_var
+   generateList: true
+   useGroup: true
+   expressionType: resource
+   vars:
+      valueIn: OBR.2.1
+      systemCX: OBR.2.2 
+      valueInORC: ORC.2.1
+   constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "PLAC"
+      display: "Placer Identifier"    
+      
+identifier_3c:
+   condition: $valueInORC NULL && $valueInOBR NULL && $valueIn NOT_NULL 
+   valueOf: datatype/Identifier_var
+   generateList: true
+   useGroup: true
+   expressionType: resource
+   vars:
+      valueIn: TXA.14.1
+      systemCX: TXA.14.2 
+      valueInORC: ORC.2.1
+      valueInOBR:  OBR.2.1
    constants:
       system: "http://terminology.hl7.org/CodeSystem/v2-0203"
       code: "PLAC"

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -22,31 +22,71 @@ identifier_1:
       code: "VN"
       display: "Visit number"
 
-identifier_2:
+# The logic for Filler appears it should be:     
+#  valueIn: ORC.3.1 | OBR.3.1
+#  systemCX: ORC.3.2 | OBR.3.2    
+# But if ORC.3.1 has a value and ORC.3.2 is empty but OBR.3.2 has a value,
+# it results in mismatched code and system values.
+# The code below forces the value and the system to be of the same pair.
+# Similar settings for Placer.
+
+identifier_2a:
    condition: $valueIn NOT_NULL
    valueOf: datatype/Identifier_var
    generateList: true
+   useGroup: true
    expressionType: resource
    vars:
-      valueIn: ORC.3.1 | OBR.3.1
-      systemCX: ORC.3.2 | OBR.3.2
+      valueIn: ORC.3.1
+      systemCX: ORC.3.2
    constants:
       system: "http://terminology.hl7.org/CodeSystem/v2-0203"
       code: "FILL"
       display: "Filler Identifier"
 
-identifier_3:
+identifier_2b:
+   condition: $valueInORC NULL && $valueIn NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true
+   useGroup: true
+   expressionType: resource
+   vars:
+      valueIn: OBR.3.1
+      systemCX: OBR.3.2
+      valueInORC: ORC.3.1
+   constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "FILL"
+      display: "Filler Identifier"      
+
+identifier_3a:
    condition: $valueIn NOT_NULL
    valueOf: datatype/Identifier_var
    generateList: true
+   useGroup: true
    expressionType: resource
    vars:
-      valueIn: ORC.2.1 | OBR.2.1
-      systemCX: ORC.2.2 | OBR.2.2
+      valueIn: ORC.2.1
+      systemCX: ORC.2.2 
    constants:
       system: "http://terminology.hl7.org/CodeSystem/v2-0203"
       code: "PLAC"
       display: "Placer Identifier"
+
+identifier_3b:
+   condition:  $valueInORC NULL && $valueIn NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true
+   useGroup: true
+   expressionType: resource
+   vars:
+      valueIn: OBR.2.1
+      systemCX: OBR.2.2
+      valueInORC: ORC.2.1
+   constants:
+      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+      code: "PLAC"
+      display: "Placer Identifier"      
 
 status:
    type: SERVICE_REQUEST_STATUS

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.DocumentReference;
@@ -74,7 +73,7 @@ public class Hl7MDMMessageTest {
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); // from PID
 
-        // Two ServiceRequests.  One for Dr AAA the other for Dr BBB
+        // Two ServiceRequests from the two ORC's.  One references Dr AAA the other references Dr BBB
         List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceRequests).hasSize(2); // from TXA, OBX(type TX)
         ServiceRequest srDrAAA = ResourceUtils.getResourceServiceRequest(serviceRequests.get(0), ResourceUtils.context);
@@ -144,6 +143,9 @@ public class Hl7MDMMessageTest {
                 assertThat(system).hasToString(matchDocRefIdValuesSystems.get(code).get(1));
             }
         }  
+
+        List<Resource> practitioners = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
+        assertThat(practitioners).hasSize(7); 
 
         // Confirm that no extra resources are created
         assertThat(e.size()).isEqualTo(12);

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
@@ -7,8 +7,13 @@ package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -32,6 +37,126 @@ public class Hl7MDMMessageTest {
     // + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\n"
     // + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\n"
     // + "OBX|3|TX|05^Operative Report||                              <HOSPITAL ADDRESS2>||||||P\n";
+
+
+    // This is an important test to assure we don't have data mixing in the placer / filler identifiers.
+    // @ParameterizedTest
+    // @ValueSource(strings = { "MDM^T02", "MDM^T06" })
+    @Test
+    public void noMixingOfParamsInDocumentReference(/*String message*/) throws IOException {
+        String message = "MDM^T02";
+        String hl7message =
+            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||MDM^T06|<MESSAGEID>|P|2.6\n"
+            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+            + "PV1|1|O|2GY^2417^W||||D||||||||||OTW|<HospitalID>|||||||||||||||||||||||||20180115102400|20180118104500\n"
+            // ORC 2.1 is empty, ORC 3.1 is empty but ORC 3.2 has a system
+            // OBR 2.1 has a value, OBR 3.1 has a value
+            // We expect a placer of OBR 2.1 and no system because OBR 2.2 is the matched field and is empty
+            // We expect a filler of OBR 3.1 and no system because OBR 3.2 is the matched field and is empty (System in ORC 3.2 is ignored.)
+            + "ORC|NW||^SYS-AAA-ORC32||||^^^^^R|||||1992779250^TEST^DOCTOR-AAA|123D432^^^Family Practice Clinic||||||||FAMILY PRACTICE CLINIC\n"
+            + "OBR|1|ID-AAA-OBR21|ID-AAA-OBR31|LAMIKP^AMIKACIN LEVEL, PEAK^83718||20170725143849|20180102||||L|||||123456789^MILLER^BOB|||REASON_TEXT_1|||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1|RESP_ID1&RESP_FAMILY_1&RESP_GIVEN1||TECH_1_ID&TECH_1_FAMILY&TECH_1_GIVEN|TRANS_1_ID&TRANS_1_FAMILY&TRANS_1_GIVEN\n"
+            // ORC 2.1 has value, ORC 3.1 is empty
+            // OBR 2.1 has a value and OBR 2.2 has a system, OBR 3.1 has a value
+            // We expect a placer of ORC 2.1 and no system because ORC 2.2 is the matched field and is empty (System in OBR 2.1 is ignored)
+            // We expect a filler of OBR 3.1 and system because OBR 3.2 is the matched field and has a system
+            + "ORC|NW|ID-BBB-ORC21|||||^^^^^R|||||1992779250^TEST^DOCTOR-BBB\n"
+            + "OBR|1|ID-BBB-OBR21^SYS-BBB-OBR22|ID-BBB-OBR31^SYS-BBB-OBR32|83718^HIGH-DENSITY LIPOPROTEIN (HDL)^NAMING2||20150909170243|||||L|||||1992779250^TEST^DOCTOR||||||||CAT|A||^^^20180204^^R||||REASON_ID_2^REASON_TEXT_2|RESP_ID2&RESP_FAMILY_2&RESP_GIVEN2||TECH_2_ID&TECH_2_FAMILY&TECH_2_GIVEN|TRANS_2_ID&TRANS_2_FAMILY&TRANS_2_GIVEN\n"
+            + "TXA|1|05^Operative Report|TX|201801171442|5566^PAPLast^PAPFirst^J^^MD|201801171442|201801180346||<PHYSID>|<PHYSID>|MODL|<MESSAGEID>||4466^TRANSCLast^TRANSCFirst^J^^MD|<MESSAGEID>||P||AV\n"
+            + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\n"
+            + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\n"
+            + "OBX|3|TX|05^Operative Report||                              <HOSPITAL ADDRESS2>||||||P\n";
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        // Check for the expected resources
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        // Two ServiceRequests.  One for Dr AAA the other for Dr BBB
+        List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
+        assertThat(serviceRequests).hasSize(2); // from TXA, OBX(type TX)
+        ServiceRequest srDrAAA = ResourceUtils.getResourceServiceRequest(serviceRequests.get(0), ResourceUtils.context);
+        ServiceRequest srDrBBB = ResourceUtils.getResourceServiceRequest(serviceRequests.get(1), ResourceUtils.context);
+        // Figure out which is first and reassign if needed for testing
+        if (!srDrAAA.getRequester().getDisplay().contains("DOCTOR-AAA TEST")) {
+            ServiceRequest temp = srDrAAA;
+            srDrAAA = srDrBBB;
+            srDrBBB = temp;
+        }
+        // Three ID's for srDrAAA
+        Map<String, String> matchSrDrAAAidValues = new HashMap<>();
+        matchSrDrAAAidValues.put("VN", "20180118111520");
+        matchSrDrAAAidValues.put("FILL", "ID-AAA-OBR31");
+        matchSrDrAAAidValues.put("PLAC", "ID-AAA-OBR21");
+        Map<String, String> matchSrDrAAAidSystems = new HashMap<>();
+        matchSrDrAAAidSystems.put("VN", "");
+        matchSrDrAAAidSystems.put("FILL", "");
+        matchSrDrAAAidSystems.put("PLAC", "");
+        List<Identifier> identifiers = srDrAAA.getIdentifier();
+        // Validate the note contents and references 
+        for(int idIndex=0; idIndex < identifiers.size(); idIndex++) {  // condIndex is index for condition
+            // Get the list of Observation references
+            Identifier ident = identifiers.get(idIndex);
+            String code = ident.getType().getCodingFirstRep().getCode();
+            assertThat(ident.getValue()).hasToString(matchSrDrAAAidValues.get(code));
+            String system = ident.getSystem() == null ? "" : ident.getSystem();
+            assertThat(system).hasToString(matchSrDrAAAidSystems.get(code));
+        }
+        // Three ID's for srDrBBB
+        Map<String, String> matchSrDrBBBidValues = new HashMap<>();
+        matchSrDrBBBidValues.put("VN", "20180118111520");
+        matchSrDrBBBidValues.put("FILL", "ID-BBB-OBR31");
+        matchSrDrBBBidValues.put("PLAC", "ID-BBB-ORC21");
+        Map<String, String> matchSrDrBBBidSystems = new HashMap<>();
+        matchSrDrBBBidSystems.put("VN", "");
+        matchSrDrBBBidSystems.put("FILL", "urn:id:SYS-BBB-OBR32");  
+        matchSrDrBBBidSystems.put("PLAC", "");
+        identifiers = srDrBBB.getIdentifier();
+        // Validate the note contents and references 
+        for(int idIndex=0; idIndex < identifiers.size(); idIndex++) {  // condIndex is index for condition
+            // Get the list of Observation references
+            Identifier ident = identifiers.get(idIndex);
+            String code = ident.getType().getCodingFirstRep().getCode();
+            assertThat(ident.getValue()).hasToString(matchSrDrBBBidValues.get(code));
+            String system = ident.getSystem() == null ? "" : ident.getSystem();
+            assertThat(system).hasToString(matchSrDrBBBidSystems.get(code));
+        }  
+
+        List<Resource> documentReferenceResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
+        assertThat(documentReferenceResource).hasSize(1); // from TXA, OBX(type TX)
+        DocumentReference docRef = ResourceUtils.getResourceDocumentReference(documentReferenceResource.get(0), ResourceUtils.context);
+        
+        // Three ID's for DocRef
+        Map<String, String> matchDocRefIdValues = new HashMap<>();
+        matchDocRefIdValues.put("EntityId", "<MESSAGEID>");
+        matchDocRefIdValues.put("FILL", "ID-AAA-OBR31");  // What we get
+        // matchDocRefIdValues.put("FILL", "ID-BBB-OBR31");  // What we think it should be
+        matchDocRefIdValues.put("PLAC", "ID-BBB-ORC21");
+        Map<String, String> matchDocRefIdSystems = new HashMap<>();
+        matchDocRefIdSystems.put("EntityId", "");
+        matchDocRefIdSystems.put("FILL", "urn:id:SYS-BBB-OBR32");  
+        matchDocRefIdSystems.put("PLAC", ""); // What we get
+        // matchDocRefIdSystems.put("PLAC", "urn:id:SYS-BBB-OBR32"); // What we think it should be
+        identifiers = docRef.getIdentifier();
+        // Validate the note contents and references 
+        for(int idIndex=0; idIndex < identifiers.size(); idIndex++) {  // condIndex is index for condition
+            // Get the list of Observation references
+            Identifier ident = identifiers.get(idIndex);
+            if (ident.hasType()) {
+                String code = ident.getType().getCodingFirstRep().getCode();
+                assertThat(ident.getValue()).hasToString(matchDocRefIdValues.get(code));
+                String system = ident.getSystem() == null ? "" : ident.getSystem();
+                assertThat(system).hasToString(matchDocRefIdSystems.get(code));
+            }
+        }  
+
+        // Confirm that no extra resources are created
+        assertThat(e.size()).isEqualTo(12);
+    }
+
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -7,6 +7,8 @@ package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.AllergyIntolerance;
@@ -44,17 +46,30 @@ public class Hl7IdentifierFHIRConversionTest {
         List<Identifier> identifiers = patient.getIdentifier();
         assertThat(identifiers.size()).isEqualTo(5);
 
+        // Match the id's to position; we can't depend on an order.
+        int posMR = getIdentifierPositionByValue("MRN12345678", identifiers);
+        assertThat(posMR).isNotSameAs(-1);
+        int posSSN = getIdentifierPositionByValue("111223333", identifiers);
+        assertThat(posSSN).isNotSameAs(-1);
+        int posDL = getIdentifierPositionByValue("MN1234567", identifiers);
+        assertThat(posDL).isNotSameAs(-1);
+        int posSSNPID19 = getIdentifierPositionByValue("444556666", identifiers);
+        assertThat(posSSNPID19).isNotSameAs(-1);
+        int posDLPID20 = getIdentifierPositionByValue("D-12445889-Z", identifiers);
+        assertThat(posDLPID20).isNotSameAs(-1);
+
         // First identifier (Medical Record) deep check
-        Identifier identifier = identifiers.get(0);
+        Identifier identifier = identifiers.get(posMR);
         assertThat(identifier.hasSystem()).isTrue();
         assertThat(identifier.getSystem()).hasToString("urn:id:ID-XYZ");
         assertThat(identifier.getValue()).hasToString("MRN12345678");
         assertThat(identifier.hasType()).isTrue();
         CodeableConcept cc = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "MR", "Medical record number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "MR", "Medical record number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Second identifier (SSN) medium check
-        identifier = identifiers.get(1);
+        identifier = identifiers.get(posSSN);
         assertThat(identifier.hasSystem()).isTrue();
         assertThat(identifier.getSystem()).hasToString("urn:id:USA");
         assertThat(identifier.getValue()).hasToString("111223333");
@@ -64,7 +79,7 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(cc.hasCoding()).isTrue();
 
         // Third identifier (Driver's license) medium check
-        identifier = identifiers.get(2);
+        identifier = identifiers.get(posDL);
         assertThat(identifier.hasSystem()).isTrue();
         assertThat(identifier.getSystem()).hasToString("urn:id:MNDOT");
         assertThat(identifier.getValue()).hasToString("MN1234567");
@@ -74,24 +89,26 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(cc.hasCoding()).isTrue();
 
         // Deep check for fourth identifier, which is assembled from PID.19 SSN
-        identifier = identifiers.get(3);
+        identifier = identifiers.get(posSSNPID19);
         assertThat(identifier.hasSystem()).isFalse();
         // PID.19 SSN has no authority value and therefore no system id
         // Using different SS than ID#2 to confirm coming from PID.19
         assertThat(identifier.getValue()).hasToString("444556666");
         assertThat(identifier.hasType()).isTrue();
         cc = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "SS", "Social Security number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "SS", "Social Security number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Deep check for fifth identifier, which is assembled from PID.20 DL
-        identifier = identifiers.get(4);
+        identifier = identifiers.get(posDLPID20);
         assertThat(identifier.hasSystem()).isFalse();
         // PID.20 has no authority value and therefore no system id
         // Using different DL than ID#2 to confirm coming from PID.20
         assertThat(identifier.getValue()).hasToString("D-12445889-Z");
         assertThat(identifier.hasType()).isTrue();
         cc = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "DL", "Driver's license number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "DL", "Driver's license number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
     }
 
@@ -107,24 +124,34 @@ public class Hl7IdentifierFHIRConversionTest {
         List<Identifier> identifiers = patient.getIdentifier();
         assertThat(identifiers.size()).isEqualTo(3);
 
+        // Match the id's to position; we can't depend on an order.
+        int posMR = getIdentifierPositionByValue("MRN12345678", identifiers);
+        assertThat(posMR).isNotSameAs(-1);
+        int posSSN = getIdentifierPositionByValue("111223333", identifiers);
+        assertThat(posSSN).isNotSameAs(-1);
+        int posUNKNOWN = getIdentifierPositionByValue("A100071402", identifiers);
+        assertThat(posUNKNOWN).isNotSameAs(-1);
+
         // First identifier (Medical Record) deep check
-        Identifier identifier = identifiers.get(0);
+        Identifier identifier = identifiers.get(posMR);
         assertThat(identifier.hasSystem()).isTrue();
         // Ensure system blanks are filled in with _'s
         assertThat(identifier.getSystem()).hasToString("urn:id:Regional_Health_ID");
         assertThat(identifier.getValue()).hasToString("MRN12345678");
         assertThat(identifier.hasType()).isTrue();
         CodeableConcept cc = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "MR", "Medical record number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "MR", "Medical record number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Second identifier
-        identifier = identifiers.get(1);
+        identifier = identifiers.get(posSSN);
         // We expect no system because there was no authority.
         assertThat(identifier.hasSystem()).isFalse();
         assertThat(identifier.getValue()).hasToString("111223333");
         assertThat(identifier.hasType()).isTrue();
         cc = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "SS", "Social Security number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "SS", "Social Security number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Third identifier - unknown code.  Create the following:
         // "identifier": [ {
@@ -133,7 +160,7 @@ public class Hl7IdentifierFHIRConversionTest {
         //         },
         //         "value": "A100071402"
         //       },
-        identifier = identifiers.get(2);
+        identifier = identifiers.get(posUNKNOWN);
         assertThat(identifier.hasSystem()).isFalse();
         assertThat(identifier.getValue()).hasToString("A100071402");
         assertThat(identifier.hasType()).isTrue();
@@ -219,7 +246,8 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(system).isEqualTo("urn:id:ACME"); // PV1.19.4
         CodeableConcept type = identifier.getType();
         // Coding coding = type.getCoding().get(0);
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         String withPRB4 = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\n" +
                 "PID|1||000054321^^^MRN||||19820512|M||2106-3|||||EN^English|M|CAT|78654||||N\n" +
@@ -230,14 +258,29 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(condition.hasIdentifier()).isTrue();
         assertThat(condition.getIdentifier()).hasSize(2);
 
+        List<Identifier> identifiers = condition.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        int posVN = getIdentifierPositionByValue("78654", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        int posExtId = getIdentifierPositionByValue("53956", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+
         // Identifier 1: Visit number
-        identifier = condition.getIdentifier().get(0);
+        identifier = condition.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("78654"); // PID.18.1
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+
+        // Identifier 2:  extID based on PRB.4
+        identifier = condition.getIdentifier().get(posExtId);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("53956"); // DG1.3.1-DG1.3.3
+        assertThat(system).isEqualTo("urn:id:extID");
 
     }
 
@@ -254,17 +297,25 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(condition.hasIdentifier()).isTrue();
         assertThat(condition.getIdentifier()).hasSize(2);
 
+        List<Identifier> identifiers = condition.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        int posVN = getIdentifierPositionByValue("88654", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        int posExtId = getIdentifierPositionByValue("C56.9-I10", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+
         // Identifier 1: Visit number
-        Identifier identifier = condition.getIdentifier().get(0);
+        Identifier identifier = condition.getIdentifier().get(posVN);
         String value = identifier.getValue();
         String system = identifier.getSystem();
         assertThat(value).isEqualTo("88654"); // PID.18.1
         assertThat(system).isNull(); // null because PV1.19.4 and PID18.4  are empty
         CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2:  extID based on DG1-3.1 + DG1-3.3
-        identifier = condition.getIdentifier().get(1);
+        identifier = condition.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("C56.9-I10"); // DG1.3.1-DG1.3.3
@@ -272,41 +323,53 @@ public class Hl7IdentifierFHIRConversionTest {
 
         // Test PV1-19 for visit number; extId with DG1-3.1.
         // Also test DG1-20 creates additional identifiers.
-         String withDG120 = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
-                        + "PID|||10290^^^WEST^MR||||20040530|M||||||||||||||||||||||N\n"
-                        + "PV1||I||||||||SUR||||||||S|8846511^^^ACME|A|||||||||||||||||||SF|K||||20170215080000\n"
-                        + "DG1|1|ICD10|B45678|Broken Arm|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|one^https://terminology.hl7.org/CodeSystem/two^three^https://terminology.hl7.org/CodeSystem/four|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
+        String withDG120 = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
+                + "PID|||10290^^^WEST^MR||||20040530|M||||||||||||||||||||||N\n"
+                + "PV1||I||||||||SUR||||||||S|8846511^^^ACME|A|||||||||||||||||||SF|K||||20170215080000\n"
+                + "DG1|1|ICD10|B45678|Broken Arm|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|one^https://terminology.hl7.org/CodeSystem/two^three^https://terminology.hl7.org/CodeSystem/four|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
         condition = ResourceUtils.getCondition(withDG120);
 
         // Expect 4 identifiers
         assertThat(condition.hasIdentifier()).isTrue();
         assertThat(condition.getIdentifier()).hasSize(4);
 
+        identifiers = condition.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("8846511", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posExtId = getIdentifierPositionByValue("B45678", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posExtDG20a = getIdentifierPositionByValue("one", identifiers);
+        assertThat(posExtDG20a).isNotSameAs(-1);
+        int posExtDG20b = getIdentifierPositionByValue("three", identifiers);
+        assertThat(posExtDG20b).isNotSameAs(-1);
+
         // Identifier 1: Visit number
-        identifier = condition.getIdentifier().get(0);
+        identifier = condition.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("8846511"); // PV1.19.1
         assertThat(system).isEqualTo("urn:id:ACME"); // PV1.19.4
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: DG1.3.1
-        identifier = condition.getIdentifier().get(1);
+        identifier = condition.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("B45678"); // DG1.3.1
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 3: DG1.20.1 and DG1.20.2
-        identifier = condition.getIdentifier().get(2);
+        identifier = condition.getIdentifier().get(posExtDG20a);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("one"); // DG1.20.1
         assertThat(system).isEqualTo("https://terminology.hl7.org/CodeSystem/two"); // DG1.20.2
 
         // Identifier 4: DG1.20.3 and DG1.20.4
-        identifier = condition.getIdentifier().get(3);
+        identifier = condition.getIdentifier().get(posExtDG20b);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("three"); // DG1.20.3
@@ -318,21 +381,28 @@ public class Hl7IdentifierFHIRConversionTest {
                 + "DG1|1|ICD10|^Ovarian Cancer|Test|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326||S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
         condition = ResourceUtils.getCondition(withDG132);
 
-        // Expect 4 identifiers
+        // Expect 2 identifiers
         assertThat(condition.hasIdentifier()).isTrue();
         assertThat(condition.getIdentifier()).hasSize(2);
+        identifiers = condition.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("201610015080000", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posExtId = getIdentifierPositionByValue("Ovarian Cancer", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = condition.getIdentifier().get(0);
+        identifier = condition.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("201610015080000"); // MSH.7
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 3: DG1.3.2
-        identifier = condition.getIdentifier().get(1);
+        identifier = condition.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("Ovarian Cancer"); // DG1.3.2
@@ -385,11 +455,11 @@ public class Hl7IdentifierFHIRConversionTest {
 
         // Filler from ORC-3; OBX-3.2
         msg = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-              + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|||^^^^^626^5641111|^^^^^626^5647654||||||||N\r"
-              + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-              + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-              + "OBX|1|ST|DINnumber^^LSFUSERDATAE||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-              + "ORC|NW|PON001|FON001|PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|";
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|||^^^^^626^5641111|^^^^^626^5647654||||||||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+                + "OBX|1|ST|DINnumber^^LSFUSERDATAE||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+                + "ORC|NW|PON001|FON001|PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|";
         observation = ResourceUtils.getObservation(msg);
 
         // Expect a single identifier
@@ -405,11 +475,11 @@ public class Hl7IdentifierFHIRConversionTest {
 
         // Placer from ORC-2; OBX-3.1
         msg = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-              + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||||||||||N\r"
-              + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A||SF|K||||199501102300\r"
-              + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-              + "OBX|1|ST|DINnumber||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-              + "ORC|NW|PON001|||SC|D|1||20170825010500|MS|MS|||||";
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||||||||||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A||SF|K||||199501102300\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+                + "OBX|1|ST|DINnumber||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+                + "ORC|NW|PON001|||SC|D|1||20170825010500|MS|MS|||||";
         observation = ResourceUtils.getObservation(msg);
 
         // Expect a single identifier
@@ -438,32 +508,41 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 3 identifiers
         assertThat(report.hasIdentifier()).isTrue();
         assertThat(report.getIdentifier()).hasSize(3);
+        List<Identifier> identifiers = report.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        int posExtId = getIdentifierPositionByValue("20170825010500", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posFILLER = getIdentifierPositionByValue("FON001", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        int posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: extId with MSH-7
-        Identifier identifier = report.getIdentifier().get(0);
+        Identifier identifier = report.getIdentifier().get(posExtId);
         String value = identifier.getValue();
         String system = identifier.getSystem();
         assertThat(value).isEqualTo("20170825010500"); // MSH-7
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Filler
-        identifier = report.getIdentifier().get(1);
+        identifier = report.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("FON001"); // ORC-3.1
         assertThat(system).isEqualTo("urn:id:OE_PHIMS_Stage"); // ORC-3.2 any whitespace gets replaced with underscores
         CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 3: Placer
-        identifier = report.getIdentifier().get(2);
+        identifier = report.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
-
         assertThat(value).isEqualTo("PON001"); // ORC-2.1
         assertThat(system).isEqualTo("urn:id:LE"); // ORC-2.2
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Filler and placer from OBR
         diagnosticReport = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170825010500||ORU^R01|MSGID22102712|T|2.6\n"
@@ -476,32 +555,41 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 3 identifiers
         assertThat(report.hasIdentifier()).isTrue();
         assertThat(report.getIdentifier()).hasSize(3);
-
+        identifiers = report.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        posExtId = getIdentifierPositionByValue("20170825010500", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        posFILLER = getIdentifierPositionByValue("CD_000000", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        posPLACER = getIdentifierPositionByValue("CC_000000", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
         // Identifier 1: extId with MSH-7
-        identifier = report.getIdentifier().get(0);
+        identifier = report.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("20170825010500"); // MSH-7
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Filler
-        identifier = report.getIdentifier().get(1);
+        identifier = report.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD_000000"); // OBR-3.1
         assertThat(system).isNull(); // OBR-3.2 is empty
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 3: Placer
-        identifier = report.getIdentifier().get(2);
+        identifier = report.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
 
         assertThat(value).isEqualTo("CC_000000"); // OBR-2
         assertThat(system).isEqualTo("urn:id:OE_PHIMS_Stage"); // OBR-2.2
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
     }
 
     @Test
@@ -540,9 +628,15 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 2 identifiers
         assertThat(encounter.hasIdentifier()).isTrue();
         assertThat(encounter.getIdentifier()).hasSize(2);
+        List<Identifier> identifiers = encounter.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        int posVN1 = getIdentifierPositionByValue("8846511", identifiers);
+        assertThat(posVN1).isNotSameAs(-1);
+        int posVN2 = getIdentifierPositionByValue("POL8009", identifiers);
+        assertThat(posVN2).isNotSameAs(-1);
 
         // Identifier 1:
-        identifier = encounter.getIdentifier().get(0);
+        identifier = encounter.getIdentifier().get(posVN1);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("8846511"); // PV1-19
@@ -555,7 +649,7 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getDisplay()).isEqualTo("Visit number");
 
         // Identifier 2:
-        identifier = encounter.getIdentifier().get(1);
+        identifier = encounter.getIdentifier().get(posVN2);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("POL8009"); // PV1.50
@@ -662,23 +756,29 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 2 identifiers
         assertThat(procedure.hasIdentifier()).isTrue();
         assertThat(procedure.getIdentifier()).hasSize(2);
+        List<Identifier> identifiers = procedure.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        int posExtId = getIdentifierPositionByValue("P98", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posACME = getIdentifierPositionByValue("78654", identifiers);
+        assertThat(posACME).isNotSameAs(-1);
 
         // Identifier 1: PR1.19
-        Identifier identifier = procedure.getIdentifier().get(0);
+        Identifier identifier = procedure.getIdentifier().get(posExtId);
         String value = identifier.getValue();
         String system = identifier.getSystem();
         assertThat(value).isEqualTo("P98"); // PR1.19.1
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Visit number from PID-18
-        identifier = procedure.getIdentifier().get(1);
+        identifier = procedure.getIdentifier().get(posACME);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("78654"); // PID.18.1
         assertThat(system).isEqualTo("urn:id:ACME"); // PID.18.4
         CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Test: MSH.7 and PV1.19
         String procedureMSH = "MSH|^~\\&||Instance1|MCM||200911021022|Security|ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM|CDP|^4086::132:2A57:3C28^IPV6|^4086::132:2A57:3C25^IPV6|\n"
@@ -692,169 +792,206 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 2 identifiers
         assertThat(procedure.hasIdentifier()).isTrue();
         assertThat(procedure.getIdentifier()).hasSize(2);
+        identifiers = procedure.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        posExtId = getIdentifierPositionByValue("200911021022", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posVN = getIdentifierPositionByValue("8846511", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
 
         // Identifier 1: PR1
-        identifier = procedure.getIdentifier().get(0);
+        identifier = procedure.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("200911021022"); // MSH.7
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Visit number from PV1-19
-        identifier = procedure.getIdentifier().get(1);
+        identifier = procedure.getIdentifier().get(posVN);
         String valueOBR = identifier.getValue();
         system = identifier.getSystem();
         assertThat(valueOBR).isEqualTo("8846511"); // PV1.19.1
         assertThat(system).isNull(); // No System PV1.19.2 DNE
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
     }
 
-     @Test
-     public void documentReferenceIdentifierTest() {
-         // Filler and placer from ORC, extId from MSH-7
-         String documentReference =
-                 "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n" +
-                         "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
-                         "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
-                         "ORC|NW|PON001^LE|FON001^OE|PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n" +
-                         "OBR|1||CD_000000^IE|2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n" +
-                         "TXA|1||B45678||||||\n";
+    @Test
+    public void documentReferenceIdentifierTest() {
+        // Filler and placer from ORC, extId from MSH-7
+        String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+                +
+                "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
+                "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
+                "ORC|NW|PON001^LE|FON001^OE|PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n" +
+                "OBR|1||CD_000000^IE|2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n"
+                +
+                "TXA|1||B45678||||||\n";
 
         DocumentReference report = ResourceUtils.getDocumentReference(documentReference);
 
-         // Expect 3 identifiers
-         assertThat(report.hasIdentifier()).isTrue();
-         assertThat(report.getIdentifier()).hasSize(3);
+        // Expect 3 identifiers
+        assertThat(report.hasIdentifier()).isTrue();
+        assertThat(report.getIdentifier()).hasSize(3);
 
-         // Identifier 1: extID from MSH-7
-         Identifier identifier = report.getIdentifier().get(0);
-         String value = identifier.getValue();
-         String system = identifier.getSystem();
-         assertThat(value).isEqualTo("200911021022");  // MSH-7
-         assertThat(system).isEqualTo("urn:id:extID");
+        List<Identifier> identifiers = report.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        int posExtId = getIdentifierPositionByValue("200911021022", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posFILLER = getIdentifierPositionByValue("FON001", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        int posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
 
-         // Identifier 2: Filler
-         identifier = report.getIdentifier().get(1);
-         value = identifier.getValue();
-         system = identifier.getSystem();
-         assertThat(value).isEqualTo("FON001"); //ORC.3.1
-         assertThat(system).isEqualTo("urn:id:OE"); // ORC.3.2
-         CodeableConcept type = identifier.getType();
-         Coding coding = type.getCoding().get(0);
-         assertThat(type.getText()).isNull();
-         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
-         assertThat(coding.getCode()).isEqualTo("FILL");
-         assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
+        // Identifier 1: extID from MSH-7
+        Identifier identifier = report.getIdentifier().get(posExtId);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
+        assertThat(value).isEqualTo("200911021022"); // MSH-7
+        assertThat(system).isEqualTo("urn:id:extID");
 
-         // Identifier 3: Placer
-         Identifier identifier3 = report.getIdentifier().get(2);
-         value = identifier3.getValue();
-         system = identifier3.getSystem();
-         assertThat(value).isEqualTo("PON001"); //ORC.2.1
-         assertThat(system).isEqualTo("urn:id:LE"); // ORC.2.2
-         type = identifier3.getType();
-         coding = type.getCoding().get(0);
-         assertThat(type.getText()).isNull();
-         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
-         assertThat(coding.getCode()).isEqualTo("PLAC");
-         assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
+        // Identifier 2: Filler
+        identifier = report.getIdentifier().get(posFILLER);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("FON001"); //ORC.3.1
+        assertThat(system).isEqualTo("urn:id:OE"); // ORC.3.2
+        CodeableConcept type = identifier.getType();
+        Coding coding = type.getCoding().get(0);
+        assertThat(type.getText()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
+        assertThat(coding.getCode()).isEqualTo("FILL");
+        assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
 
-         // Filler from OBR, placer from TXA-14
-         documentReference =
-                 "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n" +
-                         "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
-                         "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
-                         "ORC|NW|||PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n" +
-                         "OBR|1||CD_000000^OE|2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n" +
-                         "TXA|1||B45678|||||||||||PON001^IE||\n";
-         report = ResourceUtils.getDocumentReference(documentReference);
+        // Identifier 3: Placer
+        Identifier identifier3 = report.getIdentifier().get(posPLACER);
+        value = identifier3.getValue();
+        system = identifier3.getSystem();
+        assertThat(value).isEqualTo("PON001"); //ORC.2.1
+        assertThat(system).isEqualTo("urn:id:LE"); // ORC.2.2
+        type = identifier3.getType();
+        coding = type.getCoding().get(0);
+        assertThat(type.getText()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
+        assertThat(coding.getCode()).isEqualTo("PLAC");
+        assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
 
-         // Expect 3 identifiers
-         assertThat(report.hasIdentifier()).isTrue();
-         assertThat(report.getIdentifier()).hasSize(3);
+        // Filler from OBR, placer from TXA-14
+        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+                +
+                "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
+                "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
+                "ORC|NW|||PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n" +
+                "OBR|1||CD_000000^OE|2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n"
+                +
+                "TXA|1||B45678|||||||||||PON001^IE||\n";
+        report = ResourceUtils.getDocumentReference(documentReference);
 
-         // Identifier 1: extID from MSH-7
-         identifier = report.getIdentifier().get(0);
-         value = identifier.getValue();
-         system = identifier.getSystem();
-         assertThat(value).isEqualTo("200911021022");  // MSH-7
-         assertThat(system).isEqualTo("urn:id:extID");
+        // Expect 3 identifiers
+        assertThat(report.hasIdentifier()).isTrue();
+        assertThat(report.getIdentifier()).hasSize(3);
 
-         // Identifier 2: Filler
-         identifier = report.getIdentifier().get(1);
-         value = identifier.getValue();
-         system = identifier.getSystem();
-         assertThat(value).isEqualTo("CD_000000"); //OBR.3.1
-         assertThat(system).isEqualTo("urn:id:OE"); // OBR.3.2
-         type = identifier.getType();
-         coding = type.getCoding().get(0);
-         assertThat(type.getText()).isNull();
-         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
-         assertThat(coding.getCode()).isEqualTo("FILL");
-         assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
+        identifiers = report.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        posExtId = getIdentifierPositionByValue("200911021022", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        posFILLER = getIdentifierPositionByValue("CD_000000", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
 
-         // Identifier 3: Placer
-         identifier3 = report.getIdentifier().get(2);
-         value = identifier3.getValue();
-         system = identifier3.getSystem();
-         assertThat(value).isEqualTo("PON001"); // TXA-14.1
-         assertThat(system).isEqualTo("urn:id:IE"); // TXA.14.2
-         type = identifier3.getType();
-         coding = type.getCoding().get(0);
-         assertThat(type.getText()).isNull();
-         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
-         assertThat(coding.getCode()).isEqualTo("PLAC");
-         assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
+        // Identifier 1: extID from MSH-7
+        identifier = report.getIdentifier().get(posExtId);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("200911021022"); // MSH-7
+        assertThat(system).isEqualTo("urn:id:extID");
 
-         // Placer from OBR, Filler from TXA-15
-         documentReference =
-                 "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n" +
-                         "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
-                         "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
-                         "ORC|NW|||PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n" +
-                         "OBR|1|CD_000000^OE||2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n" +
-                         "TXA|1||B45678||||||||||||PON001^IE\n";
-         report = ResourceUtils.getDocumentReference(documentReference);
+        // Identifier 2: Filler
+        identifier = report.getIdentifier().get(posFILLER);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("CD_000000"); //OBR.3.1
+        assertThat(system).isEqualTo("urn:id:OE"); // OBR.3.2
+        type = identifier.getType();
+        coding = type.getCoding().get(0);
+        assertThat(type.getText()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
+        assertThat(coding.getCode()).isEqualTo("FILL");
+        assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
 
-         // Expect 3 identifiers
-         assertThat(report.hasIdentifier()).isTrue();
-         assertThat(report.getIdentifier()).hasSize(3);
-         // Identifier 1: extID from MSH-7
-         identifier = report.getIdentifier().get(0);
-         value = identifier.getValue();
-         system = identifier.getSystem();
-         assertThat(value).isEqualTo("200911021022");  // MSH-7
-         assertThat(system).isEqualTo("urn:id:extID");
+        // Identifier 3: Placer
+        identifier3 = report.getIdentifier().get(posPLACER);
+        value = identifier3.getValue();
+        system = identifier3.getSystem();
+        assertThat(value).isEqualTo("PON001"); // TXA-14.1
+        assertThat(system).isEqualTo("urn:id:IE"); // TXA.14.2
+        type = identifier3.getType();
+        coding = type.getCoding().get(0);
+        assertThat(type.getText()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
+        assertThat(coding.getCode()).isEqualTo("PLAC");
+        assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
 
-         // Identifier 2: Filler
-         identifier3 = report.getIdentifier().get(1);
-         value = identifier3.getValue();
-         system = identifier3.getSystem();
-         assertThat(value).isEqualTo("PON001"); // TXA-15.1
-         assertThat(system).isEqualTo("urn:id:IE"); // TXA.15.2
-         type = identifier3.getType();
-         coding = type.getCoding().get(0);
-         assertThat(type.getText()).isNull();
-         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
-         assertThat(coding.getCode()).isEqualTo("FILL");
-         assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
+        // Placer from OBR, Filler from TXA-15
+        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+                +
+                "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
+                "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
+                "ORC|NW|||PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n" +
+                "OBR|1|CD_000000^OE||2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n"
+                +
+                "TXA|1||B45678||||||||||||FON001^IE\n";
+        report = ResourceUtils.getDocumentReference(documentReference);
 
-         // Identifier 3: Placer
-         identifier = report.getIdentifier().get(2);
-         value = identifier.getValue();
-         system = identifier.getSystem();
-         assertThat(value).isEqualTo("CD_000000"); //OBR.2.1
-         assertThat(system).isEqualTo("urn:id:OE"); // OBR.2.2
-         type = identifier.getType();
-         coding = type.getCoding().get(0);
-         assertThat(type.getText()).isNull();
-         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
-         assertThat(coding.getCode()).isEqualTo("PLAC");
-         assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
-     }
+        // Expect 3 identifiers
+        assertThat(report.hasIdentifier()).isTrue();
+        assertThat(report.getIdentifier()).hasSize(3);
 
-     
+        identifiers = report.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        posExtId = getIdentifierPositionByValue("200911021022", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        posFILLER = getIdentifierPositionByValue("FON001", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        posPLACER = getIdentifierPositionByValue("CD_000000", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
+
+        // Identifier 1: extID from MSH-7
+        identifier = report.getIdentifier().get(posExtId);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("200911021022"); // MSH-7
+        assertThat(system).isEqualTo("urn:id:extID");
+
+        // Identifier 2: Filler
+        identifier3 = report.getIdentifier().get(posFILLER);
+        value = identifier3.getValue();
+        system = identifier3.getSystem();
+        assertThat(value).isEqualTo("FON001"); // TXA-15.1
+        assertThat(system).isEqualTo("urn:id:IE"); // TXA.15.2
+        type = identifier3.getType();
+        coding = type.getCoding().get(0);
+        assertThat(type.getText()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
+        assertThat(coding.getCode()).isEqualTo("FILL");
+        assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
+
+        // Identifier 3: Placer
+        identifier = report.getIdentifier().get(posPLACER);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("CD_000000"); //OBR.2.1
+        assertThat(system).isEqualTo("urn:id:OE"); // OBR.2.2
+        type = identifier.getType();
+        coding = type.getCoding().get(0);
+        assertThat(type.getText()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
+        assertThat(coding.getCode()).isEqualTo("PLAC");
+        assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
+    }
+
     @Test
     public void serviceRequestIdentifierTest1() {
         // Test 1 removed:  OMP_O09 messages do not create a service request
@@ -862,12 +999,13 @@ public class Hl7IdentifierFHIRConversionTest {
         // Test 2:
         //  - Visit number with PID-18
         //  - filler and placer from OBR
-        String serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n" +
+        String serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
+                +
                 "PID|1||000054321^^^MRN|||||||||||||M|CAT|78654||||N\n" +
                 "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n" +
                 // ORC.4 is not used as an identifier
                 "ORC||||PG1234567^MYPG||E|^Q6H^D10^^^R\n" +
-                "OBR|1|CD150920001336^OE|CD150920001336^IE|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||";
+                "OBR|1|CD150920001336^OE|CD150920001337^IE|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||";
 
         ServiceRequest serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
@@ -875,40 +1013,54 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
 
+        List<Identifier> identifiers = serviceReq.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        int posVN = getIdentifierPositionByValue("78654", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        int posFILLER = getIdentifierPositionByValue("CD150920001337", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        int posPLACER = getIdentifierPositionByValue("CD150920001336", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
+
         // Identifier 1: visit number
-        Identifier identifier = serviceReq.getIdentifier().get(0);
+        Identifier identifier = serviceReq.getIdentifier().get(posVN);
         String value = identifier.getValue();
         String system = identifier.getSystem();
         assertThat(value).isEqualTo("78654"); // PID.18
         assertThat(system).isNull();
         CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: filler
-        identifier = serviceReq.getIdentifier().get(1);
+        identifier = serviceReq.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
-        assertThat(value).isEqualTo("CD150920001336"); // OBR.3.1
+        assertThat(value).isEqualTo("CD150920001337"); // OBR.3.1
         assertThat(system).isEqualTo("urn:id:IE"); // OBR.3.2
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         //Identifier 3: placer
-        identifier = serviceReq.getIdentifier().get(2);
+        identifier = serviceReq.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD150920001336"); // OBR.2.1
         assertThat(system).isEqualTo("urn:id:OE"); // OBR.2.2
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Test 3:
         //  - Visit number with PV1-19
         //  - filler from OBR
         //  - placer from ORC
-        serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n" +
+        serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
+                +
                 "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
-                "PV1||I|6N^1234^A^GENERAL HOSPITAL2|||||||SUR||||||||S|8846511|A|||||||||||||||||||SF|K||||20170215080000\n" +
+                "PV1||I|6N^1234^A^GENERAL HOSPITAL2|||||||SUR||||||||S|8846511|A|||||||||||||||||||SF|K||||20170215080000\n"
+                +
                 "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n" +
                 "ORC||PON001||||E|^Q6H^D10^^^R\n" +
                 "OBR|1||CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||";
@@ -918,36 +1070,46 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 3 identifiers
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
+        identifiers = serviceReq.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("8846511", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posFILLER = getIdentifierPositionByValue("CD150920001336", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: visit number
-        identifier = serviceReq.getIdentifier().get(0);
+        identifier = serviceReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("8846511"); // PV1.19
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: filler
-        identifier = serviceReq.getIdentifier().get(1);
+        identifier = serviceReq.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD150920001336"); // OBR.3.1
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         //Identifier 3: placer
-        identifier = serviceReq.getIdentifier().get(2);
+        identifier = serviceReq.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("PON001"); // ORC.2.1
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
     }
-
 
     // NOTE: ORU_RO1 records do not create the ServiceRequest directly.  They create a DiagnosticReport and it creates the ServiceRequest.
     // This test makes sure the specification for ORU_RO1.DiagnosticReport is specifying PID and PV1 correctly in AdditionalSegments.
@@ -957,16 +1119,16 @@ public class Hl7IdentifierFHIRConversionTest {
         //  - Visit number with PV1.19
         //  - filler and placer from OBR
         String serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
-        // PID.18 is ignored as visit number identifier because PV1.19 is present
-        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-        // PV1.19 is used as the identifier visit number
-        + "PV1|1|E|||||||||||||||||78654||||||||||||||||||||||||||\n"
-        //  1. ORC.2 empty so OBR.2 is used
-        //  2. ORC.3 empty so OBR.3 is used
-        + "ORC|RE|||ML18267-C00001^Beaker||||||||||||||||||||||||||||||||||\n"
-        //  10. OBR.3 used for Filler 
-        //  11. OBR.2 used for Placer
-        + "OBR|1|CD150920001336^OE|CD150920001336^IE|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||||||||||||||||||||||||||||||||||||||\n";
+                // PID.18 is ignored as visit number identifier because PV1.19 is present
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                // PV1.19 is used as the identifier visit number
+                + "PV1|1|E|||||||||||||||||78654||||||||||||||||||||||||||\n"
+                //  1. ORC.2 empty so OBR.2 is used
+                //  2. ORC.3 empty so OBR.3 is used
+                + "ORC|RE|||ML18267-C00001^Beaker||||||||||||||||||||||||||||||||||\n"
+                //  10. OBR.3 used for Filler 
+                //  11. OBR.2 used for Placer
+                + "OBR|1|CD150920001336^OE|CD150920001337^IE|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||||||||||||||||||||||||||||||||||||||\n";
 
         ServiceRequest serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
@@ -974,98 +1136,120 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
 
+        List<Identifier> identifiers = serviceReq.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        int posVN = getIdentifierPositionByValue("78654", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        int posFILLER = getIdentifierPositionByValue("CD150920001337", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        int posPLACER = getIdentifierPositionByValue("CD150920001336", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
+
         // Identifier 1: visit number should be set by PV1.19
-        Identifier identifier = serviceReq.getIdentifier().get(0);
+        Identifier identifier = serviceReq.getIdentifier().get(posVN);
         String value = identifier.getValue();
         String system = identifier.getSystem();
         assertThat(value).isEqualTo("78654"); // PV1.19
         assertThat(system).isNull();
         CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: filler
-        identifier = serviceReq.getIdentifier().get(1);
+        identifier = serviceReq.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
-        assertThat(value).isEqualTo("CD150920001336"); // OBR.3.1
+        assertThat(value).isEqualTo("CD150920001337"); // OBR.3.1
         assertThat(system).isEqualTo("urn:id:IE"); // OBR.3.2
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         //Identifier 3: placer
-        identifier = serviceReq.getIdentifier().get(2);
+        identifier = serviceReq.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD150920001336"); // OBR.2.1
         assertThat(system).isEqualTo("urn:id:OE"); // OBR.2.2
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Test 2
         //  - Visit number with PID.18
         //  - filler from ORC
         //  - placer from ORC
-        serviceRequest = 
-        "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
-        // PID.18 is used as backup identifier visit number because PV1.19 is empty
-        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||665544||||||||||||\n"
-        // PV1.19 is empty and not used as visit number identifier 
-        + "PV1|1|E|||||||||||||||||||||||||||||||||||||||||||\n"
-        //  1. ORC.2 is used as Placer because it has priority over OBR.2
-        //  1. ORC.3 is used as Filler because it has priority over OBR.3
-        + "ORC|RE|248648498|248648499|ML18267-C00001^Beaker||||||||||||||||||||||||||||||||||||\n"
-        //  10. OBR.2 ignored as Placer
-        //  11. OBR.3 ignored as Filler
-        + "OBR|1|CD150920001336|CD150920001336|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||||||||||\n";
+        serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
+                // PID.18 is used as backup identifier visit number because PV1.19 is empty
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||665544||||||||||||\n"
+                // PV1.19 is empty and not used as visit number identifier 
+                + "PV1|1|E|||||||||||||||||||||||||||||||||||||||||||\n"
+                //  1. ORC.2 is used as Placer because it has priority over OBR.2
+                //  1. ORC.3 is used as Filler because it has priority over OBR.3
+                + "ORC|RE|248648498|248648499|ML18267-C00001^Beaker||||||||||||||||||||||||||||||||||||\n"
+                //  10. OBR.2 ignored as Placer
+                //  11. OBR.3 ignored as Filler
+                + "OBR|1|CD150920001336|CD150920001336|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||||||||||\n";
 
         serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
         // Expect 3 identifiers
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
+        identifiers = serviceReq.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("665544", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posFILLER = getIdentifierPositionByValue("248648499", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        posPLACER = getIdentifierPositionByValue("248648498", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: visit number should be set by PID.18
-        identifier = serviceReq.getIdentifier().get(0);
+        identifier = serviceReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("665544"); // PID.18
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: filler
-        identifier = serviceReq.getIdentifier().get(1);
+        identifier = serviceReq.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("248648499"); // ORC.3
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         //Identifier 3: placer
-        identifier = serviceReq.getIdentifier().get(2);
+        identifier = serviceReq.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("248648498"); // ORC.2
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Test 3:
         //  - MSH.7 as the visit number
         //  - filler from ORC
         //  - placer from ORC
-        serviceRequest =  "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
-        // PID.18 is empty so MSH.7 with be used as backup identifier visit number 
-        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-        // PV1.19 is empty so MSH.7 with be used as backup identifier visit number 
-        + "PV1|1|E|||||||||||||||||||||||||||||||||||||||||||\n"
-        //  1. ORC.2 is used as Placer because it has priority over OBR.2
-        //  1. ORC.3 is used as Filler because it has priority over OBR.3
-        + "ORC|RE|222298|222299|ML18267-C00001^Beaker||||||||||||||||||||||||||||\n"
-        //  10. OBR.2 ignored as Placer
-        //  11. OBR.3 ignored as Filler
-        + "OBR|1|||83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||||||||||||||||||||||||||||||||||||||\n";
+        serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
+                // PID.18 is empty so MSH.7 with be used as backup identifier visit number 
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                // PV1.19 is empty so MSH.7 with be used as backup identifier visit number 
+                + "PV1|1|E|||||||||||||||||||||||||||||||||||||||||||\n"
+                //  1. ORC.2 is used as Placer because it has priority over OBR.2
+                //  1. ORC.3 is used as Filler because it has priority over OBR.3
+                + "ORC|RE|222298|222299|ML18267-C00001^Beaker||||||||||||||||||||||||||||\n"
+                //  10. OBR.2 ignored as Placer
+                //  11. OBR.3 ignored as Filler
+                + "OBR|1|||83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||||||||||||||||||||||||||||||||||||||\n";
 
         serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
@@ -1073,35 +1257,49 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
 
+        // Expect 3 identifiers
+        assertThat(serviceReq.hasIdentifier()).isTrue();
+        assertThat(serviceReq.getIdentifier()).hasSize(3);
+        identifiers = serviceReq.getIdentifier();
+        // Match the three id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("20180924152907", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posFILLER = getIdentifierPositionByValue("222299", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        posPLACER = getIdentifierPositionByValue("222298", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
+
         // Identifier 1: visit number should be set by MSH.7
-        identifier = serviceReq.getIdentifier().get(0);
+        identifier = serviceReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("20180924152907"); // MSH.7
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: filler
-        identifier = serviceReq.getIdentifier().get(1);
+        identifier = serviceReq.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("222299"); // ORC.3
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         //Identifier 3: placer
-        identifier = serviceReq.getIdentifier().get(2);
+        identifier = serviceReq.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("222298"); // ORC.2
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
     }
-
 
     @Test
     public void medicationRequestIdentifierTest() {
@@ -1116,40 +1314,53 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 4 identifiers
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(4);
+        List<Identifier> identifiers = medReq.getIdentifier();
+        // Match the four id's to position; we can't depend on an order.
+        int posVN = getIdentifierPositionByValue("78654", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        int posExtId = getIdentifierPositionByValue("RX700001", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posFILLER = getIdentifierPositionByValue("CD2017071101", identifiers);
+        assertThat(posFILLER).isNotSameAs(-1);
+        int posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        Identifier identifier = medReq.getIdentifier().get(0);
+        Identifier identifier = medReq.getIdentifier().get(posVN);
         String value = identifier.getValue();
         String system = identifier.getSystem();
         assertThat(value).isEqualTo("78654"); // PID.18.1, since no PV1.19.1 in this message
         assertThat(system).isNull();
         CodeableConcept type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: extID based on RXO-1.1
-        identifier = medReq.getIdentifier().get(1);
+        identifier = medReq.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("RX700001"); // RXO-1.1
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 3: Filler
-        identifier = medReq.getIdentifier().get(2);
+        identifier = medReq.getIdentifier().get(posFILLER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD2017071101"); // ORC-3.1
         assertThat(system).isEqualTo("urn:id:RX"); // ORC-3.2 any whitespace gets replaced with underscores
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 4: Placer
-        identifier = medReq.getIdentifier().get(3);
+        identifier = medReq.getIdentifier().get(posPLACER);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("PON001"); // ORC-3.1
         assertThat(system).isEqualTo("urn:id:OE"); // ORC-3.2 any whitespace gets replaced with underscores
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Test: Visit number from PV1-19, extID from RXO-1.1 and RXO-1.3
         medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||OMP^O09|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
@@ -1163,17 +1374,25 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(2);
 
+        identifiers = medReq.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("789789", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posExtId = getIdentifierPositionByValue("RX700001-ABC", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(0);
+        identifier = medReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("789789"); // PV1.19
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: extID based on RXO-1.1 and RX-O1.3
-        identifier = medReq.getIdentifier().get(1);
+        identifier = medReq.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("RX700001-ABC"); // RXO-1.1 and RXO-1.3
@@ -1190,31 +1409,41 @@ public class Hl7IdentifierFHIRConversionTest {
         // Expect 3 identifiers
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(3);
+        identifiers = medReq.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("20170215080000", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posExtId = getIdentifierPositionByValue("DOCUSATE SODIUM 100 MG CAPSULE", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+        int posRX = getIdentifierPositionByValue("CD2017071101", identifiers);
+        assertThat(posRX).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(0);
+        identifier = medReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("20170215080000"); // MSH-7
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: extID based on RXO-1.2
-        identifier = medReq.getIdentifier().get(1);
+        identifier = medReq.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("DOCUSATE SODIUM 100 MG CAPSULE"); // RXO-1.2
         assertThat(system).isEqualTo("urn:id:extID");
 
-        // Identifier 3: Filler
-        identifier = medReq.getIdentifier().get(2);
+        // Identifier 3: RX
+        identifier = medReq.getIdentifier().get(posRX);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD2017071101"); // ORC.3.1
         assertThat(system).isEqualTo("urn:id:RX"); // ORC-3.2 any whitespace gets replaced with underscores
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Test: Visit number from MSH-7, no RXO-1
         medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||RDE^O11^RDE_O11|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
@@ -1229,22 +1458,30 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(2);
 
+        identifiers = medReq.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("20170215080000", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posExtId = getIdentifierPositionByValue("999-NDC", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(0);
+        identifier = medReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("20170215080000"); // MSH-7
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-        
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+
         // Identifier 2: extID based on RXE-2.1 and RXE-2.3
-        identifier = medReq.getIdentifier().get(1);
+        identifier = medReq.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("999-NDC"); // RXE-2.1 and RXE-2.3
         assertThat(system).isEqualTo("urn:id:extID");
-        
+
         // Test: Visit number from PV1-19, extID from RXE-2.1 and RXE-2.3
         medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||RDE^O11^RDE_O11|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "PID|1||000054321^^^MRN|||||||||||||||78654\r"
@@ -1257,17 +1494,25 @@ public class Hl7IdentifierFHIRConversionTest {
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(2);
 
+        identifiers = medReq.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        posVN = getIdentifierPositionByValue("789789", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        posExtId = getIdentifierPositionByValue("999-NDC", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(0);
+        identifier = medReq.getIdentifier().get(posVN);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("789789"); // PV1.19
         assertThat(system).isNull();
         type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number", "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Identifier 2: extID based on RXE-2.1 and RXE-2.3
-        identifier = medReq.getIdentifier().get(1);
+        identifier = medReq.getIdentifier().get(posExtId);
         value = identifier.getValue();
         system = identifier.getSystem();
         assertThat(value).isEqualTo("999-NDC"); // RXE-2.1 and RXE-2.3
@@ -1279,6 +1524,16 @@ public class Hl7IdentifierFHIRConversionTest {
     public void medicationAdministration_identifier_test() {
         // TODO
         // Currently no messages generate MedicationAdministration resources
+    }
+
+    private static int getIdentifierPositionByValue(String value, List<Identifier> identifiers) {
+        for (int i = 0; i < identifiers.size(); i++) {
+            if (value.contains(identifiers.get(i).getValue())) {
+                return i;
+            }
+        }
+        return -1;
+
     }
 
 }


### PR DESCRIPTION
This fixes service requests mixing values.
It does not fix document references mixing service request values.
A TODO is left in the code for future reference, as well as tests with expected results.