### PR TITLE
#336b NTE for MedReqs, ORM_O01 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The converter supports the following message types/events:
 * MDM_T02 - Original Document Notifcication and Content
 * MDM_T06 - Document Addendum Notification and Content
 * OMP_O09 - Pharmacy/Treatment Order
+* ORM_O01 - General Order Message
 * ORU_R01 - Observation Reporting: Observation and Result Transmission (Laboratory)
 * PPR_PC1 - Patient Problem: Add Problem
 * RDE_O11 - Pharmacy/Treatment Encoded Order

--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -195,7 +195,7 @@ evidence:
 ```
 
 ### Expressions Types
-The extraction logic for each field can be defined by using expressions. This component supports 4 different type of expressions. All expressions have the following attributes:
+The extraction logic for each field can be defined by using expressions. This component supports several different types of expressions. All expressions have the following attributes:
 * type: DEFAULT - Object <br>
   Represents the class type for the final return value extracted for the field.
 * specs: DEFAULT - NONE<br>
@@ -217,7 +217,8 @@ The extraction logic for each field can be defined by using expressions. This co
   Generates an output list output for all values of the specification. If this value is false, then first valid value of spec would be used for evaluation.
 * constants: DEFAULT - EMPTY<br>
   List of Constants (string values) which can be used during the extraction process.
-* evaluateLater:  DEFAULT: false, If evaluate latter is true then the resource that has this expression will be evaluated _except_ for this expression and will re-evaluate this expression _after_ all the other resources are evaluated. NOTE: this feature currently should only be used for expressions in main resource templates (example Patient, Encounter, Observation etc) and not in datatype templates (example: Coding, Address etc).
+* evaluateLater:  DEFAULT: false, If evaluate latter is true then the resource that has this expression will be evaluated _except_ for this expression and will re-evaluate this expression _after_ all the other resources are evaluated. NOTE: this feature currently should only be used for expressions in main resource templates (example Patient, Encounter, Observation etc) and not in datatype templates (example: Coding, Address etc). 
+* useGroup:  if true, only segments of the same group are used. 
 * expressions: DEFAULT - EMPTY<br>
   Elements to create as a subset of the element, when `expressionType: nested`.  Usually a list or a map.
 * expressionsMap: DEFAULT - EMPTY<br>
@@ -281,6 +282,8 @@ Note: $NULL is reserved as the value `null` for comparison and variable assignme
             code: String, MSH.9.2
             display: $NULL
  ```
+
+Variables are scoped to the resource expression they are created in and all children of the resource.  A variable created in an expression is local to that expression for that instance and its children.  Care should be taken to keep variables sufficiently unique to avoid contamination.
 
 #### Condition
 Conditions evaluate to true or false.<br>

--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -219,16 +219,23 @@ public class Hl7RelatedGeneralUtils {
         else return null;
     }
 
+    // Concatenates strings with a delimeter character(s) 
+    // Used for NTEs and OBX of type TX
     public static String concatenateWithChar(Object input, String delimiterChar) {
-        // Engine converts the delimiter character to a String; need to fix escaped characters
-        // as they become 2 separate characters rather than 1. 
-        // Currently handling '\n' specifically, have not found a more general solution.
-        String delimiter = delimiterChar;
-        if (delimiterChar.equals("\\n")) {
-            delimiter = Character.toString('\n');
-        }
+        // Engine converts the delimiter character(s) to a String.
+        // We need to fix escaped characters because YAML parsing sees every character as literal 
+        // and passes them in as 2 separate characters rather than 1. 
+        // Example '\n' is not reduced to 10 linefeed, but comes in as 92 78, a literal backslash n
+        // We want to replace 92 78 '\n' as 10 linefeed, 
+        // but want input double backslash 92 92 78 '\\n' to remain as literal 
+        // Currently only \n linefeed is handled.
 
-        return Hl7DataHandlerUtil.getStringValue(input, true, delimiter, false);
+        // Use this regex: r"(?<!\\)\\n|\n" but must double up backslashes in java string
+        String delimiter = delimiterChar.replaceAll("(?<!\\\\)\\\\n|\\n", "\n");
+
+        String result = Hl7DataHandlerUtil.getStringValue(input, true, delimiter, false);
+        return result;
+        // return Hl7DataHandlerUtil.getStringValue(input, true, delimiter, false);
     }
 
     public static List<String> makeStringArray(String... strs) {

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,4 +1,4 @@
 base.path.resource=
-supported.hl7.messages=ADT_A01, ADT_A08, ADT_A34, ADT_A40, MDM_T02, MDM_T06, OMP_O09, ORU_R01, PPR_PC1, RDE_O11, RDE_O25, VXU_V04
+supported.hl7.messages=ADT_A01, ADT_A08, ADT_A34, ADT_A40, MDM_T02, MDM_T06, ORM_O01, OMP_O09, ORU_R01, PPR_PC1, RDE_O11, RDE_O25, VXU_V04
 default.zoneid=+08:00
 additional.conceptmap.file=

--- a/src/main/resources/hl7/message/OMP_O09.yml
+++ b/src/main/resources/hl7/message/OMP_O09.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -44,6 +44,7 @@ resources:
     additionalSegments:
       - .ORC
       - .COMPONENT.RXC
+      - .NTE
       - MSH
       - PATIENT.PATIENT_VISIT.PV1
       - PATIENT.PID
@@ -55,8 +56,6 @@ resources:
     additionalSegments:
       - MSH
 
-
-
   - resourceName: Observation
     segment: .OBSERVATION.OBX
     group: ORDER
@@ -66,3 +65,5 @@ resources:
     additionalSegments:
       - .ORC
       - MSH
+      - .OBSERVATION.NTE 
+ 

--- a/src/main/resources/hl7/message/ORM_O01.yml
+++ b/src/main/resources/hl7/message/ORM_O01.yml
@@ -93,6 +93,7 @@ resources:
     resourcePath: resource/DocumentReference
     additionalSegments:
       - ORDER.ORDER_DETAIL.OBR
+      - ORDER.ORDER_DETAIL.OBSERVATION.OBX
       - PATIENT.PATIENT_VISIT.PV1
       - MSH
       - PATIENT.PID

--- a/src/main/resources/hl7/message/ORM_O01.yml
+++ b/src/main/resources/hl7/message/ORM_O01.yml
@@ -33,15 +33,6 @@ resources:
             - .PATIENT_VISIT.PV2
             - MSH
             - ORDER_DETAIL.OBSERVATION.OBX
-
-  - resourceName: Observation
-    segment: .ORDER_DETAIL.OBSERVATION.OBX
-    resourcePath: resource/Observation
-    group: ORDER
-    repeats: true
-    isReferenced: true
-    additionalSegments:
-            - MSH
     
   - resourceName: AllergyIntolerance
     segment: .AL1
@@ -58,6 +49,32 @@ resources:
     repeats: true
     additionalSegments:
       - MSH
+
+  - resourceName: ServiceRequest
+    segment: .ORC
+    group: ORDER
+    resourcePath: resource/ServiceRequest
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - .ORDER_DETAIL.OBR
+      - .ORDER_DETAIL.NTE
+      - PATIENT_VISIT.PV1
+      - MSH
+      - PID
+
+  # This OBX is for the Order Observation
+  - resourceName: Observation
+    segment: .ORDER_DETAIL.OBSERVATION.OBX
+    group: ORDER
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - .ORC
+      - .ORDER_DETAIL.OBR
+      - MSH
+      - .ORDER_DETAIL.OBSERVATION.NTE   
 
   - resourceName: MedicationRequest
     segment: .ORDER_DETAIL.RXO
@@ -76,7 +93,6 @@ resources:
     resourcePath: resource/DocumentReference
     additionalSegments:
       - ORDER.ORDER_DETAIL.OBR
-      - ORDER.ORDER_DETAIL.OBSERVATION.OBX
       - PATIENT.PATIENT_VISIT.PV1
       - MSH
       - PATIENT.PID

--- a/src/main/resources/hl7/message/RDE_O11.yml
+++ b/src/main/resources/hl7/message/RDE_O11.yml
@@ -49,9 +49,11 @@ resources:
     additionalSegments:
       - MSH
       - .ORC
+      - .NTE
       - PATIENT.PATIENT_VISIT.PV1
       - PATIENT.PID
       # RXO not included on purpose, only want to use RXE for RDE messages
+      # RXO content and NTEs associated with RXO are not processed
 
   - resourceName: Observation
     segment: .OBSERVATION.OBX
@@ -62,3 +64,4 @@ resources:
     additionalSegments:
       - .ORC
       - MSH
+      - .OBSERVATION.NTE

--- a/src/main/resources/hl7/message/RDE_O25.yml
+++ b/src/main/resources/hl7/message/RDE_O25.yml
@@ -42,9 +42,11 @@ resources:
     additionalSegments:
       - MSH
       - .ORC
+      - .NTE
       - PATIENT.PATIENT_VISIT.PV1
       - PATIENT.PID
       # RXO not included on purpose, only want to use RXE for RDE messages
+      # RXO content and NTEs associated with RXO are not processed
 
   - resourceName: AllergyIntolerance
     segment: PATIENT.AL1
@@ -62,3 +64,4 @@ resources:
     additionalSegments:
       - .ORC
       - MSH
+      - .OBSERVATION.NTE

--- a/src/main/resources/hl7/resource/Condition.yml
+++ b/src/main/resources/hl7/resource/Condition.yml
@@ -188,6 +188,5 @@ note:
    valueOf: datatype/Annotation
    condition: $annotationText NOT_NULL
    expressionType: resource
-   # Note on separator: Must double back-slashes to create single backslash in string.
    vars:
-      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \\n')            
+      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')            

--- a/src/main/resources/hl7/resource/MedicationRequest.yml
+++ b/src/main/resources/hl7/resource/MedicationRequest.yml
@@ -162,6 +162,5 @@ note:
   valueOf: datatype/Annotation
   condition: $annotationText NOT_NULL
   expressionType: resource
-  # Note on separator: Must double back-slashes to create single backslash in string.
   vars:
-    annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \\n')  
+    annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')  

--- a/src/main/resources/hl7/resource/MedicationRequest.yml
+++ b/src/main/resources/hl7/resource/MedicationRequest.yml
@@ -158,3 +158,10 @@ dispenseRequest:
   vars:
     timestamp: ORC.15
 
+note:
+  valueOf: datatype/Annotation
+  condition: $annotationText NOT_NULL
+  expressionType: resource
+  # Note on separator: Must double back-slashes to create single backslash in string.
+  vars:
+    annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \\n')  

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -194,9 +194,8 @@ note_2:
    valueOf: datatype/Annotation
    condition: $annotationText NOT_NULL
    expressionType: resource
-   # Note on separator: Must double back-slashes to create single backslash in string.
    vars:
-      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \\n')
+      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')
 
 bodySite:
    valueOf: datatype/CodeableConcept

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -149,6 +149,5 @@ note:
    valueOf: datatype/Annotation
    condition: $annotationText NOT_NULL
    expressionType: resource
-   # Note on separator: Must double back-slashes to create single backslash in string.
    vars:
-      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \\n')            
+      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')            

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -7,6 +7,7 @@ package io.github.linuxforhealth.hl7.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -15,27 +16,53 @@ import org.slf4j.LoggerFactory;
 import org.hl7.fhir.r4.model.codesystems.EncounterStatus;
 import org.junit.jupiter.api.Test;
 
-
-
 public class Hl7RelatedGeneralUtilsTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Hl7RelatedGeneralUtilsTest.class);
 
   @Test
+  public void testConcatenateWithChar() {
+
+    ArrayList<Object> objects = new ArrayList<Object>();
+    String st = "AA";
+    objects.add(st);
+    st = "BB";
+    objects.add(st);
+
+    String concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \n");
+    assertThat(concatted).isEqualTo("AA  \nBB  \n");
+
+    // Simulate the input from YAML
+    // YAML doesn't reduce the '\n' to linefeed, but inputs 92 78, a literal backslash n
+    // For this test, we force the string to contain 32 32 92 78 by using a double backslash
+    concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \\n");
+    assertThat(concatted).isEqualTo("AA  \nBB  \n");
+
+    // Simulate the input from YAML
+    // For this test, we force the string to contain 32 32 92 92 78 by using a two double backslashes
+    // We want, in this case to assure that a double backslash input will be taken literally
+    concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \\\\n");
+    assertThat(concatted).isEqualTo("AA  \\\\nBB  \\\\n");
+
+    // Simulate the input from YAML
+    // For this test, we force the string to contain 32 92 78 32 92 78 32 by using double backslash
+    // This tests that both intended linefeeds in input " \n \n " are handled.
+    concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, " \\n \\n ");
+    assertThat(concatted).isEqualTo("AA \n \n BB \n \n ");
+  }
+
+  @Test
   public void test_generate_name() {
     String name = Hl7RelatedGeneralUtils.generateName("prefix", "first", "M", "family", "suffix");
     assertThat(name).isEqualTo("prefix first M family suffix");
-    LOGGER.debug("name="+name);
+    LOGGER.debug("name=" + name);
   }
-
 
   @Test
   public void test_generate_name_prefix_suffix_missing() {
     String name = Hl7RelatedGeneralUtils.generateName(null, "first", "M", "family", null);
     assertThat(name).isEqualTo("first M family");
   }
-
-
 
   @Test
   public void test_get_encounter_var1() {
@@ -44,14 +71,12 @@ public class Hl7RelatedGeneralUtilsTest {
     assertThat(name).isEqualTo(EncounterStatus.FINISHED.toCode());
   }
 
-
   @Test
   public void test_get_encounter_var2() {
 
     String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, "var2", "var3");
     assertThat(name).isEqualTo(EncounterStatus.ARRIVED.toCode());
   }
-
 
   @Test
   public void test_get_encounter_var3() {
@@ -67,7 +92,6 @@ public class Hl7RelatedGeneralUtilsTest {
     assertThat(name).isEqualTo(EncounterStatus.UNKNOWN.toCode());
   }
 
-
   @Test
   public void test_date_diff_valid_values_same_dates() {
 
@@ -75,7 +99,6 @@ public class Hl7RelatedGeneralUtilsTest {
         "2007-11-04T01:32:06.345+09:00");
     assertThat(diff).isEqualTo(0);
   }
-
 
   @Test
   public void test_date_diff_valid_values_1min_ahead() {
@@ -85,15 +108,13 @@ public class Hl7RelatedGeneralUtilsTest {
     assertThat(diff).isEqualTo(1);
   }
 
-
- @Test
+  @Test
   public void test_date_diff_valid_values_no_min() {
 
     Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-05",
         "2007-11-04T01:33:06.345+20:00");
     assertThat(diff).isNull();
   }
-
 
   @Test
   public void test_date_diff_null_values() {
@@ -102,16 +123,13 @@ public class Hl7RelatedGeneralUtilsTest {
     assertThat(diff).isNull();
   }
 
-
   @Test
   public void test_date_diff_incorrect_date_format() {
 
-    Long diff =
-        Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:33:06890",
-            "2007-11-04T01:33:06.345+09:00");
+    Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:33:06890",
+        "2007-11-04T01:33:06.345+09:00");
     assertThat(diff).isNull();
   }
-
 
   @Test
   public void test_splitting_values() {
@@ -119,8 +137,6 @@ public class Hl7RelatedGeneralUtilsTest {
     String val = Hl7RelatedGeneralUtils.split("5.9-8.4", "-", 0);
     assertThat(val).isEqualTo("5.9");
   }
-
-
 
   // ExtractHigh and ExtractLow assumes if there are two or more values, the first is low, the second is high,
   // but if there is only one value, it is the high
@@ -177,7 +193,6 @@ public class Hl7RelatedGeneralUtilsTest {
 
   }
 
-
   @Test
   public void test_makeStringArray() {
     // Test for 2
@@ -197,47 +212,47 @@ public class Hl7RelatedGeneralUtilsTest {
   public void test_getAddressUse() {
     String ANYTHING = "anything";
     // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C","", ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C","", null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",null, ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",null, null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,"Y", ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,"Y", null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,"Y", ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,"Y", null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C",ANYTHING, null)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",ANYTHING, "")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",ANYTHING, null)).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",null, "")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",null, null)).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,ANYTHING, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,ANYTHING, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,null, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,null, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA",null, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",ANYTHING, ANYTHING)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",null, ANYTHING)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",ANYTHING, null)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H",null, null)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",ANYTHING, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",ANYTHING, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",null, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B",null, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",ANYTHING, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",ANYTHING, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",null, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O",null, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",ANYTHING, ANYTHING)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",null, ANYTHING)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",ANYTHING, null)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI",null, null)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,null, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING,ANYTHING, null)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null,null, null)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", null)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", null, ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", null, null)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", null)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", ANYTHING)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", null)).isEqualTo("temp");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, null)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, "")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, null)).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, "")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, null)).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, "Y")).isEqualTo("old");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, ANYTHING)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, ANYTHING)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, null)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, null)).isEqualTo("home");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", ANYTHING, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", ANYTHING, null)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", null, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", null, null)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", ANYTHING, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", ANYTHING, null)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", null, ANYTHING)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", null, null)).isEqualTo("work");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, ANYTHING)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, ANYTHING)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, null)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, null)).isEqualTo("billing");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, null)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, null)).isEqualTo("");
 
   }
 
@@ -247,78 +262,97 @@ public class Hl7RelatedGeneralUtilsTest {
     // Inputs are XAD.7 Type, XAD.18 Type 
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
     assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "M")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M","")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M",null)).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M",ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", null)).isEqualTo("postal");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
     assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "V")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH","")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH",null)).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH",ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING,ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING,null)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(null,ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(null,null)).isEqualTo("");
-
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", null)).isEqualTo("physical");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, null)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, null)).isEqualTo("");
 
   }
 
   @Test
   public void test_getAddressDistrict() {
     String ANYTHING = "anything";
-    
+
     // Inputs are XAD.7 Type, XAD.18 Type 
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M","")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M",ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
     assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH","")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH",ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING,ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
+    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
   }
   // Note: Utility  Hl7RelatedGeneralUtils.getAddressDistrict is more effectively tested as part of Patient Address testing
 
   @Test
-  public void getFormattedTelecomNumberValue() {  
+  public void getFormattedTelecomNumberValue() {
     // Empty values return nothing
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("","","","","","")).isEmpty();
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "")).isEmpty();
     // Everything empty except XTN1 returns XTN1.
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","","","")).isEqualTo("111");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "", "", "")).isEqualTo("111");
     // Everything empty except XTN12 returns XTN12.
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("","","","","","112")).isEqualTo("112");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "112")).isEqualTo("112");
     // XTN12 takes priority over XTN1
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","","","112")).isEqualTo("112");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "", "", "112")).isEqualTo("112");
     // Country, Area, and Extension are ignored if there is no Local number
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("","22","333","","555","")).isEmpty();
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "22", "333", "", "555", "")).isEmpty();
     // XTN12 and XTN1 will be used if no local number
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","","555","")).isEqualTo("111");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("","22","333","","555","112")).isEqualTo("112");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "", "555", ""))
+        .isEqualTo("111");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "22", "333", "", "555", "112"))
+        .isEqualTo("112");
     // Country, Area, and Extension are used if there is a Local number and they exist, and XTN1 and XTN12 are ignored  
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","555","112")).isNotEmpty();
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","555","112")).contains("+22");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","555","112")).contains("333");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","555","112")).contains("4444");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","555","112")).contains("ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","555","112")).isEqualTo("+22 333 444 4444 ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","22","333","4444444","","112")).isEqualTo("+22 333 444 4444");  // Same rule without extension
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+        .isNotEmpty();
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+        .contains("+22");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+        .contains("333");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+        .contains("4444");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+        .contains("ext. 555");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+        .isEqualTo("+22 333 444 4444 ext. 555");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "", "112"))
+        .isEqualTo("+22 333 444 4444"); // Same rule without extension
     // Area, and Extension are used if there is a Local number, and XTN1 and XTN12 are ignored  
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","333","4444444","555","112")).isNotEmpty();
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","333","4444444","555","112")).contains("333");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","333","4444444","555","112")).contains("4444");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","333","4444444","555","112")).contains("ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","333","4444444","555","112")).isEqualTo("(333) 444 4444 ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","333","4444444","","112")).isEqualTo("(333) 444 4444");  // Same rule without extension
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+        .isNotEmpty();
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+        .contains("333");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+        .contains("4444");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+        .contains("ext. 555");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+        .isEqualTo("(333) 444 4444 ext. 555");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "", "112"))
+        .isEqualTo("(333) 444 4444"); // Same rule without extension
     // If local and country but no area, country is not prepended,only local is returned; XTN1 and XTN12 are ignored  
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","4444444","555","112")).isNotEmpty();
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","4444444","555","112")).contains("4444");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","4444444","555","112")).contains("ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","4444444","555","112")).isEqualTo("444 4444 ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111","","","4444444","","112")).isEqualTo("444 4444");  // Same rule without extension
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+        .isNotEmpty();
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+        .contains("4444");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+        .contains("ext. 555");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+        .isEqualTo("444 4444 ext. 555");
+    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "", "112"))
+        .isEqualTo("444 4444"); // Same rule without extension
   }
 
   @Test
   public void testGetFormatAsId() {
-   
+
     // Inputs are any string
     assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");
     assertThat(Hl7RelatedGeneralUtils.formatAsId("OMC")).isEqualTo("omc");

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
@@ -38,31 +38,29 @@ public class Hl7MDMMessageTest {
     // + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\n"
     // + "OBX|3|TX|05^Operative Report||                              <HOSPITAL ADDRESS2>||||||P\n";
 
-
     // This test assures we don't have data mixing in the placer / filler identifiers.
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void noMixingOfParamsInDocumentReference(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||MDM^T02|"+message+"|P|2.6\n"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-            + "PV1|1|O|2GY^2417^W||||D||||||||||OTW|<HospitalID>|||||||||||||||||||||||||20180115102400|20180118104500\n"
-            // ORC 2.1 is empty, ORC 3.1 is empty but ORC 3.2 has a system
-            // OBR 2.1 has a value, OBR 3.1 has a value
-            // We expect a placer of OBR 2.1 and no system because OBR 2.2 is the matched field and is empty
-            // We expect a filler of OBR 3.1 and no system because OBR 3.2 is the matched field and is empty (System in ORC 3.2 is ignored.)
-            + "ORC|NW||^SYS-AAA-ORC32||||^^^^^R|||||1992779250^TEST^DOCTOR-AAA|||||||||\n"
-            + "OBR|1|ID-AAA-OBR21|ID-AAA-OBR31|LAMIKP^AMIKACIN LEVEL, PEAK^83718|||||||L|||||||||||||RAD|O||^^^^^R||||||||\n"
-            // ORC 2.1 has value, ORC 3.1 is empty
-            // OBR 2.1 has a value and OBR 2.2 has a system, OBR 3.1 has a value
-            // We expect a placer of ORC 2.1 and no system because ORC 2.2 is the matched field and is empty (System in OBR 2.1 is ignored)
-            // We expect a filler of OBR 3.1 and system because OBR 3.2 is the matched field and has a system
-            + "ORC|NW|ID-BBB-ORC21|||||^^^^^R|||||1992779251^TEST^DOCTOR-BBB\n"
-            + "OBR|1|ID-BBB-OBR21^SYS-BBB-OBR22|ID-BBB-OBR31^SYS-BBB-OBR32|83718^HIGH-DENSITY LIPOPROTEIN (HDL)^NAMING2||||||||||||||||||||CAT|A||^^^20180204^^R||||||||\n"
-            + "TXA|1|05^Operative Report|TX|201801171442|5566^PAPLast^PAPFirst^J^^MD|201801171442|201801180346||<PHYSID>|<PHYSID>|MODL|<MESSAGEID>||4466^TRANSCLast^TRANSCFirst^J^^MD|<MESSAGEID>||P||AV\n"
-            + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\n"
-            + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\n"
-            + "OBX|3|TX|05^Operative Report||                              <HOSPITAL ADDRESS2>||||||P\n";
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||MDM^T02|" + message + "|P|2.6\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1|1|O|2GY^2417^W||||D||||||||||OTW|<HospitalID>|||||||||||||||||||||||||20180115102400|20180118104500\n"
+                // ORC 2.1 is empty, ORC 3.1 is empty but ORC 3.2 has a system
+                // OBR 2.1 has a value, OBR 3.1 has a value
+                // We expect a placer of OBR 2.1 and no system because OBR 2.2 is the matched field and is empty
+                // We expect a filler of OBR 3.1 and no system because OBR 3.2 is the matched field and is empty (System in ORC 3.2 is ignored.)
+                + "ORC|NW||^SYS-AAA-ORC32||||^^^^^R|||||1992779250^TEST^DOCTOR-AAA|||||||||\n"
+                + "OBR|1|ID-AAA-OBR21|ID-AAA-OBR31|LAMIKP^AMIKACIN LEVEL, PEAK^83718|||||||L|||||||||||||RAD|O||^^^^^R||||||||\n"
+                // ORC 2.1 has value, ORC 3.1 is empty
+                // OBR 2.1 has a value and OBR 2.2 has a system, OBR 3.1 has a value
+                // We expect a placer of ORC 2.1 and no system because ORC 2.2 is the matched field and is empty (System in OBR 2.1 is ignored)
+                // We expect a filler of OBR 3.1 and system because OBR 3.2 is the matched field and has a system
+                + "ORC|NW|ID-BBB-ORC21|||||^^^^^R|||||1992779251^TEST^DOCTOR-BBB\n"
+                + "OBR|1|ID-BBB-OBR21^SYS-BBB-OBR22|ID-BBB-OBR31^SYS-BBB-OBR32|83718^HIGH-DENSITY LIPOPROTEIN (HDL)^NAMING2||||||||||||||||||||CAT|A||^^^20180204^^R||||||||\n"
+                + "TXA|1|05^Operative Report|TX|201801171442|5566^PAPLast^PAPFirst^J^^MD|201801171442|201801180346||<PHYSID>|<PHYSID>|MODL|<MESSAGEID>||4466^TRANSCLast^TRANSCFirst^J^^MD|<MESSAGEID>||P||AV\n"
+                + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\n"
+                + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\n"
+                + "OBX|3|TX|05^Operative Report||                              <HOSPITAL ADDRESS2>||||||P\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -88,52 +86,53 @@ public class Hl7MDMMessageTest {
         // Three ID's for srDrAAA
         // Map of String arrays of expected (Value, System) 
         HashMap<String, List<String>> matchSrDrAAAidValuesSystems = new HashMap<String, List<String>>();
-        matchSrDrAAAidValuesSystems.put("VN", Arrays.asList("20180118111520",""));
-        matchSrDrAAAidValuesSystems.put("FILL", Arrays.asList("ID-AAA-OBR31",""));
-        matchSrDrAAAidValuesSystems.put("PLAC", Arrays.asList("ID-AAA-OBR21",""));
+        matchSrDrAAAidValuesSystems.put("VN", Arrays.asList("20180118111520", ""));
+        matchSrDrAAAidValuesSystems.put("FILL", Arrays.asList("ID-AAA-OBR31", ""));
+        matchSrDrAAAidValuesSystems.put("PLAC", Arrays.asList("ID-AAA-OBR21", ""));
         List<Identifier> identifiers = srDrAAA.getIdentifier();
         // Validate the note contents and references 
-        for(int idIndex=0; idIndex < identifiers.size(); idIndex++) {  // condIndex is index for condition
+        for (int idIndex = 0; idIndex < identifiers.size(); idIndex++) { // condIndex is index for condition
             // Get the list of Observation references
             Identifier ident = identifiers.get(idIndex);
             String code = ident.getType().getCodingFirstRep().getCode();
             assertThat(ident.getValue()).hasToString(matchSrDrAAAidValuesSystems.get(code).get(0));
             String system = ident.getSystem() == null ? "" : ident.getSystem();
             assertThat(system).hasToString(matchSrDrAAAidValuesSystems.get(code).get(1));
-        }  
+        }
 
         // Three ID's for srDrBBB
         // Map of String arrays of expected (Value, System) 
         HashMap<String, List<String>> matchSrDrBBBidValuesSystems = new HashMap<String, List<String>>();
-        matchSrDrBBBidValuesSystems.put("VN", Arrays.asList("20180118111520",""));
-        matchSrDrBBBidValuesSystems.put("FILL", Arrays.asList("ID-BBB-OBR31","urn:id:SYS-BBB-OBR32"));
-        matchSrDrBBBidValuesSystems.put("PLAC", Arrays.asList("ID-BBB-ORC21",""));
+        matchSrDrBBBidValuesSystems.put("VN", Arrays.asList("20180118111520", ""));
+        matchSrDrBBBidValuesSystems.put("FILL", Arrays.asList("ID-BBB-OBR31", "urn:id:SYS-BBB-OBR32"));
+        matchSrDrBBBidValuesSystems.put("PLAC", Arrays.asList("ID-BBB-ORC21", ""));
         identifiers = srDrBBB.getIdentifier();
         // Validate the note contents and references 
-        for(int idIndex=0; idIndex < identifiers.size(); idIndex++) {  // condIndex is index for condition
+        for (int idIndex = 0; idIndex < identifiers.size(); idIndex++) { // condIndex is index for condition
             // Get the list of Observation references
             Identifier ident = identifiers.get(idIndex);
             String code = ident.getType().getCodingFirstRep().getCode();
             assertThat(ident.getValue()).hasToString(matchSrDrBBBidValuesSystems.get(code).get(0));
             String system = ident.getSystem() == null ? "" : ident.getSystem();
             assertThat(system).hasToString(matchSrDrBBBidValuesSystems.get(code).get(1));
-        }  
+        }
 
         List<Resource> documentReferenceResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
         assertThat(documentReferenceResource).hasSize(1); // from TXA, OBX(type TX)
-        DocumentReference docRef = ResourceUtils.getResourceDocumentReference(documentReferenceResource.get(0), ResourceUtils.context);
-        
+        DocumentReference docRef = ResourceUtils.getResourceDocumentReference(documentReferenceResource.get(0),
+                ResourceUtils.context);
+
         // TODO: Solve the problem of data bleed when there is more than one ServiceRequest
         // Three ID's for DocRef
         // Map of String arrays of expected (Value, System)
         HashMap<String, List<String>> matchDocRefIdValuesSystems = new HashMap<String, List<String>>();
-        matchDocRefIdValuesSystems.put("EntityId", Arrays.asList("<MESSAGEID>",""));
-        matchDocRefIdValuesSystems.put("FILL", Arrays.asList("ID-AAA-OBR31","urn:id:SYS-BBB-OBR32")); // What we get - mix of SR1 and SR2
+        matchDocRefIdValuesSystems.put("EntityId", Arrays.asList("<MESSAGEID>", ""));
+        matchDocRefIdValuesSystems.put("FILL", Arrays.asList("ID-AAA-OBR31", "urn:id:SYS-BBB-OBR32")); // What we get - mix of SR1 and SR2
         // matchDocRefIdValuesSystems.put("FILL", Arrays.asList("ID-BBB-OBR31","urn:id:SYS-BBB-OBR32")); // What we think it should be
-        matchDocRefIdValuesSystems.put("PLAC", Arrays.asList("ID-BBB-ORC21","")); 
+        matchDocRefIdValuesSystems.put("PLAC", Arrays.asList("ID-BBB-ORC21", ""));
         identifiers = docRef.getIdentifier();
         // Validate the note contents and references 
-        for(int idIndex=0; idIndex < identifiers.size(); idIndex++) {  // condIndex is index for condition
+        for (int idIndex = 0; idIndex < identifiers.size(); idIndex++) { // condIndex is index for condition
             // Get the list of Observation references
             Identifier ident = identifiers.get(idIndex);
             if (ident.hasType()) {
@@ -142,27 +141,24 @@ public class Hl7MDMMessageTest {
                 String system = ident.getSystem() == null ? "" : ident.getSystem();
                 assertThat(system).hasToString(matchDocRefIdValuesSystems.get(code).get(1));
             }
-        }  
+        }
 
         List<Resource> practitioners = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
-        assertThat(practitioners).hasSize(7); 
+        assertThat(practitioners).hasSize(7);
 
         // Confirm that no extra resources are created
         assertThat(e.size()).isEqualTo(12);
     }
 
-
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_mininum_with_OBXtypeTXtoDocumenReference(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -183,14 +179,12 @@ public class Hl7MDMMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_mininum_with_OBXnotTX(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -214,16 +208,14 @@ public class Hl7MDMMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_mininum_with_multiple_OBXtypeTXtoDocumentReference(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r"
-            + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS>||||||P\r"
-            + "OBX|3|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r"
+                + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS>||||||P\r"
+                + "OBX|3|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -244,16 +236,14 @@ public class Hl7MDMMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_mininum_with_multipleOBXnotTX(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
-            + "OBX|2|ST|100||This is content|||||||X\r"
-            + "OBX|3|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
+                + "OBX|2|ST|100||This is content|||||||X\r"
+                + "OBX|3|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -277,16 +267,14 @@ public class Hl7MDMMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_ORDER_group_and_OBXtypeTX(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -311,22 +299,20 @@ public class Hl7MDMMessageTest {
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_ORDER_with_OBXnotTX(String message) throws IOException {
         // Also check NTE working for MDM messages.
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            // ServiceRequest NTE has a practitioner reference in NTE.5
-            + "NTE|1|O|TEST ORC/OBR NOTE AA line 1||Pract1ID^Pract1Last^Pract1First|\n" 
-            + "NTE|2|O|TEST NOTE AA line 2|\n"
-            + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
-            // Observation NTE has a practitioner reference in second NTE.5. Annotation uses the first valid NTE.5
-            + "NTE|1|L|TEST OBX NOTE BB line 1|\n" 
-            + "NTE|2|L|TEST NOTE BB line 2||Pract2ID^Pract2Last^Pract2First|\n"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                // ServiceRequest NTE has a practitioner reference in NTE.5
+                + "NTE|1|O|TEST ORC/OBR NOTE AA line 1||Pract1ID^Pract1Last^Pract1First|\n"
+                + "NTE|2|O|TEST NOTE AA line 2|\n"
+                + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
+                // Observation NTE has a practitioner reference in second NTE.5. Annotation uses the first valid NTE.5
+                + "NTE|1|L|TEST OBX NOTE BB line 1|\n"
+                + "NTE|2|L|TEST NOTE BB line 2||Pract2ID^Pract2Last^Pract2First|\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -345,7 +331,7 @@ public class Hl7MDMMessageTest {
         assertThat(serviceRequest.hasNote()).isTrue();
         assertThat(serviceRequest.getNote()).hasSize(1);
         assertThat(serviceRequest.getNote().get(0).getText())
-                .isEqualTo("TEST ORC/OBR NOTE AA line 1  \\nTEST NOTE AA line 2  \\n");
+                .isEqualTo("TEST ORC/OBR NOTE AA line 1  \nTEST NOTE AA line 2");
         assertThat(serviceRequest.getNote().get(0).hasAuthorReference()).isTrue();
 
         List<Resource> documentReferenceResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
@@ -354,13 +340,14 @@ public class Hl7MDMMessageTest {
         List<Resource> observationResources = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(observationResources).hasSize(1); // from OBX(not type TX)
         // Light check that Observation contains NTE for OBX;  Deep check of NTE in Hl7NoteFHIRConverterTest.
-        Observation observation = ResourceUtils.getResourceObservation(observationResources.get(0), ResourceUtils.context);
+        Observation observation = ResourceUtils.getResourceObservation(observationResources.get(0),
+                ResourceUtils.context);
         // Validate the note contents and reference existance.
         assertThat(observation.hasNote()).isTrue();
         assertThat(observation.getNote()).hasSize(1);
         assertThat(observation.getNote().get(0).getText())
-                .isEqualTo("TEST OBX NOTE BB line 1  \\nTEST NOTE BB line 2  \\n");
-        assertThat(observation.getNote().get(0).hasAuthorReference()).isTrue(); 
+                .isEqualTo("TEST OBX NOTE BB line 1  \nTEST NOTE BB line 2");
+        assertThat(observation.getNote().get(0).hasAuthorReference()).isTrue();
 
         // Two Practitioners, one for the serviceRequest, one for the Observation
         List<Resource> practitioners = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
@@ -373,22 +360,20 @@ public class Hl7MDMMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_multiple_ORDERs_and_multiple_OBXtypeTX(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r"
-            + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS>||||||P\r"
-            + "OBX|3|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "TXA|1|OP^Operative Report|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|TX|05^Operative Report||                        <HOSPITAL NAME>||||||P\r"
+                + "OBX|2|TX|05^Operative Report||                             <HOSPITAL ADDRESS>||||||P\r"
+                + "OBX|3|TX|05^Operative Report||                             <HOSPITAL ADDRESS2>||||||P\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -412,22 +397,20 @@ public class Hl7MDMMessageTest {
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
     public void test_mdm_multiple_ORDERs_and_multiple_OBXnotTX(String message) throws IOException {
-        String hl7message =
-            "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
-            + "EVN||20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
-            + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
-            + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
-            + "OBX|2|ST|100||This is content|||||||X\r"
-            + "OBX|3|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r"
-            ;
+        String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
+                + "EVN||20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||O||||||||||||||||||||||||||||||||||||||||||199501102300\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "ORC|NW|622470H432|||||^^^^^R||||||||||||||\r"
+                + "OBR|1|622470H432|102397CE432|||20170725143849|20180102|||||||||||||||||RAD|O||^^^^^R||||REASON_ID_1^REASON_TEXT_1||||\r"
+                + "TXA|1|HP^History and physical examination|TX||||201801171442||||||||||||AV|||||\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
+                + "OBX|2|ST|100||This is content|||||||X\r"
+                + "OBX|3|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORMMessageTest.java
@@ -8,59 +8,39 @@ package io.github.linuxforhealth.hl7.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import io.github.linuxforhealth.hl7.segments.Hl7EncounterFHIRConversionTest;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import io.github.linuxforhealth.fhir.FHIRContext;
-import io.github.linuxforhealth.hl7.ConverterOptions;
-import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
-import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Hl7ORMMessageTest {
-  private static FHIRContext context = new FHIRContext();
-  private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
-  private static final Logger LOGGER = LoggerFactory.getLogger(Hl7ORMMessageTest.class);
 
+    @Test
+    public void test_ORMO01_patient_encounter_present() throws IOException {
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|IBMWATSON_LAB|IBM|20210407191758||ORM^O01|MSGID_e30a3471-7afd-4aa2-a3d5-e93fd89d24b3|T|2.3\n"
+                + "PID|1||0a1f7838-4230-4752-b8f6-948b07c38b25^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator||9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900|||||Account_0a1f7838-4230-4752-b8f6-948b07c38b25|123-456-7890||||BIRTH PLACE\n"
+                + "PV1||IP|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting|IP^I|Visit_0a1f7838-4230-4752-b8f6-948b07c38b25|||||||||||||||||||||||||20210407191758\n"
+                + "PV2|||^|||X-5546||20210407191758|||||||||||||||\n"
+                + "ORC|SN|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|2950|||||20210407191758|2739^BY^ENTERED|2799^BY^VERIFIED|3122^PROVIDER^ORDERING||(696)901-1300|20210407191758||||||ORDERING FAC NAME|ADDR^^CITY^STATE^ZIP^USA|(515)-290-8888|9999^^CITY^STATE^ZIP^CAN\n"
+                + "OBR|1|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|4916^Diffusion-weighted imaging||20210331214400|20210407191758|20210407191758||||||20210331214600||1234^SOURCE^SPECIMEN^LNAME^FNAME^^^^^^^^^LABNAME||||W18562||||P|||^^^^^POCPR|660600^Doctor^FYI||||Result Interpreter\n";
 
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-    @Test@Disabled
-  public void test_ORMO01_patient_encounter_present() throws IOException {
-	  String hl7message =
-		        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|IBMWATSON_LAB|IBM|20210407191758||ORM^O01|MSGID_e30a3471-7afd-4aa2-a3d5-e93fd89d24b3|T|2.3\n"
-		        + "PID|1||0a1f7838-4230-4752-b8f6-948b07c38b25^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator||9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900|||||Account_0a1f7838-4230-4752-b8f6-948b07c38b25|123-456-7890||||BIRTH PLACE\n"
-		        + "PV1||IP|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting|IP^I|Visit_0a1f7838-4230-4752-b8f6-948b07c38b25|||||||||||||||||||||||||20210407191758\n"
-		        + "PV2|||^|||X-5546||20210407191758|||||||||||||||\n"
-		        + "ORC|SN|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|2950|||||20210407191758|2739^BY^ENTERED|2799^BY^VERIFIED|3122^PROVIDER^ORDERING||(696)901-1300|20210407191758||||||ORDERING FAC NAME|ADDR^^CITY^STATE^ZIP^USA|(515)-290-8888|9999^^CITY^STATE^ZIP^CAN\n"
-		        + "OBR|1|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|ACCESSION_a42990b7-4155-4404-81ef-e85158caed72|4916^Diffusion-weighted imaging||20210331214400|20210407191758|20210407191758||||||20210331214600||1234^SOURCE^SPECIMEN^LNAME^FNAME^^^^^^^^^LABNAME||||W18562||||P|||^^^^^POCPR|660600^Doctor^FYI||||Result Interpreter\n";
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1);
 
-      HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-      String json = ftv.convert(hl7message, OPTIONS);
-      assertThat(json).isNotBlank();
-      LOGGER.info("FHIR json result:\n" + json);
-      IBaseResource bundleResource = context.getParser().parseResource(json);
-      assertThat(bundleResource).isNotNull();
-      Bundle b = (Bundle) bundleResource;
-      List<BundleEntryComponent> e = b.getEntry();
-      List<Resource> patientResource = e.stream()
-              .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-              .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(patientResource).hasSize(1);
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1);
 
-      List<Resource> encounterResource = e.stream()
-              .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-              .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(encounterResource).hasSize(1);
+        List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
+        assertThat(serviceRequests).hasSize(1);
 
-  }
+        List<Resource> practitioners = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
+        assertThat(practitioners).hasSize(5);
+
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(1);
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -11,17 +11,22 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Condition.ConditionEvidenceComponent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
@@ -33,9 +38,20 @@ public class Hl7NoteFHIRConverterTest {
 
     // Tests NTE creation for OBX (Observations) and ORC/OBRs (ServiceRequests)
     // Test associated Practitioners and references created. (NTE.4)
-    @Test
-    public void testNoteCreationMutipleOBX() {
-        String hl7ORU = "MSH|^~\\&|||||20180924152907||ORU^R01^ORU_R01|213|T|2.3.1|||||||||||\n"
+    // Tests messages "ORM^O01" & "ORU^R01^ORU_R01"
+
+    // This private method provide parameters to the the test
+    private static Stream<Arguments> provideParmsForNoteCreationServiceRequestMutipleOBX() {
+        return Stream.of(
+                //  Arguments are: (message, numExpectedDiagnosticReports)
+                Arguments.of("ORU^R01^ORU_R01", 1),
+                Arguments.of("ORM^O01", 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParmsForNoteCreationServiceRequestMutipleOBX")
+    public void testNoteCreationServiceRequestMutipleOBX(String message, int numExpectedDiagnosticReports) {
+        String hl7ORU = "MSH|^~\\&|||||20180924152907||" + message + "|213|T|2.3.1|||||||||||\n"
                 + "PID|||Pract1ID^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 // TODO: Future work, handle NTE's on PID
                 // "NTE|1|O|TEST NOTE DD line 1|\n" + "NTE|2|O|TEST NOTE DD line 2 |\n" + "NTE|3|O|TEST NOTE D line 3|\n"  
@@ -43,25 +59,26 @@ public class Hl7NoteFHIRConverterTest {
                 + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|||||||||||||||||||||||||||\n"
                 + "OBR|1|248648498^|248648498^|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||\n"
                 // ServiceRequest NTE has a practitioner reference in NTE.5
-                + "NTE|1|O|TEST ORC/OBR NOTE AA line 1||Pract1ID^Pract1Last^Pract1First|\n" 
+                + "NTE|1|O|TEST ORC/OBR NOTE AA line 1||Pract1ID^Pract1Last^Pract1First|\n"
                 + "NTE|2|O|TEST NOTE AA line 2|\n"
                 + "NTE|3|O|TEST NOTE AA line 3|\n"
                 + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
                 // GLYCOHEMOGLOBIN Observation NTE has a practitioner reference in NTE.5.  Note in second NTE. The first valied NTE.5 is used.
-                + "NTE|1|L|TEST OBXa NOTE BB line 1|\n" 
+                + "NTE|1|L|TEST OBXa NOTE BB line 1|\n"
                 + "NTE|2|L|TEST NOTE BB line 2||Pract2ID^Pract2Last^Pract2First|\n"
                 + "NTE|3|L|TEST NOTE BB line 3|\n"
                 + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
                 // Glucose Observation NTE has no practitioner reference in NTE.5
-                + "NTE|1|L|TEST OBXb NOTE CC line 1|\n" 
+                + "NTE|1|L|TEST OBXb NOTE CC line 1|\n"
                 + "NTE|2|L|TEST NOTE CC line 2|\n"
-                + "NTE|3|L|TEST NOTE CC line 3|\n"
-                + "NTE|4|L|TEST NOTE CC line 4|\n"
-                + "SPM|1|||^^^^^^^^Blood|||||||||||||20180924152700|20180924152755||||||";
+                + "NTE|3|L| |\n" // Test that blank lines are preserved.
+                + "NTE|4|L|TEST NOTE CC line 4|\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7ORU);
         List<Resource> diagnosticReports = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
-        assertThat(diagnosticReports).hasSize(1); // From the OBR
+
+        // DiagnosticReport expected for ORU, but not for ORM
+        assertThat(diagnosticReports).hasSize(numExpectedDiagnosticReports); // From the OBR in the ORU test case
 
         // One ServiceRequest contains NTE for ORC/OBR
         List<Resource> serviceRequests = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
@@ -79,7 +96,7 @@ public class Hl7NoteFHIRConverterTest {
 
         // Two observations.  One has GLYCOHEMOGLOBIN and notes BB, One has GLUCOSE and notes CC
         List<Resource> observations = ResourceUtils.getResourceList(e, ResourceType.Observation);
-        assertThat(observations).hasSize(2);
+        assertThat(observations).hasSize(2); // Should be 2 for ORU and ORM
         Observation obsGlucose = ResourceUtils.getResourceObservation(observations.get(0), ResourceUtils.context);
         Observation obsHemoglobin = ResourceUtils.getResourceObservation(observations.get(1), ResourceUtils.context);
         // Figure out which is first and reassign if needed for testing
@@ -93,15 +110,14 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(obsHemoglobin.getNote()).hasSize(1);
         assertThat(obsHemoglobin.getNote().get(0).getText())
                 .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
-        assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();  
-        String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();   
+        assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();
+        String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();
 
         assertThat(obsGlucose.hasNote()).isTrue();
         assertThat(obsGlucose.getNote()).hasSize(1);
         assertThat(obsGlucose.getNote().get(0).getText()).isEqualTo(
-                "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\nTEST NOTE CC line 4  \\n");
+                "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\n   \\nTEST NOTE CC line 4  \\n"); // Test that blank lines are preserved.
         assertThat(obsGlucose.getNote().get(0).hasAuthorReference()).isFalse();
-     
 
         // Two Practitioners, one for the serviceRequest, one for the GLYCOHEMOGLOBIN Observation
         List<Resource> practitioners = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
@@ -110,34 +126,148 @@ public class Hl7NoteFHIRConverterTest {
                 ResourceUtils.context);
         Practitioner practitionerObsHemoglobin = ResourceUtils.getResourcePractitioner(practitioners.get(1),
                 ResourceUtils.context);
-        if (practitionerServReq.getIdentifierFirstRep().getValue() != "Pract1ID") {
-                Practitioner temp = practitionerObsHemoglobin;
-                practitionerObsHemoglobin = practitionerServReq;
-                practitionerServReq = temp;
+        // Adjust to correct practitioner if needed        
+        if (!practitionerServReq.getIdentifierFirstRep().getValue().contentEquals("Pract1ID")) {
+            Practitioner temp = practitionerObsHemoglobin;
+            practitionerObsHemoglobin = practitionerServReq;
+            practitionerServReq = temp;
         }
         // Check the values for the Practitioners and validate match to references.             
         assertThat(practitionerServReq.getIdentifier()).hasSize(1);
         assertThat(practitionerServReq.getIdentifierFirstRep().getValue()).isEqualTo("Pract1ID");
         assertThat(practitionerServReq.getName()).hasSize(1);
         assertThat(practitionerServReq.getNameFirstRep().getText()).isEqualTo("Pract1First Pract1Last");
-        assertThat(practitionerServReq.getId()).isEqualTo(practitionerServReqRefId);   // Check the cross-reference
+        assertThat(practitionerServReq.getId()).isEqualTo(practitionerServReqRefId); // Check the cross-reference
         // Sanity check to confirm data corruption in meta content has not returned.
-        CodeableConcept ccSourceEventTrigger = (CodeableConcept)practitionerServReq.getMeta().getExtensionByUrl("http://ibm.com/fhir/cdm/StructureDefinition/source-event-trigger").getValue();
-        assertThat(ccSourceEventTrigger.hasText()).isFalse(); 
-        
+        CodeableConcept ccSourceEventTrigger = (CodeableConcept) practitionerServReq.getMeta()
+                .getExtensionByUrl("http://ibm.com/fhir/cdm/StructureDefinition/source-event-trigger").getValue();
+        assertThat(ccSourceEventTrigger.hasText()).isFalse();
+
         assertThat(practitionerObsHemoglobin.getIdentifier()).hasSize(1);
         assertThat(practitionerObsHemoglobin.getIdentifierFirstRep().getValue()).isEqualTo("Pract2ID");
         assertThat(practitionerObsHemoglobin.getName()).hasSize(1);
         assertThat(practitionerObsHemoglobin.getNameFirstRep().getText()).isEqualTo("Pract2First Pract2Last");
-        assertThat(practitionerObsHemoglobin.getId()).isEqualTo(practitionerObsHemoglobinRefId);   // Check the cross-reference  
+        assertThat(practitionerObsHemoglobin.getId()).isEqualTo(practitionerObsHemoglobinRefId); // Check the cross-reference  
+    }
 
+    // Tests NTE creation for OMP/RDE (MedicationRequest) messages and OBX (Observations) 
+    // Test associated Practitioners and references created. (NTE.4)
+    // This private method provide parameters to the the test
+    private static Stream<Arguments> parmsTestMedicationRequestNoteCreation() {
+        return Stream.of(
+                //  Arguments are: (message, medicalRequestSegments)
+                Arguments.of("OMP^O09",
+                        "RXO|00054418425^Dexamethasone 4 MG Oral Tablet^NDC^^^^^^dexamethasone (DECADRON) 4 MG TABS||||||||G||4||0|||||||||||\n"),
+                // NOTE: RDE processing prioritizes RXE segments and ignores RXO segments and their associated NTE's and NTE practitioner references.
+                // They are included below to show that no extra MedicationRequests, NTEs or Practitioners are added.
+                Arguments.of("RDE^O11",
+                        "RXO|00054418425^Dexamethasone 4 MG Oral Tablet^NDC^^^^^^dexamethasone (DECADRON) 4 MG TABS||||||||G||4||0|||||||||||\n"
+                                + "NTE|1|O|TEST ORC/OBR NOTE DDD line 1||Pract3ID^Pract3Last^Pract3First|\n"
+                                + "RXE|^Q24H&0600^^20210407191342^^ROU|0169-6339-10^insulin aspart (NOVOLOG) subcutaneous injection (CORRECTION SCALE INSULIN) 0-16 Units^NDC|0||Units|47^SOLN|||||||\n"),
+                Arguments.of("RDE^O25",
+                        "RXO|00054418425^Dexamethasone 4 MG Oral Tablet^NDC^^^^^^dexamethasone (DECADRON) 4 MG TABS||||||||G||4||0|||||||||||\n"
+                                + "NTE|1|O|TEST ORC/OBR NOTE DDD line 1||Pract3ID^Pract3Last^Pract3First|\n"
+                                + "RXE|^Q24H&0600^^20210407191342^^ROU|0169-6339-10^insulin aspart (NOVOLOG) subcutaneous injection (CORRECTION SCALE INSULIN) 0-16 Units^NDC|0||Units|47^SOLN|||||||\n"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parmsTestMedicationRequestNoteCreation")
+    public void testMedicationRequestNoteCreation(String message, String medicalRequestSegments) {
+        // Minimal valid ORC message.  Requires RXO and RXR segments.
+        String hl7message = "MSH|^~\\&||||IBM|20210101000000||" + message + "|MSGID|T|2.6\n"
+                + "PID|||1234||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1||I||||||||||||||||||||||||||||||||||||||||||\n"
+                + "ORC|OP|1234|1234|0827||||||||||||||||||||\n"
+                + medicalRequestSegments // May be RXO or RXO+RXE values from parmsTestMedicationRequestNoteCreation
+                + "NTE|1|O|TEST MedReq NOTE AA line 1||Pract1ID^Pract1Last^Pract1First|\n"
+                + "NTE|2|O|TEST NOTE AA line 2|\n"
+                + "NTE|3|O|TEST NOTE AA line 3|\n"
+                + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
+                // GLYCOHEMOGLOBIN Observation NTE has a practitioner reference in NTE.5.  Note in second NTE. The first valid NTE.5 is used.
+                + "NTE|1|L|TEST OBXa NOTE BB line 1|\n"
+                + "NTE|2|L|TEST NOTE BB line 2||Pract2ID^Pract2Last^Pract2First|\n"
+                + "NTE|3|L|TEST NOTE BB line 3|\n"
+                + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
+                // Glucose Observation NTE has no practitioner reference in NTE.5
+                + "NTE|1|L|TEST OBXb NOTE CC line 1|\n"
+                + "NTE|2|L|TEST NOTE CC line 2|\n"
+                + "NTE|3|L| |\n" // Test that blank lines are preserved.
+                + "NTE|4|L|TEST NOTE CC line 4|\n";
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        // Expect MedicationRequest containing NTE for RXO or RXE
+        List<Resource> medicationRequests = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
+        assertThat(medicationRequests).hasSize(1);
+        MedicationRequest medicationRequest = ResourceUtils.getResourceMedicationRequest(medicationRequests.get(0),
+                ResourceUtils.context);
+        assertThat(medicationRequest.hasNote()).isTrue();
+        assertThat(medicationRequest.getNote()).hasSize(1);
+        assertThat(medicationRequest.getNote().get(0).getText())
+                .isEqualTo("TEST MedReq NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+        assertThat(medicationRequest.getNote().get(0).hasAuthorReference()).isTrue();
+        String practitionerServReqRefId = medicationRequest.getNote().get(0).getAuthorReference().getReference();
+
+        // Two observations.  One has GLYCOHEMOGLOBIN and notes BB, One has GLUCOSE and notes CC
+        List<Resource> observations = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observations).hasSize(2); // Should be 2 for ORU and ORM
+        Observation obsGlucose = ResourceUtils.getResourceObservation(observations.get(0), ResourceUtils.context);
+        Observation obsHemoglobin = ResourceUtils.getResourceObservation(observations.get(1), ResourceUtils.context);
+        // Figure out which is first and reassign if needed for testing
+        if (obsGlucose.getCode().getText() != "MEAN BLOOD GLUCOSE") {
+            Observation temp = obsGlucose;
+            obsGlucose = obsHemoglobin;
+            obsHemoglobin = temp;
+        }
+        // Validate the note contents and references 
+        assertThat(obsHemoglobin.hasNote()).isTrue();
+        assertThat(obsHemoglobin.getNote()).hasSize(1);
+        assertThat(obsHemoglobin.getNote().get(0).getText())
+                .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+        assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();
+        String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();
+
+        assertThat(obsGlucose.hasNote()).isTrue();
+        assertThat(obsGlucose.getNote()).hasSize(1);
+        assertThat(obsGlucose.getNote().get(0).getText()).isEqualTo(
+                "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\n   \\nTEST NOTE CC line 4  \\n"); // Test that blank lines are preserved.
+        assertThat(obsGlucose.getNote().get(0).hasAuthorReference()).isFalse();
+
+        // Two Practitioners, one for the serviceRequest, one for the GLYCOHEMOGLOBIN Observation
+        List<Resource> practitioners = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
+        assertThat(practitioners).hasSize(2);
+        Practitioner practitionerServReq = ResourceUtils.getResourcePractitioner(practitioners.get(0),
+                ResourceUtils.context);
+        Practitioner practitionerObsHemoglobin = ResourceUtils.getResourcePractitioner(practitioners.get(1),
+                ResourceUtils.context);
+        // Adjust to correct practitioner if needed        
+        if (!practitionerServReq.getIdentifierFirstRep().getValue().contentEquals("Pract1ID")) {
+            Practitioner temp = practitionerObsHemoglobin;
+            practitionerObsHemoglobin = practitionerServReq;
+            practitionerServReq = temp;
+        }
+        // Check the values for the Practitioners and validate match to references.             
+        assertThat(practitionerServReq.getIdentifier()).hasSize(1);
+        assertThat(practitionerServReq.getIdentifierFirstRep().getValue()).isEqualTo("Pract1ID");
+        assertThat(practitionerServReq.getName()).hasSize(1);
+        assertThat(practitionerServReq.getNameFirstRep().getText()).isEqualTo("Pract1First Pract1Last");
+        assertThat(practitionerServReq.getId()).isEqualTo(practitionerServReqRefId); // Check the cross-reference
+        // Sanity check to confirm data corruption in meta content has not returned.
+        CodeableConcept ccSourceEventTrigger = (CodeableConcept) practitionerServReq.getMeta()
+                .getExtensionByUrl("http://ibm.com/fhir/cdm/StructureDefinition/source-event-trigger").getValue();
+        assertThat(ccSourceEventTrigger.hasText()).isFalse();
+
+        assertThat(practitionerObsHemoglobin.getIdentifier()).hasSize(1);
+        assertThat(practitionerObsHemoglobin.getIdentifierFirstRep().getValue()).isEqualTo("Pract2ID");
+        assertThat(practitionerObsHemoglobin.getName()).hasSize(1);
+        assertThat(practitionerObsHemoglobin.getNameFirstRep().getText()).isEqualTo("Pract2First Pract2Last");
+        assertThat(practitionerObsHemoglobin.getId()).isEqualTo(practitionerObsHemoglobinRefId); // Check the cross-reference  
     }
 
     // Test that multiple problems (PRB) each with multiple notes (NTE) are associated with the correct NTE / PRB 
     // and that there is no "bleed"
     @Test
-    public void testNoteCreationMutiplePPR()
-            throws IOException {
+    public void testNoteCreationMutiplePPR() throws IOException {
         // TODO: Add PC2 and PC3 tests in future            
         String message = "PPR^PC1";
         String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message
@@ -145,28 +275,28 @@ public class Hl7NoteFHIRConverterTest {
                 + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\n"
                 + "PV1||I|||||||||||||||||1400|||||||||||||||||||||||||199501102300\n"
                 + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\n"
-                + "NTE|1|O|TEST PRBa NOTE AA line 1|\n" 
+                + "NTE|1|O|TEST PRBa NOTE AA line 1|\n"
                 + "NTE|2|O|TEST NOTE AA line 2|\n"
                 + "NTE|3|O|TEST NOTE AA line 3|\n"
                 + "OBX|1|NM|17985^GLYCOHEMOGLOBIN HGB A1C^LRR^^^^^^GLYCOHEMOGLOBIN HGB A1C||5.6|%|<6.0||||F||||||||||||||\n"
-                + "NTE|1|L|TEST OBXb NOTE BB line 1|\n" 
+                + "NTE|1|L|TEST OBXb NOTE BB line 1|\n"
                 + "NTE|2|L|TEST NOTE BB line 2|\n"
                 + "NTE|3|L|TEST NOTE BB line 3|\n"
                 + "OBX|2|NM|17853^MEAN BLOOD GLUCOSE^LRR^^^^^^MEAN BLOOD GLUCOSE||114.02|mg/dL|||||F||||||||||||||\n"
-                + "NTE|1|L|TEST OBXc NOTE CC line 1|\n" 
+                + "NTE|1|L|TEST OBXc NOTE CC line 1|\n"
                 + "NTE|2|L|TEST NOTE CC line 2|\n"
                 + "NTE|3|L|TEST NOTE CC line 3|\n"
                 + "PRB|AD|200603150625|I47.2^Ventricular tachycardia^ICD-10-CM|53692||2||200603150625\n"
-                + "NTE|1|O|TEST PRBd NOTE DD line 1|\n" 
+                + "NTE|1|O|TEST PRBd NOTE DD line 1|\n"
                 + "NTE|2|O|TEST NOTE DD line 2|\n"
                 + "NTE|3|O|TEST NOTE DD line 3|\n"
                 + "OBX|1|NM|8595^BP Mean|1|88|MM HG|||||F|||20180520230000|||\n"
-                + "NTE|1|L|TEST OBXe NOTE EE line 1|\n" 
+                + "NTE|1|L|TEST OBXe NOTE EE line 1|\n"
                 + "NTE|2|L|TEST NOTE EE line 2|\n"
                 + "NTE|3|L|TEST NOTE EE line 3|\n"
                 + "OBX|2|NM|7302^Resp Rate|1|19||||||F|||20180520230000|||\n"
-                + "NTE|1|L|TEST OBXf NOTE FF line 1|\n";  // Single NTE to ensure it is created correctly
- 
+                + "NTE|1|L|TEST OBXf NOTE FF line 1|\n"; // Single NTE to ensure it is created correctly
+
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
         List<Resource> patients = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patients).hasSize(1);
@@ -192,14 +322,17 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(condTachy.hasNote()).isTrue();
         assertThat(condTachy.getNote()).hasSize(1);
         assertThat(condTachy.getNote().get(0).getText())
-                .isEqualTo("TEST PRBd NOTE DD line 1  \\nTEST NOTE DD line 2  \\nTEST NOTE DD line 3  \\n");        
+                .isEqualTo("TEST PRBd NOTE DD line 1  \\nTEST NOTE DD line 2  \\nTEST NOTE DD line 3  \\n");
 
         // Four observations.  Two associated with the first problem and two with the second
         // This map tells us what Annotation text is associated with an Observation code
         Map<String, String> matchObsCodeToNotes = new HashMap<>();
-        matchObsCodeToNotes.put("17985", "TEST OBXb NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
-        matchObsCodeToNotes.put("17853", "TEST OBXc NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\n");
-        matchObsCodeToNotes.put("8595", "TEST OBXe NOTE EE line 1  \\nTEST NOTE EE line 2  \\nTEST NOTE EE line 3  \\n");
+        matchObsCodeToNotes.put("17985",
+                "TEST OBXb NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+        matchObsCodeToNotes.put("17853",
+                "TEST OBXc NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\n");
+        matchObsCodeToNotes.put("8595",
+                "TEST OBXe NOTE EE line 1  \\nTEST NOTE EE line 2  \\nTEST NOTE EE line 3  \\n");
         matchObsCodeToNotes.put("7302", "TEST OBXf NOTE FF line 1");
 
         // This map tells us what Parent should be associated with an Observation code
@@ -215,29 +348,31 @@ public class Hl7NoteFHIRConverterTest {
         // Dig through the Conditions, find the referenced Observations, find the matching Observation resource
         // and ensure it has the expected Notes and referenced parent.
         // For the list of Conditions
-        for(int condIndex=0; condIndex < conditions.size(); condIndex++) {  // condIndex is index for condition
+        for (int condIndex = 0; condIndex < conditions.size(); condIndex++) { // condIndex is index for condition
             // Get the list of Observation references
             Condition cond = ResourceUtils.getResourceCondition(conditions.get(condIndex), ResourceUtils.context);
             List<ConditionEvidenceComponent> evidences = cond.getEvidence();
-            for(int evidenceIndex=0; evidenceIndex < evidences.size(); evidenceIndex++) {
+            for (int evidenceIndex = 0; evidenceIndex < evidences.size(); evidenceIndex++) {
                 // Get the evidence Observation reference
                 String obsReferenceId = evidences.get(evidenceIndex).getDetailFirstRep().getReference();
                 // Find the referenced observation
-                for(int obsIndex=0; obsIndex < observations.size(); obsIndex++) {
+                for (int obsIndex = 0; obsIndex < observations.size(); obsIndex++) {
                     // If the Id's match
                     if (obsReferenceId.contains(observations.get(obsIndex).getId())) {
                         // Check the contents and the parent
-                        Observation obs = ResourceUtils.getResourceObservation(observations.get(obsIndex),ResourceUtils.context);
+                        Observation obs = ResourceUtils.getResourceObservation(observations.get(obsIndex),
+                                ResourceUtils.context);
                         String code = obs.getCode().getCodingFirstRep().getCode().toString();
                         // The Annotation text should match the mapped text for this key
                         assertThat(obs.getNoteFirstRep().getText()).hasToString(matchObsCodeToNotes.get(code));
                         // The parent Condition code.coding.code should match the expected mapped code for this key
-                        assertThat(cond.getCode().getCodingFirstRep().getCode()).hasToString(matchObsCodeToParent.get(code));
+                        assertThat(cond.getCode().getCodingFirstRep().getCode())
+                                .hasToString(matchObsCodeToParent.get(code));
                         observationsVerified++;
                         break;
                     }
                 }
-            }    
+            }
         }
         // This confirms ALL of the observations were checked.
         assertThat(observationsVerified).isEqualTo(4);

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -88,9 +88,8 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(serviceRequest.hasNote()).isTrue();
         assertThat(serviceRequest.getNote()).hasSize(1);
         // Processing adds "  \n" two spaces and a line feed
-        // Note on test strings. Must double back-slashes to create single backslash in string.
         assertThat(serviceRequest.getNote().get(0).getText())
-                .isEqualTo("TEST ORC/OBR NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+                .isEqualTo("TEST ORC/OBR NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
         assertThat(serviceRequest.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerServReqRefId = serviceRequest.getNote().get(0).getAuthorReference().getReference();
 
@@ -109,14 +108,14 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(obsHemoglobin.hasNote()).isTrue();
         assertThat(obsHemoglobin.getNote()).hasSize(1);
         assertThat(obsHemoglobin.getNote().get(0).getText())
-                .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+                .isEqualTo("TEST OBXa NOTE BB line 1  \nTEST NOTE BB line 2  \nTEST NOTE BB line 3");
         assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();
 
         assertThat(obsGlucose.hasNote()).isTrue();
         assertThat(obsGlucose.getNote()).hasSize(1);
         assertThat(obsGlucose.getNote().get(0).getText()).isEqualTo(
-                "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\n   \\nTEST NOTE CC line 4  \\n"); // Test that blank lines are preserved.
+                "TEST OBXb NOTE CC line 1  \nTEST NOTE CC line 2  \n   \nTEST NOTE CC line 4"); // Test that blank lines are preserved.
         assertThat(obsGlucose.getNote().get(0).hasAuthorReference()).isFalse();
 
         // Two Practitioners, one for the serviceRequest, one for the GLYCOHEMOGLOBIN Observation
@@ -204,7 +203,7 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(medicationRequest.hasNote()).isTrue();
         assertThat(medicationRequest.getNote()).hasSize(1);
         assertThat(medicationRequest.getNote().get(0).getText())
-                .isEqualTo("TEST MedReq NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+                .isEqualTo("TEST MedReq NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
         assertThat(medicationRequest.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerServReqRefId = medicationRequest.getNote().get(0).getAuthorReference().getReference();
 
@@ -223,14 +222,14 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(obsHemoglobin.hasNote()).isTrue();
         assertThat(obsHemoglobin.getNote()).hasSize(1);
         assertThat(obsHemoglobin.getNote().get(0).getText())
-                .isEqualTo("TEST OBXa NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+                .isEqualTo("TEST OBXa NOTE BB line 1  \nTEST NOTE BB line 2  \nTEST NOTE BB line 3");
         assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();
 
         assertThat(obsGlucose.hasNote()).isTrue();
         assertThat(obsGlucose.getNote()).hasSize(1);
         assertThat(obsGlucose.getNote().get(0).getText()).isEqualTo(
-                "TEST OBXb NOTE CC line 1  \\nTEST NOTE CC line 2  \\n   \\nTEST NOTE CC line 4  \\n"); // Test that blank lines are preserved.
+                "TEST OBXb NOTE CC line 1  \nTEST NOTE CC line 2  \n   \nTEST NOTE CC line 4"); // Test that blank lines are preserved.
         assertThat(obsGlucose.getNote().get(0).hasAuthorReference()).isFalse();
 
         // Two Practitioners, one for the serviceRequest, one for the GLYCOHEMOGLOBIN Observation
@@ -318,21 +317,21 @@ public class Hl7NoteFHIRConverterTest {
         assertThat(condStenosis.hasNote()).isTrue();
         assertThat(condStenosis.getNote()).hasSize(1);
         assertThat(condStenosis.getNote().get(0).getText())
-                .isEqualTo("TEST PRBa NOTE AA line 1  \\nTEST NOTE AA line 2  \\nTEST NOTE AA line 3  \\n");
+                .isEqualTo("TEST PRBa NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
         assertThat(condTachy.hasNote()).isTrue();
         assertThat(condTachy.getNote()).hasSize(1);
         assertThat(condTachy.getNote().get(0).getText())
-                .isEqualTo("TEST PRBd NOTE DD line 1  \\nTEST NOTE DD line 2  \\nTEST NOTE DD line 3  \\n");
+                .isEqualTo("TEST PRBd NOTE DD line 1  \nTEST NOTE DD line 2  \nTEST NOTE DD line 3");
 
         // Four observations.  Two associated with the first problem and two with the second
         // This map tells us what Annotation text is associated with an Observation code
         Map<String, String> matchObsCodeToNotes = new HashMap<>();
         matchObsCodeToNotes.put("17985",
-                "TEST OBXb NOTE BB line 1  \\nTEST NOTE BB line 2  \\nTEST NOTE BB line 3  \\n");
+                "TEST OBXb NOTE BB line 1  \nTEST NOTE BB line 2  \nTEST NOTE BB line 3");
         matchObsCodeToNotes.put("17853",
-                "TEST OBXc NOTE CC line 1  \\nTEST NOTE CC line 2  \\nTEST NOTE CC line 3  \\n");
+                "TEST OBXc NOTE CC line 1  \nTEST NOTE CC line 2  \nTEST NOTE CC line 3");
         matchObsCodeToNotes.put("8595",
-                "TEST OBXe NOTE EE line 1  \\nTEST NOTE EE line 2  \\nTEST NOTE EE line 3  \\n");
+                "TEST OBXe NOTE EE line 1  \nTEST NOTE EE line 2  \nTEST NOTE EE line 3");
         matchObsCodeToNotes.put("7302", "TEST OBXf NOTE FF line 1");
 
         // This map tells us what Parent should be associated with an Observation code

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
@@ -47,6 +47,7 @@ import io.github.linuxforhealth.hl7.message.HL7MessageModel;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class Hl7ObservationFHIRConversionTest {
     private static FHIRContext context = new FHIRContext();
@@ -108,16 +109,10 @@ public class Hl7ObservationFHIRConversionTest {
     @Test
     public void testObservationSN_valueQuantity_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|28-1^Ampicillin Islt MIC^LN||<^0.06|ug/mL^^UCUM|||";
-        
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         //Check valueQuantity
@@ -125,7 +120,7 @@ public class Hl7ObservationFHIRConversionTest {
         Quantity q = obs.getValueQuantity();
         assertEquals("ug/mL", q.getCode()); //code for unit
         assertEquals("ug/mL", q.getUnit()); //setting unit to OBX.6.1
-        assertEquals("http://unitsofmeasure.org", q.getSystem());  //system for unit
+        assertEquals("http://unitsofmeasure.org", q.getSystem()); //system for unit
         assertEquals(0.06f, q.getValue().floatValue());
         assertEquals("<", q.getComparator().toCode());
     }
@@ -142,15 +137,9 @@ public class Hl7ObservationFHIRConversionTest {
         String hl7message = baseMessage
                 + "OBX|1|SN|24467-3^CD3+CD4+ (T4 helper) cells [#/volume] in Blood^LN||=^440|{Cells}/uL^cells per microliter^UCUM|649-1346 cells/mcL|L|||F";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         //Check valueQuantity
@@ -158,7 +147,7 @@ public class Hl7ObservationFHIRConversionTest {
         Quantity q = obs.getValueQuantity();
         assertEquals("{Cells}/uL", q.getCode()); //code for unit
         assertEquals("{Cells}/uL", q.getUnit()); //unit units to OBX.6.1
-        assertEquals("http://unitsofmeasure.org", q.getSystem());  //system for unit
+        assertEquals("http://unitsofmeasure.org", q.getSystem()); //system for unit
         assertEquals(440f, q.getValue().floatValue());
         assertNull(q.getComparator()); // = is not put in comparator
         //Check referenceRange
@@ -181,7 +170,7 @@ public class Hl7ObservationFHIRConversionTest {
         DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getInterpretation().get(0), "L", "Low",
                 "http://terminology.hl7.org/CodeSystem/v2-0078", null);
     }
-    
+
     /**
      * Testing Observation.yml valueQuantity_3
      * 
@@ -191,16 +180,10 @@ public class Hl7ObservationFHIRConversionTest {
     public void testObservationSN_valueQuantity_notnull_separator_result() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|SN|24467-3^CD3+CD4+ (T4 helper) cells [#/volume] in Blood^LN||=^440^.|{Cells}/uL^cells per microliter^UCUM|||||F";
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-        
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertNotNull(obs.getValueQuantity());
@@ -208,7 +191,7 @@ public class Hl7ObservationFHIRConversionTest {
         Quantity q = obs.getValueQuantity();
         assertEquals("{Cells}/uL", q.getCode()); //code for unit
         assertEquals("{Cells}/uL", q.getUnit()); //set units to OBX.6.1
-        assertEquals("http://unitsofmeasure.org", q.getSystem());  //system for unit
+        assertEquals("http://unitsofmeasure.org", q.getSystem()); //system for unit
         assertEquals(440f, q.getValue().floatValue());
         assertNull(q.getComparator()); // = is not put in comparator       
     }
@@ -216,16 +199,10 @@ public class Hl7ObservationFHIRConversionTest {
     @Test
     public void testObservationSN_valueQuantity_missing_comparator_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|1554-5^GLUCOSE||^182|mg/dl|70_105||||F";
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-        
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         //Check valueQuantity
@@ -233,7 +210,7 @@ public class Hl7ObservationFHIRConversionTest {
         Quantity q = obs.getValueQuantity();
         assertNull(q.getCode()); //code only set if system exists
         assertEquals("mg/dl", q.getUnit());
-        assertNull(q.getSystem());  
+        assertNull(q.getSystem());
         assertEquals(182, q.getValue().floatValue());
         assertNull(q.getComparator()); // no comparator passed in
         //Check referenceRange
@@ -251,20 +228,14 @@ public class Hl7ObservationFHIRConversionTest {
         assertEquals(70f, low.getValue().floatValue());
         assertEquals("70_105", range.getText());
     }
-    
+
     @Test
     public void testObservationSN_valueRatio_colon_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|111^LabWithRatio||^2^:^3|";
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-     
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertTrue(obs.hasValueRatio());
@@ -276,16 +247,10 @@ public class Hl7ObservationFHIRConversionTest {
     @Test
     public void testObservationSN_valueRatio_slash_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|111^LabWithRatio||^2^/^3|";
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-     
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertTrue(obs.hasValueRatio());
@@ -294,20 +259,14 @@ public class Hl7ObservationFHIRConversionTest {
         assertEquals(3f, r.getDenominator().getValue().floatValue());
     }
 
- 
     @Test
     public void testObservationSTResult() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|ST|^Type of protein feed^L||Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F||||Alex||";
-        String json = message.convert(hl7message, engine);
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.getValueStringType()).isNotNull();
@@ -316,18 +275,14 @@ public class Hl7ObservationFHIRConversionTest {
                 .isEqualTo("Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
     }
 
-     @Test
+    @Test
     public void testObservationSTMultiplePartsResult() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|ST|^Type of protein feed^L||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%~Fifth line, as part of a repeated field||||||F||";
-        String json = message.convert(hl7message, engine);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.getValueStringType()).isNotNull();
@@ -341,15 +296,10 @@ public class Hl7ObservationFHIRConversionTest {
     public void testObservationCeResultUnknownSystem() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
-        String json = message.convert(hl7message, engine);
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.getValueCodeableConcept()).isNotNull();
@@ -366,15 +316,10 @@ public class Hl7ObservationFHIRConversionTest {
     public void testObservationCeResultKnownSystem() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^LN";
-        String json = message.convert(hl7message, engine);
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.getValueCodeableConcept()).isNotNull();
@@ -391,15 +336,10 @@ public class Hl7ObservationFHIRConversionTest {
     public void testObservationStNullResult() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|ST|14151-5^HCO3 BldCo-sCnc^LN|TEST|||||||F|||20210311122016|||||20210311122153||||";
-        String json = message.convert(hl7message, engine);
 
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.getValueStringType()).isNotNull();
@@ -421,34 +361,33 @@ public class Hl7ObservationFHIRConversionTest {
 
     // Tests most fields of OBX
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A01|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A03|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A04|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A08|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A28|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A31|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|OMP^O09|||2.6||||||||2.6\r",
-        //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ORM^O01|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ORU^R01|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC1|||2.6||||||||2.6\r",
-        //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC2|||2.6||||||||2.6\r",
-        //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC3|||2.6||||||||2.6\r",
-        "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|VXU^V04|||2.6||||||||2.6\r",
+    @ValueSource(strings = {
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A01|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A03|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A04|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A08|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A28|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ADT^A31|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|OMP^O09|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ORM^O01|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|ORU^R01|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC1|||2.6||||||||2.6\r",
+            //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC2|||2.6||||||||2.6\r",
+            //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC3|||2.6||||||||2.6\r",
+            "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|VXU^V04|||2.6||||||||2.6\r",
     })
     public void extendedObservationTestMostMessages(String msh) throws IOException {
         String hl7message = msh
                 + "OBX|1|CWE|DQW^Some text 1^SNM3|100|DQW^Other text 2^SNM3|mm^Text 3^SNM3|56-98|IND|25|ST|F|20210322153839|LKJ|20210320153850|N56|1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567^mySystem|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
 
-        String json = message.convert(hl7message, engine);
+        String json = message.convert(hl7message, engine); // use special created engine
 
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.hasValueCodeableConcept()).isTrue();
@@ -497,7 +436,7 @@ public class Hl7ObservationFHIRConversionTest {
                 .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(1);
-        Practitioner doctor = getResourcePractitioner(practitionerResource.get(0));
+        Practitioner doctor = ResourceUtils.getResourcePractitioner(practitionerResource.get(0), ResourceUtils.context);
         assertThat(doctor.getName().get(0).getFamily()).isEqualTo("ClinicianLastName");
         // Get Organization and see that it is populated with OBX.23/OBX.24/OBX.25 information
         assertThat(obs.getPerformer().get(1).hasReference()).isTrue();
@@ -505,7 +444,7 @@ public class Hl7ObservationFHIRConversionTest {
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(organizationResource).hasSize(1);
-        Organization org = getResourceOrganization(organizationResource.get(0));
+        Organization org = ResourceUtils.getResourceOrganization(organizationResource.get(0), ResourceUtils.context);
         assertThat(org.getName()).isEqualTo("Radiology"); // from OBX.23
         assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString())
                 .isEqualTo("467 Albany Hospital"); // from OBX.24
@@ -532,7 +471,7 @@ public class Hl7ObservationFHIRConversionTest {
                 .filter(v -> ResourceType.Device == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(deviceResource).hasSize(1);
-        Device device = getResourceDevice(deviceResource.get(0));
+        Device device = ResourceUtils.getResourceDevice(deviceResource.get(0), ResourceUtils.context);
         assertThat(device.getIdentifier().get(0).getValue()).isEqualTo("Device_1234567");
         assertThat(device.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:mySystem");
 
@@ -564,17 +503,9 @@ public class Hl7ObservationFHIRConversionTest {
                 + "OBX|2|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400\r"
                 + "SPM|1|SpecimenID||BLOOD^Blood^^87612001^BLOOD^SCT^^||||Cord Art^Blood, Cord Arterial^^^^^^^|||P||||||201110060535|201110060821||Y||||||1\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(ORU_r01, OPTIONS);
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(ORU_r01);
 
-        FHIRContext context = new FHIRContext();
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(2);
         Observation obs = (Observation) obsResource.get(0);
         assertThat(obs.hasReferenceRange()).isTrue();
@@ -613,48 +544,41 @@ public class Hl7ObservationFHIRConversionTest {
         assertThat(obs.getCategory()).hasSize(1);
         DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getCategoryFirstRep(), "laboratory", "Laboratory",
                 "http://terminology.hl7.org/CodeSystem/observation-category", null);
-
     }
 
     // Tests resources created for Observations from RDE messages
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
     public void extendedObservationTestForRDEMessages(String msh) throws IOException {
 
         String hl7message = msh
-        + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-        + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-        + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\n"
-        + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg||IND||||||20210320153850||1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567^mySystem|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\n"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg||IND||||||20210320153850||1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567^mySystem|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-          
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
 
         Observation obs = (Observation) obsResource.get(0);
 
         // Check the coding  (OBX.3)
         assertThat(obs.hasCode()).isTrue();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getCode(), "Most Current Weight", "Most current measured weight (actual)",
+        DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getCode(), "Most Current Weight",
+                "Most current measured weight (actual)",
                 null, "Most current measured weight (actual)");
-    
+
         // Check the value  (OBX.5)
         assertNotNull(obs.getValueQuantity());
         Quantity q = obs.getValueQuantity();
         assertNull(q.getCode()); //code for unit
         assertEquals("kg", q.getUnit()); //unit units to OBX.6.1
-        assertNull(q.getSystem());  //system for unit
+        assertNull(q.getSystem()); //system for unit
         assertEquals(90f, q.getValue().floatValue());
         assertNull(q.getComparator()); // = is not put in comparator
 
@@ -666,12 +590,12 @@ public class Hl7ObservationFHIRConversionTest {
         assertThat(obs.getInterpretation()).hasSize(1);
         DatatypeUtils.checkCommonCodeableConceptAssertions(obs.getInterpretationFirstRep(), "IND", "Indeterminate",
                 "http://terminology.hl7.org/CodeSystem/v2-0078", null);
-        
+
         // Check the effective Date Time  (OBX.14)
         assertThat(obs.hasEffective()).isTrue();
         assertThat(obs.hasEffectiveDateTimeType()).isTrue();
         assertThat(obs.getEffectiveDateTimeType().asStringValue()).isEqualTo("2021-03-20T15:38:50+08:00");
-        
+
         // Check performer  (OBX.16 Practictioner + OBX.23/OBX.24/OBX.25 Organization)
         assertThat(obs.hasPerformer()).isTrue();
         assertThat(obs.getPerformer()).hasSize(2); // Practioner and Organization
@@ -681,7 +605,7 @@ public class Hl7ObservationFHIRConversionTest {
                 .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(1);
-        Practitioner doctor = getResourcePractitioner(practitionerResource.get(0));
+        Practitioner doctor = ResourceUtils.getResourcePractitioner(practitionerResource.get(0), ResourceUtils.context);
         assertThat(doctor.getName().get(0).getFamily()).isEqualTo("ClinicianLastName");
         // Get Organization and see that it is populated with OBX.23/OBX.24/OBX.25 information
         assertThat(obs.getPerformer().get(1).hasReference()).isTrue();
@@ -689,7 +613,7 @@ public class Hl7ObservationFHIRConversionTest {
                 .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(organizationResource).hasSize(1);
-        Organization org = getResourceOrganization(organizationResource.get(0));
+        Organization org = ResourceUtils.getResourceOrganization(organizationResource.get(0), ResourceUtils.context);
         assertThat(org.getName()).isEqualTo("Radiology"); // from OBX.23
         assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString())
                 .isEqualTo("467 Albany Hospital"); // from OBX.24
@@ -697,7 +621,7 @@ public class Hl7ObservationFHIRConversionTest {
         assertThat(org.getAddress().get(0).getState()).isEqualTo("NY"); // from OBX.24
         assertThat(org.getContact().get(0).getName().getFamily()).isEqualTo("ContactLastName"); // from OBX.25
         assertThat(org.getContact().get(0).getName().getGiven().get(0).getValueAsString()).isEqualTo("Jane"); // from OBX.25
-        assertThat(org.getContact().get(0).getName().getSuffix()).hasSize(0); // There should be no suffix, currently not putting degree 'Title' in suffix
+        assertThat(org.getContact().get(0).getName().getSuffix()).isEmpty(); // There should be no suffix, currently not putting degree 'Title' in suffix
         assertThat(org.getContact().get(0).getName().getText()).isEqualTo("Dr. Jane Q ContactLastName"); // from OBX.25
         assertThat(org.getContact().get(0).hasPurpose()).isTrue(); // purpose added because of OBX.25
         DatatypeUtils.checkCommonCodeableConceptAssertions(org.getContact().get(0).getPurpose(), "ADMIN",
@@ -717,7 +641,7 @@ public class Hl7ObservationFHIRConversionTest {
                 .filter(v -> ResourceType.Device == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(deviceResource).hasSize(1);
-        Device device = getResourceDevice(deviceResource.get(0));
+        Device device = ResourceUtils.getResourceDevice(deviceResource.get(0), ResourceUtils.context);
         assertThat(device.getIdentifier().get(0).getValue()).isEqualTo("Device_1234567");
         assertThat(device.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:mySystem");
 
@@ -736,24 +660,6 @@ public class Hl7ObservationFHIRConversionTest {
 
         // Check for ABSENCE of category (because no SPM)  Presence of category tested in extendedObservationUnusualRangesAndOtherTest
         assertThat(obs.hasCategory()).isFalse();
-    }
-    
-    private static Practitioner getResourcePractitioner(Resource resource) {
-        String s = context.getParser().encodeResourceToString(resource);
-        Class<? extends IBaseResource> klass = Practitioner.class;
-        return (Practitioner) context.getParser().parseResource(klass, s);
-    }
-
-    private static Organization getResourceOrganization(Resource resource) {
-        String s = context.getParser().encodeResourceToString(resource);
-        Class<? extends IBaseResource> klass = Organization.class;
-        return (Organization) context.getParser().parseResource(klass, s);
-    }
-
-    private static Device getResourceDevice(Resource resource) {
-        String s = context.getParser().encodeResourceToString(resource);
-        Class<? extends IBaseResource> klass = Device.class;
-        return (Device) context.getParser().parseResource(klass, s);
     }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -212,7 +212,12 @@ public class ResourceUtils {
   // Given a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
   // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
   public static Practitioner getSpecificPractitionerFromBundle(Bundle bundle, String practitionerRef) {
-    List<BundleEntryComponent> entries = bundle.getEntry();
+    return getSpecificPractitionerFromBundleEntriesList(bundle.getEntry(), practitionerRef);
+  }
+
+  // Given a list of entries from a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
+  // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
+  public static Practitioner getSpecificPractitionerFromBundleEntriesList(List<BundleEntryComponent> entries, String practitionerRef) {
     // Find the practitioner resources from the FHIR bundle.
     List<Resource> practitioners = entries.stream()
         .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
@@ -300,6 +305,12 @@ public class ResourceUtils {
     String s = context.getParser().encodeResourceToString(resource);
     Class<? extends IBaseResource> klass = Observation.class;
     return (Observation) context.getParser().parseResource(klass, s);
+  }
+
+  public static Device getResourceDevice(Resource resource, FHIRContext context) {
+    String s = context.getParser().encodeResourceToString(resource);
+    Class<? extends IBaseResource> klass = Device.class;
+    return (Device) context.getParser().parseResource(klass, s);
   }
 
   public static List<Resource> getResourceList(List<BundleEntryComponent> e, ResourceType resourceType){


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Support for ORM-O01, OMP-O09, RDE-O011, RDE_O25

Fix linefeed problems so that true linefeeds are created.

Update tests; refactor touched tests with common utilities.

Activate ORM-O01 as supported