### PR TITLE
Eliminate extraneous newline added at end of text reports.

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7DataHandlerUtil.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7DataHandlerUtil.java
@@ -7,9 +7,11 @@ package io.github.linuxforhealth.hl7.data;
 
 import java.util.Collection;
 import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import ca.uhn.hl7v2.model.Composite;
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.Primitive;
@@ -32,10 +34,19 @@ public class Hl7DataHandlerUtil {
     }
 
     public static String getStringValue(Object obj, boolean allComponents) {
-        return getStringValue(obj, allComponents, ". ", true);
+        return getStringValue(obj, allComponents, ". ", true, true);
     }
 
-    public static String getStringValue(Object obj, boolean allComponents, String separatorString, boolean trim) {
+    /**
+     * @param obj - object to return the string value of
+     * @param allComponents -
+     * @param separatorString - string to insert between items when obj is a list
+     * @param trim - whether to trim (whitespace) from the result
+     * @param separatorAtEnd - whether to add the separatorString after the final element when obj parm is a list
+     * @return
+     */
+    public static String getStringValue(Object obj, boolean allComponents, String separatorString, boolean trim,
+            boolean separatorAtEnd) {
         if (obj == null) {
             return null;
         }
@@ -48,8 +59,17 @@ public class Hl7DataHandlerUtil {
             if (list.size() == 1) {
                 returnValue = toStringValue(list.get(0), allComponents);
             } else if (!list.isEmpty()) {
+                int listSize = list.size();
+                int listCount = 1;
                 StringBuilder sb = new StringBuilder();
-                list.forEach(e -> sb.append(toStringValue(e, allComponents)).append(separatorString));
+                for (Object listItem : list) {
+                    sb.append(toStringValue(listItem, allComponents));
+                    if (separatorAtEnd || listCount < listSize) {
+                        // append separator, except after last item when separatorAtEnd=false
+                        sb.append(separatorString);
+                    }
+                    listCount++;
+                }
                 returnValue = sb.toString();
                 if (trim) {
                     returnValue = StringUtils.strip(returnValue);

--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -21,15 +21,15 @@ import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.codesystems.EncounterStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Segment;
 import ca.uhn.hl7v2.model.Type;
 import io.github.linuxforhealth.hl7.data.date.DateUtil;
 
-
 public class Hl7RelatedGeneralUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7RelatedGeneralUtils.class);
-    
+
     private Hl7RelatedGeneralUtils() {
     }
 
@@ -56,7 +56,8 @@ public class Hl7RelatedGeneralUtils {
     // .* any number of characters
     private static final String REGEX_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT = "^\\D*?([\\d.]+)\\D*([\\d.]*).*";
     // Compile this into a pattern for reuse
-    private static final Pattern PATTERN_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT = Pattern.compile(REGEX_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT);
+    private static final Pattern PATTERN_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT = Pattern
+            .compile(REGEX_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT);
 
     // ExtractLow - see comments above
     public static String extractLow(Object input) {
@@ -65,9 +66,9 @@ public class Hl7RelatedGeneralUtils {
             Matcher m = PATTERN_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT.matcher(val);
 
             // Only the low (first) number if there is also a high (second) number
-            if (m.find() && !m.group(2).isEmpty()){
-                    return m.group(1);
-            } 
+            if (m.find() && !m.group(2).isEmpty()) {
+                return m.group(1);
+            }
             return null;
         }
         return null;
@@ -80,11 +81,11 @@ public class Hl7RelatedGeneralUtils {
             Matcher m = PATTERN_FIRST_TWO_NUMBERS_AMID_OTHER_TEXT.matcher(val);
 
             // If one number, it is the high.  If two numbers, the second is high.
-            if(m.find()) {
-                if (!m.group(2).isEmpty()){
+            if (m.find()) {
+                if (!m.group(2).isEmpty()) {
                     return m.group(2);
                 } else {
-                    return m.group(1);   
+                    return m.group(1);
                 }
             }
             return null;
@@ -106,7 +107,6 @@ public class Hl7RelatedGeneralUtils {
         return status.toCode();
     }
 
-
     // DocumentReference.yml uses a required:true on status to control the creation of the DocumentReference.
     // It depends on this getDocumentReferenceStatus returning a status value ONLY when a DocumentReference should be created.
     // Together with the required:true, this creates logic for messages (MDM, PPR, ORM, OMP) that create DocumentReferences 
@@ -116,27 +116,28 @@ public class Hl7RelatedGeneralUtils {
     // Observation creation is controlled by different code
     public static String getDocumentReferenceStatus(Object txa, Object txa19, Object orc, Object obr25, Object obx2) {
         LOGGER.info("Generating DocumentReference status");
-        LOGGER.debug("Generating DocumentReference status from txa{}, txa19 {}, orc {}, obr25 {}, obx2 {}, ", txa, txa19, orc, obr25, obx2);
+        LOGGER.debug("Generating DocumentReference status from txa{}, txa19 {}, orc {}, obr25 {}, obx2 {}, ", txa,
+                txa19, orc, obr25, obx2);
 
-        if (txa != null || (orc!= null && Objects.equals(Hl7DataHandlerUtil.getStringValue(obx2),"TX"))) {
+        if (txa != null || (orc != null && Objects.equals(Hl7DataHandlerUtil.getStringValue(obx2), "TX"))) {
             String val = Hl7DataHandlerUtil.getStringValue(txa19);
             if (val == null) {
                 val = Hl7DataHandlerUtil.getStringValue(obr25);
             }
             String code = SimpleDataValueResolver.getFHIRCode(val, Enumerations.DocumentReferenceStatus.class);
-
             if (code != null) {
                 return code;
             } else {
                 return "current";
             }
-        } 
+        }
         return null;
     }
 
     public static String generateName(Object prefix, Object first, Object middle, Object family, Object suffix) {
         LOGGER.info("Generating name");
-        LOGGER.debug("Generating name from  from prefix {}, first {}, middle {}, family {} ,suffix {}", prefix, first, middle, family, suffix);
+        LOGGER.debug("Generating name from  from prefix {}, first {}, middle {}, family {} ,suffix {}", prefix, first,
+                middle, family, suffix);
         StringBuilder sb = new StringBuilder();
         String valprefix = Hl7DataHandlerUtil.getStringValue(prefix);
         String valfirst = Hl7DataHandlerUtil.getStringValue(first);
@@ -145,7 +146,6 @@ public class Hl7RelatedGeneralUtils {
         String valsuffix = Hl7DataHandlerUtil.getStringValue(suffix);
 
         if (valprefix != null) {
-
             sb.append(valprefix).append(" ");
         }
         if (valfirst != null) {
@@ -166,7 +166,6 @@ public class Hl7RelatedGeneralUtils {
         } else {
             return null;
         }
-
     }
 
     /**
@@ -176,14 +175,13 @@ public class Hl7RelatedGeneralUtils {
      * @param end DateTime
      * @return Minutes in Long
      */
-
     public static Long diffDateMin(Object start, Object end) {
         LOGGER.info("Generating time diff");
         LOGGER.debug("Generating time diff in min  from var1 {}, var2 {}", start, end);
         try {
             Temporal date1 = DateUtil.getTemporal(Hl7DataHandlerUtil.getStringValue(start));
             Temporal date2 = DateUtil.getTemporal(Hl7DataHandlerUtil.getStringValue(end));
-            LOGGER.info("computing temporal dates"); 
+            LOGGER.info("computing temporal dates");
             LOGGER.debug("temporal dates start: {} , end: {} ", date1, date2);
             if (date1 != null && date2 != null) {
                 return ChronoUnit.MINUTES.between(date1, date2);
@@ -203,20 +201,18 @@ public class Hl7RelatedGeneralUtils {
             if (stk.getTokenList().size() > index) {
                 return stk.getTokenList().get(index);
             }
-
         }
         return null;
     }
 
     public static String noWhiteSpace(Object input) {
         String val = Hl7DataHandlerUtil.getStringValue(input);
-        if(val != null) {
+        if (val != null) {
             String newVal = val.replaceAll("\\s", "_");
             String system = "urn:id:" + newVal;
-
             return system;
-        }
-        else return null;
+        } else
+            return null;
     }
 
     // Concatenates strings with a delimeter character(s) 
@@ -232,26 +228,19 @@ public class Hl7RelatedGeneralUtils {
 
         // Use this regex: r"(?<!\\)\\n|\n" but must double up backslashes in java string
         String delimiter = delimiterChar.replaceAll("(?<!\\\\)\\\\n|\\n", "\n");
-
-        String result = Hl7DataHandlerUtil.getStringValue(input, true, delimiter, false);
-        return result;
-        // return Hl7DataHandlerUtil.getStringValue(input, true, delimiter, false);
+        return Hl7DataHandlerUtil.getStringValue(input, true, delimiter, false, false);
     }
 
     public static List<String> makeStringArray(String... strs) {
         List<String> result = new ArrayList<>();
-
         for (String str : strs)
             if (str != null)
                 result.add(str);
-
         return result;
     }
 
-
-    public static String formatAsId(Object input)
-    {
-        if (input != null){
+    public static String formatAsId(Object input) {
+        if (input != null) {
             // This replaces any special character (other than letters, numbers, dashes, or periods) with a period
             // Then lower-cases, and truncates to 64 characters.
             String stringValue = Hl7DataHandlerUtil.getStringValue(input).trim();
@@ -321,25 +310,20 @@ public class Hl7RelatedGeneralUtils {
                 if (addresses.length == 1) {
                     returnDistrict = patientCountyPid12;
                 }
-
             } catch (HL7Exception e) {
                 // Do nothing. Just eat the error.
                 // Let the initial value stand
             }
-
         }
 
         return returnDistrict;
     }
-
-
 
     // Takes all the pieces of ContactPoint/telecom number from XTN, formats to a user friendly
     // ContactPoint/Telecom number based on rules documented in the steps
     public static String getFormattedTelecomNumberValue(String xtn1Old, String xtn5Country, String xtn6Area,
             String xtn7Local, String xtn8Extension, String xtn12Unformatted) {
         String returnValue = "";
-
         // If the local number exists...
         if (xtn7Local != null && xtn7Local.length() > 0) {
             returnValue = formatCountryAndArea(xtn5Country, xtn6Area) + formatLocalNumber(xtn7Local);
@@ -358,13 +342,11 @@ public class Hl7RelatedGeneralUtils {
         return returnValue;
     }
 
-
     public static String getNarrativeDiv(String text) {
-
-    	String divText = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>%s</p></div>";
-    	return String.format(divText, StringEscapeUtils.escapeHtml4(text).replace("~", "<br />"));    
+        String divText = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>%s</p></div>";
+        return String.format(divText, StringEscapeUtils.escapeHtml4(text).replace("~", "<br />"));
     }
-    
+
     // Private method to split and format the 7 digit local telecom number
     private static String formatLocalNumber(String localNumber) {
         // Split after the 3rd digit, add a space, add the rest of the number
@@ -387,6 +369,5 @@ public class Hl7RelatedGeneralUtils {
         }
         return returnValue;
     }
-    
 
 }

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -6,6 +6,7 @@
 package io.github.linuxforhealth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,354 +15,358 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import ca.uhn.hl7v2.model.Message;
-import ca.uhn.hl7v2.util.Hl7InputStreamMessageStringIterator;
-import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
-import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 import org.apache.commons.io.IOUtils;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
-import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Immunization;
 import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.util.Hl7InputStreamMessageStringIterator;
 import io.github.linuxforhealth.core.Constants;
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
+import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 
 public class FHIRConverterTest {
-  private static final String HL7_FILE_UNIX_NEWLINE = "src/test/resources/sample_unix.hl7";
-  private static final String HL7_FILE_WIN_NEWLINE = "src/test/resources/sample_win.hl7";
-  private static final String HL7_FILE_WIN_NEWLINE_BATCH = "src/test/resources/sample_win_batch.hl7";
-  private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
-  private static final Logger LOGGER = LoggerFactory.getLogger(FHIRConverterTest.class);
+    private static final String HL7_FILE_UNIX_NEWLINE = "src/test/resources/sample_unix.hl7";
+    private static final String HL7_FILE_WIN_NEWLINE = "src/test/resources/sample_win.hl7";
+    private static final String HL7_FILE_WIN_NEWLINE_BATCH = "src/test/resources/sample_win_batch.hl7";
+    private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
+    private static final Logger LOGGER = LoggerFactory.getLogger(FHIRConverterTest.class);
 
+    @Test
+    public void test_patient_encounter() throws IOException {
 
-  @Test
-  public void test_patient_encounter() throws IOException {
+        String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+                + "EVN||201209122222\r"
+                + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
+                + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
+                + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r"
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
 
-    String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
-        + "EVN||201209122222\r"
-        + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
-        + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
-        + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r"
-        + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
-        + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+        verifyResult(json, Constants.DEFAULT_BUNDLE_TYPE);
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
-    verifyResult(json, Constants.DEFAULT_BUNDLE_TYPE);
+    }
 
-  }
+    @Test
+    public void test_patient_encounter_no_message_header() throws IOException {
 
-  @Test
-  public void test_patient_encounter_no_message_header() throws IOException {
+        String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||\r"
+                + "EVN||201209122222\r"
+                + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
+                + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
+                + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r"
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
 
-    String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE|764|ASCII||||||\r"
-        + "EVN||201209122222\r"
-        + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
-        + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|20150206031726\r"
-        + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r"
-        + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
-        + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+        LOGGER.debug("FHIR json result:\n" + json);
+        verifyResult(json, Constants.DEFAULT_BUNDLE_TYPE, false);
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
-    LOGGER.info("FHIR json result:\n" + json);
-    verifyResult(json, Constants.DEFAULT_BUNDLE_TYPE, false);
+    }
 
-  }
+    @Test
+    public void convert_hl7_from_file_to_fhir_unix_line_endings() throws IOException {
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(new File(HL7_FILE_UNIX_NEWLINE));
+        verifyResult(json, BundleType.COLLECTION);
 
-  @Test
-  public void convert_hl7_from_file_to_fhir_unix_line_endings() throws IOException {
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(new File(HL7_FILE_UNIX_NEWLINE));
-    verifyResult(json, BundleType.COLLECTION);
+    }
 
-  }
+    @Test
+    public void convert_hl7_from_file_to_fhir_wiin_line_endings() throws IOException {
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        ConverterOptions options = new Builder().withBundleType(BundleType.COLLECTION).withValidateResource().build();
 
-  @Test
-  public void convert_hl7_from_file_to_fhir_wiin_line_endings() throws IOException {
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    ConverterOptions options = new Builder().withBundleType(BundleType.COLLECTION).withValidateResource().build();
+        String json = ftv.convert(new File(HL7_FILE_WIN_NEWLINE), options);
+        verifyResult(json, BundleType.COLLECTION);
 
-    String json = ftv.convert(new File(HL7_FILE_WIN_NEWLINE), options);
-    verifyResult(json, BundleType.COLLECTION);
+    }
 
-  }
+    @Test
+    public void test_valid_message_but_unsupported_message_throws_exception() throws IOException {
+        String hl7message = "MSH|^~\\&|MESA_ADT|XYZ_ADMITTING|MESA_IS|XYZ_HOSPITAL|201612291501||ADT^A18^ADT_A18|101166|P|2.3.1\n"
+                + "EVN|A18|201604211000||||201604210950\n"
+                + "PID|1||000010004^^^ST01A^MR~000010014^^^ST01B^MR~000010024^^^ST01^MR~000029970^^^EHIS^PI~999999999^^^SSA^SS||SENTARA10004^PAT^L||19251008|F||Caucasian||||||Married|Protestant|1002523||||||||||||PV1|1|O|||||2740^Tsadok^Janetary|2913^Merrit^Darren^F|3065^Mahoney^Paul^J||||||||9052^Winter^Oscar^||1001918\n"
+                + "PV1|1|O|||||2741^Yung^Den|2914^Smith^John^F|3066^Mahr^Paul^J||||||||9053^Summer^Oscar^||1001200\n"
+                + "MRG|000010510^^^def^MR~000010765^^^ST01B^MR|||000010510^^^def|||WHITE^CHARLES";
 
-  @Test
-  public void test_valid_message_but_unsupported_message_throws_exception() throws IOException {
-    String hl7message = "MSH|^~\\&|MESA_ADT|XYZ_ADMITTING|MESA_IS|XYZ_HOSPITAL|201612291501||ADT^A18^ADT_A18|101166|P|2.3.1\n"
-    		+ "EVN|A18|201604211000||||201604210950\n"
-    		+ "PID|1||000010004^^^ST01A^MR~000010014^^^ST01B^MR~000010024^^^ST01^MR~000029970^^^EHIS^PI~999999999^^^SSA^SS||SENTARA10004^PAT^L||19251008|F||Caucasian||||||Married|Protestant|1002523||||||||||||PV1|1|O|||||2740^Tsadok^Janetary|2913^Merrit^Darren^F|3065^Mahoney^Paul^J||||||||9052^Winter^Oscar^||1001918\n"
-    		+ "PV1|1|O|||||2741^Yung^Den|2914^Smith^John^F|3066^Mahr^Paul^J||||||||9053^Summer^Oscar^||1001200\n"
-    		+ "MRG|000010510^^^def^MR~000010765^^^ST01B^MR|||000010510^^^def|||WHITE^CHARLES";
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            ftv.convert(hl7message);
+        });
+    }
 
-    Assertions.assertThrows(UnsupportedOperationException.class, () -> {
-        ftv.convert(hl7message);
-    });
-  }
-
-  @Test
-  public void test_dosage_output() throws  IOException {
-String hl7message =
-                "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r" +
-                "PID|1||PA123456^^^MYEMR^MR||JONES^GEORGE^M^JR^^^L|MILLER^MARTHA^G^^^^M|20140227|M||2106-3^WHITE^CDCREC|1234 W FIRST ST^^BEVERLY HILLS^CA^90210^^H||^PRN^PH^^^555^5555555||ENG^English^HL70296|||||||2186-5^ not Hispanic or Latino^CDCREC||Y|2\r" +
+    @Test
+    public void test_dosage_output() throws IOException {
+        String hl7message = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
+                +
+                "PID|1||PA123456^^^MYEMR^MR||JONES^GEORGE^M^JR^^^L|MILLER^MARTHA^G^^^^M|20140227|M||2106-3^WHITE^CDCREC|1234 W FIRST ST^^BEVERLY HILLS^CA^90210^^H||^PRN^PH^^^555^5555555||ENG^English^HL70296|||||||2186-5^ not Hispanic or Latino^CDCREC||Y|2\r"
+                +
                 "ORC|RE||197023^CMC|||||||^Clark^Dave||1234567890^Smith^Janet^^^^^^NPPES^L^^^NPI^^^^^^^^MD\r" +
                 "RXA|0|1|20140730||08^HEPB-PEDIATRIC/ADOLESCENT^CVX|.5|mL^mL^UCUM||00^NEW IMMUNIZATION RECORD^NIP001|1234567890^Smith^Janet^^^^^^NPPES^^^^NPI^^^^^^^^MD |^^^DE-000001||||0039F|20200531|MSD^MERCK^MVX|||CP|A";
 
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7message, OPTIONS);
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
 
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> immunization =
-            e.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> immunization = e.stream()
+                .filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(immunization).hasSize(1);
+
+        String s = context.getParser().encodeResourceToString(immunization.get(0));
+        Class<? extends IBaseResource> klass = Immunization.class;
+        Immunization expectDoseQuantity = (Immunization) context.getParser().parseResource(klass, s);
+        assertThat(expectDoseQuantity.hasDoseQuantity()).isTrue();
+        Quantity dosage = expectDoseQuantity.getDoseQuantity();
+        BigDecimal value = dosage.getValue();
+        String unit = dosage.getUnit();
+        assertThat(value).isEqualTo(BigDecimal.valueOf(.5));
+        assertThat(unit).isEqualTo("mL");
+    }
+
+    @Test
+    public void test_invalid_message_throws_error() throws IOException {
+        String hl7message = "some text";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ftv.convert(hl7message);
+        });
+    }
+
+    @Test
+    public void test_blank_message_throws_error() throws IOException {
+        String hl7message = "";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ftv.convert(hl7message);
+        });
+    }
+
+    @Test
+    // Test an example of a message with message structure specified
+    public void test_adt_40_message_with_adt_a39_structure_specified() throws Exception {
+        Message hl7message = null;
+        // Test that an ADT A40 message with MSH-9.3 of 'ADT_A39' is successfully parsed and converted as an ADT A40 message.
+        // Note that ADT_A39 is the expected structure of an ADT_A40 message.
+        String hl7messageString = "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40^ADT_A39|00000003|P|2.6\n" +
+                "PID|||MR1^^^XYZ||MAIDENNAME^EVE\n" +
+                "MRG|MR2^^^XYZ\n";
+
+        InputStream ins = IOUtils.toInputStream(hl7messageString, StandardCharsets.UTF_8);
+        Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
+
+        if (iterator.hasNext()) {
+            HL7HapiParser hparser = new HL7HapiParser();
+            hl7message = hparser.getParser().parse(iterator.next());
+        }
+
+        String messageType = HL7DataExtractor.getMessageType(hl7message);
+
+        assertThat(messageType).isEqualTo("ADT_A40");
+
+        // Convert and check for a patient resource
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7messageString, ConverterOptions.SIMPLE_OPTIONS);
+
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+        assertThat(b.getId()).isNotNull();
+        assertThat(b.getMeta().getLastUpdated()).isNotNull();
+
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(2);
+
+    }
+
+    @Test
+    // Test an example of a message with no message structure specifed
+    public void test_adt_40_message() throws Exception {
+        Message hl7message = null;
+        // Test that an ADT A40 message with no MSH-9.3 is successfully parsed and converted.
+        String hl7messageString = "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40|00000003|P|2.6\n" +
+                "PID|||MR1^^^XYZ||MAIDENNAME^EVE\n" +
+                "MRG|MR2^^^XYZ\n";
+
+        InputStream ins = IOUtils.toInputStream(hl7messageString, StandardCharsets.UTF_8);
+        Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
+
+        if (iterator.hasNext()) {
+            HL7HapiParser hparser = new HL7HapiParser();
+            hl7message = hparser.getParser().parse(iterator.next());
+        }
+
+        String messageType = HL7DataExtractor.getMessageType(hl7message);
+
+        assertThat(messageType).isEqualTo("ADT_A40");
+
+        // Convert and check for a patient resource
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7messageString, ConverterOptions.SIMPLE_OPTIONS);
+
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+        assertThat(b.getId()).isNotNull();
+        assertThat(b.getMeta().getLastUpdated()).isNotNull();
+
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(2);
+
+    }
+
+    @Test
+    /*
+     * This tests some of coding systems of interest or potential problems
+     */
+    public void testCodingSystems() throws FHIRException {
+        String hl7VUXmessageRep = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|201305330||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+                + "EVN|A01|20130617154644||01\r"
+                + "PID|1||12345678^^^MYEMR^MR||TestPatient^John|||M|\r"
+                + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
+                // Test MVX
+                + "RXA|0|1|20130528|20130529|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
+                // Test HL70162 & HL70163
+                + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+
+        String json = ftv.convert(hl7VUXmessageRep, OPTIONS);
+
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+        assertThat(b.getId()).isNotNull();
+        List<BundleEntryComponent> e = b.getEntry();
+
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(obsResource).hasSize(1);
+
+        Immunization immunization = (Immunization) obsResource.get(0);
+
+        // Check that organization identifier (MVX) has a system
+        Organization org = (Organization) immunization.getManufacturer().getResource();
+        List<Identifier> li = org.getIdentifier();
+        Identifier ident = li.get(0);
+        assertThat(ident.hasSystem()).isTrue();
+        assertThat(ident.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/MVX");
+        assertThat(ident.hasValue()).isTrue();
+        assertThat(ident.getValue()).isEqualTo("PMC");
+
+        // Check that route (HL70162) has a system
+        CodeableConcept route = immunization.getRoute();
+        assertThat(route.hasCoding()).isTrue();
+        List<Coding> codings = route.getCoding();
+        assertThat(codings.size()).isEqualTo(2);
+        Coding coding = codings.get(0);
+        // If the first one is not the one we want look at the second one.
+        if (coding.getCode().contains("C28161")) {
+            coding = codings.get(1);
+        }
+        assertThat(coding.hasSystem()).isTrue();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0162");
+
+        // Check that site (HL70163) has a system
+        CodeableConcept site = immunization.getSite();
+        coding = site.getCodingFirstRep();
+        assertThat(coding.hasSystem()).isTrue();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0163");
+    }
+
+    private void verifyResult(String json, BundleType expectedBundleType) {
+        verifyResult(json, expectedBundleType, true);
+    }
+
+    private void verifyResult(String json, BundleType expectedBundleType, boolean messageHeaderExpected) {
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        assertThat(b.getType()).isEqualTo(expectedBundleType);
+        assertThat(b.getId()).isNotNull();
+        assertThat(b.getMeta().getLastUpdated()).isNotNull();
+
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
+
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource)
+                .collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
+        List<Resource> obsResource = e.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // No Observation resource because OBX.2 is type TX        
+        assertThat(obsResource).isEmpty();
+
+        List<Resource> pracResource = e.stream()
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(pracResource).hasSize(4);
+
+        List<Resource> allergyResources = e.stream()
+                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(allergyResources).hasSize(2);
+
+        if (messageHeaderExpected) {
+            List<Resource> messageHeader = e.stream()
+                    .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
                     .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(immunization).hasSize(1);
-
-    String s = context.getParser().encodeResourceToString(immunization.get(0));
-    Class<? extends IBaseResource> klass = Immunization.class;
-    Immunization expectDoseQuantity = (Immunization) context.getParser().parseResource(klass, s);
-    assertThat(expectDoseQuantity.hasDoseQuantity()).isTrue();
-    Quantity dosage = expectDoseQuantity.getDoseQuantity();
-    BigDecimal value = dosage.getValue();
-    String  unit = dosage.getUnit();
-    assertThat(value).isEqualTo(BigDecimal.valueOf(.5));
-    assertThat(unit).isEqualTo("mL");
-  }
-
-  @Test
-  public void test_invalid_message_throws_error() throws IOException {
-    String hl7message = "some text";
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-   
-    Assertions.assertThrows(IllegalArgumentException.class, () -> {
-        ftv.convert(hl7message);
-    });
-  }
-
-  @Test
-  public void test_blank_message_throws_error() throws IOException {
-    String hl7message = "";
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-
-    Assertions.assertThrows(IllegalArgumentException.class, () -> {
-        ftv.convert(hl7message);
-    });
-  }
-
-  @Test
-  // Test an example of a message with message structure specified
-  public void test_adt_40_message_with_adt_a39_structure_specified() throws Exception {
-    Message hl7message = null;
-    // Test that an ADT A40 message with MSH-9.3 of 'ADT_A39' is successfully parsed and converted as an ADT A40 message.
-    // Note that ADT_A39 is the expected structure of an ADT_A40 message.
-    String hl7messageString =
-            "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40^ADT_A39|00000003|P|2.6\n" +
-            "PID|||MR1^^^XYZ||MAIDENNAME^EVE\n" +
-            "MRG|MR2^^^XYZ\n";
-
-    InputStream ins = IOUtils.toInputStream(hl7messageString, StandardCharsets.UTF_8);
-    Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
-
-    if (iterator.hasNext()) {
-      HL7HapiParser hparser = new HL7HapiParser();
-      hl7message = hparser.getParser().parse(iterator.next());
+            assertThat(messageHeader).hasSize(1);
+        }
     }
-
-    String messageType = HL7DataExtractor.getMessageType(hl7message);
-
-    assertThat(messageType).isEqualTo("ADT_A40");
-
-    // Convert and check for a patient resource
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7messageString, ConverterOptions.SIMPLE_OPTIONS);
-
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource = e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(2);
-
-  }
-
-  @Test
-  // Test an example of a message with no message structure specifed
-  public void test_adt_40_message() throws Exception {
-    Message hl7message = null;
-    // Test that an ADT A40 message with no MSH-9.3 is successfully parsed and converted.
-    String hl7messageString =
-            "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40|00000003|P|2.6\n" +
-            "PID|||MR1^^^XYZ||MAIDENNAME^EVE\n" +
-            "MRG|MR2^^^XYZ\n";
-
-    InputStream ins = IOUtils.toInputStream(hl7messageString, StandardCharsets.UTF_8);
-    Hl7InputStreamMessageStringIterator iterator = new Hl7InputStreamMessageStringIterator(ins);
-
-    if (iterator.hasNext()) {
-      HL7HapiParser hparser = new HL7HapiParser();
-      hl7message = hparser.getParser().parse(iterator.next());
-    }
-
-    String messageType = HL7DataExtractor.getMessageType(hl7message);
-    
-
-    assertThat(messageType).isEqualTo("ADT_A40");
-
-    // Convert and check for a patient resource
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(hl7messageString, ConverterOptions.SIMPLE_OPTIONS);
-
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource = e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(2);
-
-  }
-
-  @Test
-  /*
-   * This tests some of coding systems of interest or potential problems
-   */
-  public void testCodingSystems() throws FHIRException {
-    String hl7VUXmessageRep = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|201305330||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
-        + "EVN|A01|20130617154644||01\r"
-        + "PID|1||12345678^^^MYEMR^MR||TestPatient^John|||M|\r"
-        + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-        // Test MVX
-        + "RXA|0|1|20130528|20130529|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
-        // Test HL70162 & HL70163
-        + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r";
-
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-
-    String json = ftv.convert(hl7VUXmessageRep, OPTIONS);
-
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-    assertThat(b.getId()).isNotNull();
-    List<BundleEntryComponent> e = b.getEntry();
-
-    List<Resource> obsResource = e.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(obsResource).hasSize(1);
-
-    Immunization immunization = (Immunization) obsResource.get(0);
-
-    // Check that organization identifier (MVX) has a system
-    Organization org = (Organization) immunization.getManufacturer().getResource();
-    List<Identifier> li = org.getIdentifier();
-    Identifier ident = li.get(0);
-    assertThat(ident.hasSystem()).isTrue();
-    assertThat(ident.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/MVX");
-    assertThat(ident.hasValue()).isTrue();
-    assertThat(ident.getValue()).isEqualTo("PMC");
-
-    // Check that route (HL70162) has a system
-    CodeableConcept route = immunization.getRoute();
-    assertThat(route.hasCoding()).isTrue();
-    List<Coding> codings = route.getCoding();
-    assertThat(codings.size()).isEqualTo(2);
-    Coding coding = codings.get(0);
-    // If the first one is not the one we want look at the second one.
-    if (coding.getCode().contains("C28161")){
-      coding = codings.get(1);
-    }
-    assertThat(coding.hasSystem()).isTrue();
-    assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0162");
-
-    // Check that site (HL70163) has a system
-    CodeableConcept site = immunization.getSite();
-    coding = site.getCodingFirstRep();
-    assertThat(coding.hasSystem()).isTrue();
-    assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0163");
-  }
-
-  private void verifyResult(String json, BundleType expectedBundleType) {
-    verifyResult(json, expectedBundleType, true);
-  }
-
-  private void verifyResult(String json, BundleType expectedBundleType, boolean messageHeaderExpected) {
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    assertThat(b.getType()).isEqualTo(expectedBundleType);
-    assertThat(b.getId()).isNotNull();
-    assertThat(b.getMeta().getLastUpdated()).isNotNull();
-
-    List<BundleEntryComponent> e = b.getEntry();
-    List<Resource> patientResource = e.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patientResource).hasSize(1);
-
-    List<Resource> encounterResource = e.stream()
-        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType()).map(BundleEntryComponent::getResource)
-        .collect(Collectors.toList());
-    assertThat(encounterResource).hasSize(1);
-    List<Resource> obsResource = e.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    // No Observation resource because OBX.2 is type TX        
-    assertThat(obsResource).isEmpty();
-    
-    List<Resource> pracResource = e.stream().filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(pracResource).hasSize(4);
-
-    List<Resource> allergyResources = e.stream()
-        .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(allergyResources).hasSize(2);
-
-    if (messageHeaderExpected) {
-      List<Resource> messageHeader = e.stream()
-          .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
-          .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(messageHeader).hasSize(1);
-    }
-  }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -10,361 +10,361 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hl7.fhir.r4.model.codesystems.EncounterStatus;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.hl7.fhir.r4.model.codesystems.EncounterStatus;
-import org.junit.jupiter.api.Test;
-
 public class Hl7RelatedGeneralUtilsTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Hl7RelatedGeneralUtilsTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7RelatedGeneralUtilsTest.class);
 
-  @Test
-  public void testConcatenateWithChar() {
+    @Test
+    public void testConcatenateWithChar() {
 
-    ArrayList<Object> objects = new ArrayList<Object>();
-    String st = "AA";
-    objects.add(st);
-    st = "BB";
-    objects.add(st);
+        ArrayList<Object> objects = new ArrayList<Object>();
+        String st = "AA";
+        objects.add(st);
+        st = "BB";
+        objects.add(st);
 
-    String concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \n");
-    assertThat(concatted).isEqualTo("AA  \nBB  \n");
+        String concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \n");
+        assertThat(concatted).isEqualTo("AA  \nBB");
 
-    // Simulate the input from YAML
-    // YAML doesn't reduce the '\n' to linefeed, but inputs 92 78, a literal backslash n
-    // For this test, we force the string to contain 32 32 92 78 by using a double backslash
-    concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \\n");
-    assertThat(concatted).isEqualTo("AA  \nBB  \n");
+        // Simulate the input from YAML
+        // YAML doesn't reduce the '\n' to linefeed, but inputs 92 78, a literal backslash n
+        // For this test, we force the string to contain 32 32 92 78 by using a double backslash
+        concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \\n");
+        assertThat(concatted).isEqualTo("AA  \nBB");
 
-    // Simulate the input from YAML
-    // For this test, we force the string to contain 32 32 92 92 78 by using a two double backslashes
-    // We want, in this case to assure that a double backslash input will be taken literally
-    concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \\\\n");
-    assertThat(concatted).isEqualTo("AA  \\\\nBB  \\\\n");
+        // Simulate the input from YAML
+        // For this test, we force the string to contain 32 32 92 92 78 by using a two double backslashes
+        // We want, in this case to assure that a double backslash input will be taken literally
+        concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, "  \\\\n");
+        assertThat(concatted).isEqualTo("AA  \\\\nBB");
 
-    // Simulate the input from YAML
-    // For this test, we force the string to contain 32 92 78 32 92 78 32 by using double backslash
-    // This tests that both intended linefeeds in input " \n \n " are handled.
-    concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, " \\n \\n ");
-    assertThat(concatted).isEqualTo("AA \n \n BB \n \n ");
-  }
+        // Simulate the input from YAML
+        // For this test, we force the string to contain 32 92 78 32 92 78 32 by using double backslash
+        // This tests that both intended linefeeds in input " \n \n " are handled.
+        concatted = Hl7RelatedGeneralUtils.concatenateWithChar(objects, " \\n \\n ");
+        assertThat(concatted).isEqualTo("AA \n \n BB");
+    }
 
-  @Test
-  public void test_generate_name() {
-    String name = Hl7RelatedGeneralUtils.generateName("prefix", "first", "M", "family", "suffix");
-    assertThat(name).isEqualTo("prefix first M family suffix");
-    LOGGER.debug("name=" + name);
-  }
+    @Test
+    public void test_generate_name() {
+        String name = Hl7RelatedGeneralUtils.generateName("prefix", "first", "M", "family", "suffix");
+        assertThat(name).isEqualTo("prefix first M family suffix");
+        LOGGER.debug("name=" + name);
+    }
 
-  @Test
-  public void test_generate_name_prefix_suffix_missing() {
-    String name = Hl7RelatedGeneralUtils.generateName(null, "first", "M", "family", null);
-    assertThat(name).isEqualTo("first M family");
-  }
+    @Test
+    public void test_generate_name_prefix_suffix_missing() {
+        String name = Hl7RelatedGeneralUtils.generateName(null, "first", "M", "family", null);
+        assertThat(name).isEqualTo("first M family");
+    }
 
-  @Test
-  public void test_get_encounter_var1() {
-    // if var1 is not null then EncounterStatus.FINISHED
-    String name = Hl7RelatedGeneralUtils.getEncounterStatus("var1", "var2", "var3");
-    assertThat(name).isEqualTo(EncounterStatus.FINISHED.toCode());
-  }
+    @Test
+    public void test_get_encounter_var1() {
+        // if var1 is not null then EncounterStatus.FINISHED
+        String name = Hl7RelatedGeneralUtils.getEncounterStatus("var1", "var2", "var3");
+        assertThat(name).isEqualTo(EncounterStatus.FINISHED.toCode());
+    }
 
-  @Test
-  public void test_get_encounter_var2() {
+    @Test
+    public void test_get_encounter_var2() {
 
-    String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, "var2", "var3");
-    assertThat(name).isEqualTo(EncounterStatus.ARRIVED.toCode());
-  }
+        String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, "var2", "var3");
+        assertThat(name).isEqualTo(EncounterStatus.ARRIVED.toCode());
+    }
 
-  @Test
-  public void test_get_encounter_var3() {
+    @Test
+    public void test_get_encounter_var3() {
 
-    String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, null, "var3");
-    assertThat(name).isEqualTo(EncounterStatus.CANCELLED.toCode());
-  }
+        String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, null, "var3");
+        assertThat(name).isEqualTo(EncounterStatus.CANCELLED.toCode());
+    }
 
-  @Test
-  public void test_get_encounter_all_vars_null() {
+    @Test
+    public void test_get_encounter_all_vars_null() {
 
-    String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, null, null);
-    assertThat(name).isEqualTo(EncounterStatus.UNKNOWN.toCode());
-  }
+        String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, null, null);
+        assertThat(name).isEqualTo(EncounterStatus.UNKNOWN.toCode());
+    }
 
-  @Test
-  public void test_date_diff_valid_values_same_dates() {
+    @Test
+    public void test_date_diff_valid_values_same_dates() {
 
-    long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
-        "2007-11-04T01:32:06.345+09:00");
-    assertThat(diff).isEqualTo(0);
-  }
+        long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
+                "2007-11-04T01:32:06.345+09:00");
+        assertThat(diff).isEqualTo(0);
+    }
 
-  @Test
-  public void test_date_diff_valid_values_1min_ahead() {
+    @Test
+    public void test_date_diff_valid_values_1min_ahead() {
 
-    long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
-        "2007-11-04T01:33:06.345+09:00");
-    assertThat(diff).isEqualTo(1);
-  }
+        long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
+                "2007-11-04T01:33:06.345+09:00");
+        assertThat(diff).isEqualTo(1);
+    }
 
-  @Test
-  public void test_date_diff_valid_values_no_min() {
+    @Test
+    public void test_date_diff_valid_values_no_min() {
 
-    Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-05",
-        "2007-11-04T01:33:06.345+20:00");
-    assertThat(diff).isNull();
-  }
+        Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-05",
+                "2007-11-04T01:33:06.345+20:00");
+        assertThat(diff).isNull();
+    }
 
-  @Test
-  public void test_date_diff_null_values() {
+    @Test
+    public void test_date_diff_null_values() {
 
-    Long diff = Hl7RelatedGeneralUtils.diffDateMin(null, "2007-11-04T01:33:06.345+09:00");
-    assertThat(diff).isNull();
-  }
+        Long diff = Hl7RelatedGeneralUtils.diffDateMin(null, "2007-11-04T01:33:06.345+09:00");
+        assertThat(diff).isNull();
+    }
 
-  @Test
-  public void test_date_diff_incorrect_date_format() {
+    @Test
+    public void test_date_diff_incorrect_date_format() {
 
-    Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:33:06890",
-        "2007-11-04T01:33:06.345+09:00");
-    assertThat(diff).isNull();
-  }
+        Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:33:06890",
+                "2007-11-04T01:33:06.345+09:00");
+        assertThat(diff).isNull();
+    }
 
-  @Test
-  public void test_splitting_values() {
+    @Test
+    public void test_splitting_values() {
 
-    String val = Hl7RelatedGeneralUtils.split("5.9-8.4", "-", 0);
-    assertThat(val).isEqualTo("5.9");
-  }
+        String val = Hl7RelatedGeneralUtils.split("5.9-8.4", "-", 0);
+        assertThat(val).isEqualTo("5.9");
+    }
 
-  // ExtractHigh and ExtractLow assumes if there are two or more values, the first is low, the second is high,
-  // but if there is only one value, it is the high
-  @Test
-  public void testExtractHigh() {
+    // ExtractHigh and ExtractLow assumes if there are two or more values, the first is low, the second is high,
+    // but if there is only one value, it is the high
+    @Test
+    public void testExtractHigh() {
 
-    String aString = "27.0-55.2";
-    String resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
-    assertThat(resultValue).isEqualTo("55.2");
+        String aString = "27.0-55.2";
+        String resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+        assertThat(resultValue).isEqualTo("55.2");
 
-    aString = "47.47";
-    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
-    assertThat(resultValue).isEqualTo("47.47");
+        aString = "47.47";
+        resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+        assertThat(resultValue).isEqualTo("47.47");
 
-    aString = "<0.50 IU/mL";
-    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
-    assertThat(resultValue).isEqualTo("0.50");
+        aString = "<0.50 IU/mL";
+        resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+        assertThat(resultValue).isEqualTo("0.50");
 
-    aString = "something111another222more333done";
-    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
-    assertThat(resultValue).isEqualTo("222");
+        aString = "something111another222more333done";
+        resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+        assertThat(resultValue).isEqualTo("222");
 
-    aString = "Normal";
-    resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
-    assertThat(resultValue).isNull();
+        aString = "Normal";
+        resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
+        assertThat(resultValue).isNull();
 
-  }
+    }
 
-  // ExtractHigh and ExtractLow assumes if there are two or more numbers (with or without decimal points), 
-  // the first is low, the second is high, but if there is only one value, it is the high
-  // See extensive notes near the methods. 
-  @Test
-  public void testExtractLow() {
+    // ExtractHigh and ExtractLow assumes if there are two or more numbers (with or without decimal points), 
+    // the first is low, the second is high, but if there is only one value, it is the high
+    // See extensive notes near the methods. 
+    @Test
+    public void testExtractLow() {
 
-    String aString = "27.0-55.2";
-    String resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
-    assertThat(resultValue).isEqualTo("27.0");
+        String aString = "27.0-55.2";
+        String resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+        assertThat(resultValue).isEqualTo("27.0");
 
-    aString = "47.47";
-    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
-    assertThat(resultValue).isNull();
+        aString = "47.47";
+        resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+        assertThat(resultValue).isNull();
 
-    aString = "<0.50 IU/mL";
-    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
-    assertThat(resultValue).isNull();
+        aString = "<0.50 IU/mL";
+        resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+        assertThat(resultValue).isNull();
 
-    aString = "something111another222more333done";
-    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
-    assertThat(resultValue).isEqualTo("111");
+        aString = "something111another222more333done";
+        resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+        assertThat(resultValue).isEqualTo("111");
 
-    aString = "Normal";
-    resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
-    assertThat(resultValue).isNull();
+        aString = "Normal";
+        resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
+        assertThat(resultValue).isNull();
 
-  }
+    }
 
-  @Test
-  public void test_makeStringArray() {
-    // Test for 2
-    List<String> stringArray = Hl7RelatedGeneralUtils.makeStringArray("banana", "peach");
-    assertThat(stringArray.size()).isEqualTo(2);
-    assertThat(stringArray.get(0)).isEqualTo("banana");
-    // Test for 3
-    stringArray = Hl7RelatedGeneralUtils.makeStringArray("apple", "banana", "peach");
-    assertThat(stringArray.size()).isEqualTo(3);
-    assertThat(stringArray.get(0)).isEqualTo("apple");
-    // Test for 0; expect an empty array
-    stringArray = Hl7RelatedGeneralUtils.makeStringArray();
-    assertThat(stringArray.size()).isEqualTo(0);
-  }
+    @Test
+    public void test_makeStringArray() {
+        // Test for 2
+        List<String> stringArray = Hl7RelatedGeneralUtils.makeStringArray("banana", "peach");
+        assertThat(stringArray.size()).isEqualTo(2);
+        assertThat(stringArray.get(0)).isEqualTo("banana");
+        // Test for 3
+        stringArray = Hl7RelatedGeneralUtils.makeStringArray("apple", "banana", "peach");
+        assertThat(stringArray.size()).isEqualTo(3);
+        assertThat(stringArray.get(0)).isEqualTo("apple");
+        // Test for 0; expect an empty array
+        stringArray = Hl7RelatedGeneralUtils.makeStringArray();
+        assertThat(stringArray.size()).isEqualTo(0);
+    }
 
-  @Test
-  public void test_getAddressUse() {
-    String ANYTHING = "anything";
-    // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", null, ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", null, null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", ANYTHING)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", null)).isEqualTo("temp");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, null)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, "")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, null)).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, "")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, null)).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, "Y")).isEqualTo("old");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, ANYTHING)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, ANYTHING)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, null)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, null)).isEqualTo("home");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", ANYTHING, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", ANYTHING, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", null, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", null, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", ANYTHING, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", ANYTHING, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", null, ANYTHING)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", null, null)).isEqualTo("work");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, ANYTHING)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, ANYTHING)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, null)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, null)).isEqualTo("billing");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, null)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, null)).isEqualTo("");
+    @Test
+    public void test_getAddressUse() {
+        String ANYTHING = "anything";
+        // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", ANYTHING)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", null)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", null, ANYTHING)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", null, null)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", ANYTHING)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", null)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", ANYTHING)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", null)).isEqualTo("temp");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, null)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, "")).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, null)).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, "")).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, null)).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, "Y")).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, "Y")).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, "Y")).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, "Y")).isEqualTo("old");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, ANYTHING)).isEqualTo("home");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, ANYTHING)).isEqualTo("home");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, null)).isEqualTo("home");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, null)).isEqualTo("home");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", ANYTHING, ANYTHING)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", ANYTHING, null)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", null, ANYTHING)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("B", null, null)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", ANYTHING, ANYTHING)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", ANYTHING, null)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", null, ANYTHING)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("O", null, null)).isEqualTo("work");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, ANYTHING)).isEqualTo("billing");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, ANYTHING)).isEqualTo("billing");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, null)).isEqualTo("billing");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, null)).isEqualTo("billing");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, null)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, null)).isEqualTo("");
 
-  }
+    }
 
-  @Test
-  public void test_getAddressType() {
-    String ANYTHING = "anything";
-    // Inputs are XAD.7 Type, XAD.18 Type 
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "M")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", null)).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "V")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", null)).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, null)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(null, null)).isEqualTo("");
+    @Test
+    public void test_getAddressType() {
+        String ANYTHING = "anything";
+        // Inputs are XAD.7 Type, XAD.18 Type 
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "M")).isEqualTo("postal");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", null)).isEqualTo("postal");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "V")).isEqualTo("physical");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", null)).isEqualTo("physical");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, null)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, null)).isEqualTo("");
 
-  }
+    }
 
-  @Test
-  public void test_getAddressDistrict() {
-    String ANYTHING = "anything";
+    @Test
+    public void test_getAddressDistrict() {
+        String ANYTHING = "anything";
 
-    // Inputs are XAD.7 Type, XAD.18 Type 
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
-    assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
-  }
-  // Note: Utility  Hl7RelatedGeneralUtils.getAddressDistrict is more effectively tested as part of Patient Address testing
+        // Inputs are XAD.7 Type, XAD.18 Type 
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
+    }
+    // Note: Utility  Hl7RelatedGeneralUtils.getAddressDistrict is more effectively tested as part of Patient Address testing
 
-  @Test
-  public void getFormattedTelecomNumberValue() {
-    // Empty values return nothing
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "")).isEmpty();
-    // Everything empty except XTN1 returns XTN1.
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "", "", "")).isEqualTo("111");
-    // Everything empty except XTN12 returns XTN12.
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "112")).isEqualTo("112");
-    // XTN12 takes priority over XTN1
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "", "", "112")).isEqualTo("112");
-    // Country, Area, and Extension are ignored if there is no Local number
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "22", "333", "", "555", "")).isEmpty();
-    // XTN12 and XTN1 will be used if no local number
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "", "555", ""))
-        .isEqualTo("111");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "22", "333", "", "555", "112"))
-        .isEqualTo("112");
-    // Country, Area, and Extension are used if there is a Local number and they exist, and XTN1 and XTN12 are ignored  
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
-        .isNotEmpty();
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
-        .contains("+22");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
-        .contains("333");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
-        .contains("4444");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
-        .contains("ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
-        .isEqualTo("+22 333 444 4444 ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "", "112"))
-        .isEqualTo("+22 333 444 4444"); // Same rule without extension
-    // Area, and Extension are used if there is a Local number, and XTN1 and XTN12 are ignored  
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
-        .isNotEmpty();
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
-        .contains("333");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
-        .contains("4444");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
-        .contains("ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
-        .isEqualTo("(333) 444 4444 ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "", "112"))
-        .isEqualTo("(333) 444 4444"); // Same rule without extension
-    // If local and country but no area, country is not prepended,only local is returned; XTN1 and XTN12 are ignored  
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
-        .isNotEmpty();
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
-        .contains("4444");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
-        .contains("ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
-        .isEqualTo("444 4444 ext. 555");
-    assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "", "112"))
-        .isEqualTo("444 4444"); // Same rule without extension
-  }
+    @Test
+    public void getFormattedTelecomNumberValue() {
+        // Empty values return nothing
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "")).isEmpty();
+        // Everything empty except XTN1 returns XTN1.
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "", "", "")).isEqualTo("111");
+        // Everything empty except XTN12 returns XTN12.
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "112")).isEqualTo("112");
+        // XTN12 takes priority over XTN1
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "", "", "112"))
+                .isEqualTo("112");
+        // Country, Area, and Extension are ignored if there is no Local number
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "22", "333", "", "555", "")).isEmpty();
+        // XTN12 and XTN1 will be used if no local number
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "", "555", ""))
+                .isEqualTo("111");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "22", "333", "", "555", "112"))
+                .isEqualTo("112");
+        // Country, Area, and Extension are used if there is a Local number and they exist, and XTN1 and XTN12 are ignored  
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+                .isNotEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+                .contains("+22");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+                .contains("333");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+                .contains("4444");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+                .contains("ext. 555");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "555", "112"))
+                .isEqualTo("+22 333 444 4444 ext. 555");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "22", "333", "4444444", "", "112"))
+                .isEqualTo("+22 333 444 4444"); // Same rule without extension
+        // Area, and Extension are used if there is a Local number, and XTN1 and XTN12 are ignored  
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+                .isNotEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+                .contains("333");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+                .contains("4444");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+                .contains("ext. 555");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "555", "112"))
+                .isEqualTo("(333) 444 4444 ext. 555");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "333", "4444444", "", "112"))
+                .isEqualTo("(333) 444 4444"); // Same rule without extension
+        // If local and country but no area, country is not prepended,only local is returned; XTN1 and XTN12 are ignored  
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+                .isNotEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+                .contains("4444");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+                .contains("ext. 555");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "555", "112"))
+                .isEqualTo("444 4444 ext. 555");
+        assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "", "112"))
+                .isEqualTo("444 4444"); // Same rule without extension
+    }
 
-  @Test
-  public void testGetFormatAsId() {
+    @Test
+    public void testGetFormatAsId() {
 
-    // Inputs are any string
-    assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");
-    assertThat(Hl7RelatedGeneralUtils.formatAsId("OMC")).isEqualTo("omc");
-    assertThat(Hl7RelatedGeneralUtils.formatAsId("   4 5 6  ")).isEqualTo("4.5.6");
+        // Inputs are any string
+        assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");
+        assertThat(Hl7RelatedGeneralUtils.formatAsId("OMC")).isEqualTo("omc");
+        assertThat(Hl7RelatedGeneralUtils.formatAsId("   4 5 6  ")).isEqualTo("4.5.6");
 
-    // Edge cases (if these occur we might have name space collisions)
-    // The input is trimmed so totally blank input becomes empty
-    assertThat(Hl7RelatedGeneralUtils.formatAsId(" ")).isEmpty();
-    assertThat(Hl7RelatedGeneralUtils.formatAsId("")).isEmpty();
-    // Null in becomes null out
-    assertThat(Hl7RelatedGeneralUtils.formatAsId(null)).isNull();
+        // Edge cases (if these occur we might have name space collisions)
+        // The input is trimmed so totally blank input becomes empty
+        assertThat(Hl7RelatedGeneralUtils.formatAsId(" ")).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.formatAsId("")).isEmpty();
+        // Null in becomes null out
+        assertThat(Hl7RelatedGeneralUtils.formatAsId(null)).isNull();
 
-  }
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
@@ -21,31 +21,30 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HL7ADTMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final Logger LOGGER = LoggerFactory.getLogger(HL7ADTMessageTest.class);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
-        .withValidateResource().withPrettyPrint().build();
+            .withValidateResource().withPrettyPrint().build();
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
     public void test_adt_a01_mininum_segments(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -57,13 +56,13 @@ public class HL7ADTMessageTest {
         List<BundleEntryComponent> e = b.getEntry();
 
         List<Resource> patientResource = e.stream()
-                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1); // from PID
 
         List<Resource> encounterResource = e.stream()
-                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1); // from EVN, PV1
 
         // Confirm that there are no extra resources
@@ -73,15 +72,14 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
     public void test_adt_a01_minimum_plus_PROCEDURE_group(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
-            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r";
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
@@ -92,18 +90,18 @@ public class HL7ADTMessageTest {
         List<BundleEntryComponent> e = b.getEntry();
 
         List<Resource> patientResource = e.stream()
-                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1); // from PID
 
         List<Resource> encounterResource = e.stream()
-                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1); // from EVN, PV1
 
         List<Resource> procedureResource = e.stream()
-                        .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(procedureResource).hasSize(1); // from PR1
 
         // Confirm that there are no extra resources
@@ -113,21 +111,20 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
     public void test_adt_a01_full_with_OBXtypeTX_and_no_groups(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
-            + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
-            + "OBX|1|TX|1234^some text^SCT||First line||||||F||\n"
-            + "OBX|2|TX|1234^some text^SCT||Second line||||||F||\n"
-            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
-            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
-            + "DG1|1||B45678|||A|\r"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+                + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
+                + "OBX|1|TX|1234^some text^SCT||First line||||||F||\n"
+                + "OBX|2|TX|1234^some text^SCT||Second line||||||F||\n"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "DG1|1||B45678|||A|\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -139,33 +136,33 @@ public class HL7ADTMessageTest {
         List<BundleEntryComponent> e = b.getEntry();
 
         List<Resource> patientResource = e.stream()
-                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1); // from PID, PD1
 
         List<Resource> encounterResource = e.stream()
-                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1); // from EVN, PV1, PV2
 
         List<Resource> observationResource = e.stream()
-                        .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(observationResource).hasSize(0); // from OBX
 
         List<Resource> allergyIntoleranceResource = e.stream()
-                        .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(allergyIntoleranceResource).hasSize(2); // from AL1
 
         List<Resource> conditionResource = e.stream()
-                        .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(conditionResource).hasSize(1); // from DG1
 
         List<Resource> documentReferenceResource = e.stream()
-                        .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(documentReferenceResource).hasSize(0); // from OBX of type TX; TODO: this should be 1 when card 855 is implemented
 
         // Confirm that there are no extra resources
@@ -175,25 +172,24 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/*, "ADT^A04"*/, "ADT^A08"/*, "ADT^A13"*/ })
+    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
     public void test_adt_a01_full_plus_multiple_PROCEDURE_group(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
-            + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
-            + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r" 
-            + "OBX|2|ST|100||Observation content|||||||X\r"
-            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
-            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r" 
-            + "DG1|1||B45678|||A|\r"
-            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
-            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
-            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
-            + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+                + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
+                + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r"
+                + "OBX|2|ST|100||Observation content|||||||X\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "DG1|1||B45678|||A|\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -205,33 +201,33 @@ public class HL7ADTMessageTest {
         List<BundleEntryComponent> e = b.getEntry();
 
         List<Resource> patientResource = e.stream()
-                        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1); // from PID, PD1
 
         List<Resource> encounterResource = e.stream()
-                        .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1); // from EVN, PV1, PV2
 
         List<Resource> observationResource = e.stream()
-                        .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(observationResource).hasSize(2); // from OBX
 
         List<Resource> allergyIntoleranceResource = e.stream()
-                        .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(allergyIntoleranceResource).hasSize(2); // from AL1
 
         List<Resource> conditionResource = e.stream()
-                        .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(conditionResource).hasSize(1); // from DG1
 
         List<Resource> procedureResource = e.stream()
-                        .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
-                        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(procedureResource).hasSize(4); //from PROCEDURE.PR1
 
         // Confirm that there are no extra resources
@@ -239,147 +235,153 @@ public class HL7ADTMessageTest {
 
     }
 
-    @Test@Disabled("adt-a02 not yet supported")
+    @Test
+    @Disabled("adt-a02 not yet supported")
     public void test_adta02_patient_encounter_present() throws IOException {
-            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\n"
-                            + "EVN|A01|20150502090000|\n"
-                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
-                            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r";
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\n"
+                + "EVN|A01|20150502090000|\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r";
 
-            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-            String json = ftv.convert(hl7message, OPTIONS);
-            assertThat(json).isNotBlank();
-            LOGGER.info("FHIR json result:\n" + json);
-            IBaseResource bundleResource = context.getParser().parseResource(json);
-            assertThat(bundleResource).isNotNull();
-            Bundle b = (Bundle) bundleResource;
-            List<BundleEntryComponent> e = b.getEntry();
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
 
-            // Expecting 2 total resources
-            assertThat(e.size()).isEqualTo(2);
+        // Expecting 2 total resources
+        assertThat(e.size()).isEqualTo(2);
 
-            List<Resource> patientResource = e.stream()
-                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(patientResource).hasSize(1);
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
 
-            List<Resource> encounterResource = e.stream()
-                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(encounterResource).hasSize(1);
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
 
     }
 
-    @Test@Disabled("adt-a03 not yet supported")
+    @Test
+    @Disabled("adt-a03 not yet supported")
     public void test_adta03_patient_encounter_present() throws IOException {
-            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\n"
-                            + "EVN|A01|20150502090000|\n"
-                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\n"
+                + "EVN|A01|20150502090000|\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
 
-            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-            String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-            assertThat(json).isNotBlank();
-            LOGGER.info("FHIR json result:\n" + json);
-            IBaseResource bundleResource = context.getParser().parseResource(json);
-            assertThat(bundleResource).isNotNull();
-            Bundle b = (Bundle) bundleResource;                
-            List<BundleEntryComponent> e = b.getEntry();
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
 
-            // Expecting 2 total resources
-            assertThat(e.size()).isEqualTo(2);
+        // Expecting 2 total resources
+        assertThat(e.size()).isEqualTo(2);
 
-            List<Resource> patientResource = e.stream()
-                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(patientResource).hasSize(1);
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
 
-            List<Resource> encounterResource = e.stream()
-                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(encounterResource).hasSize(1);
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
 
     }
 
-    @Test@Disabled("adt-a28 not yet supported")
+    @Test
+    @Disabled("adt-a28 not yet supported")
     //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
     public void test_adta28_patient_encounter_present() throws IOException {
-            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\n"
-                            + "EVN|A01|20150502090000|\n"
-                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\n"
+                + "EVN|A01|20150502090000|\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
 
-            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-            String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-            assertThat(json).isNotBlank();
-            LOGGER.info("FHIR json result:\n" + json);
-            IBaseResource bundleResource = context.getParser().parseResource(json);
-            assertThat(bundleResource).isNotNull();
-            Bundle b = (Bundle) bundleResource;
-            List<BundleEntryComponent> e = b.getEntry();
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
 
-            // Expecting 2 total resources
-            assertThat(e.size()).isEqualTo(2);
-                            
-            List<Resource> patientResource = e.stream()
-                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(patientResource).hasSize(1);
+        // Expecting 2 total resources
+        assertThat(e.size()).isEqualTo(2);
 
-            List<Resource> encounterResource = e.stream()
-                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(encounterResource).hasSize(1);
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
+
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
 
     }
 
-    @Test@Disabled("adt-a31 not yet supported")
+    @Test
+    @Disabled("adt-a31 not yet supported")
     //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
     public void test_adta31_patient_encounter_present() throws IOException {
-            String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\n"
-                            + "EVN|A01|20150502090000|\n"
-                            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                            + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\n"
+                + "EVN|A01|20150502090000|\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
 
-            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-            String json = ftv.convert(hl7message, OPTIONS);
-            assertThat(json).isNotBlank();
-            LOGGER.info("FHIR json result:\n" + json);
-            IBaseResource bundleResource = context.getParser().parseResource(json);
-            assertThat(bundleResource).isNotNull();
-            Bundle b = (Bundle) bundleResource;
-            List<BundleEntryComponent> e = b.getEntry();
-            
-            // Expecting 2 total resources
-            assertThat(e.size()).isEqualTo(2);
-                            
-            List<Resource> patientResource = e.stream()
-                            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(patientResource).hasSize(1);
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(hl7message, OPTIONS);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
 
-            List<Resource> encounterResource = e.stream()
-                            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-            assertThat(encounterResource).hasSize(1);
+        // Expecting 2 total resources
+        assertThat(e.size()).isEqualTo(2);
+
+        List<Resource> patientResource = e.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patientResource).hasSize(1);
+
+        List<Resource> encounterResource = e.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(encounterResource).hasSize(1);
 
     }
 
     @ParameterizedTest
     // ADT_A30 structure is also used by ADT_A34, ADT_A35, ADT_A36, ADT_A46, ADT_A47, ADT_A48, ADT_A49.  We can reuse this for those messages if we choose to support them in the future.
-    @ValueSource(strings = { /*"ADT^A30",*/ "ADT^A34"/*, "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48", "ADT^A49"*/ })
+    @ValueSource(strings = { /* "ADT^A30", */ "ADT^A34"/*
+                                                        * , "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48",
+                                                        * "ADT^A49"
+                                                        */ })
     public void test_adt_a30_mininum_segments(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "MRG|456||||||\n"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "MRG|456||||||\n";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -392,8 +394,8 @@ public class HL7ADTMessageTest {
 
         // There should be two patient resources, the PID patient and the MRG patient.
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(2); // from PID and MRG
 
         // We currently do not support Encounters for merging, in ADT_A34 merge
@@ -406,17 +408,19 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A30 structure is also used by ADT_A34, ADT_A35, ADT_A36, ADT_A46, ADT_A47, ADT_A48, ADT_A49.  We can reuse this for those messages if we choose to support them in the future.
-    @ValueSource(strings = { /*"ADT^A30",*/ "ADT^A34"/*, "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48", "ADT^A49"*/ })
+    @ValueSource(strings = { /* "ADT^A30", */ "ADT^A34"/*
+                                                        * , "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48",
+                                                        * "ADT^A49"
+                                                        */ })
     public void test_adt_a30_full(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "MRG|456||||||\n"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "MRG|456||||||\n";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -429,8 +433,8 @@ public class HL7ADTMessageTest {
 
         // There should be two patient resources, the PID patient and the MRG patient.
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(2); // from PID and MRG
 
         // We currently do not support Encounters for merging, in ADT_A34 merge
@@ -443,14 +447,13 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
-    @ValueSource(strings = { /*"ADT^A39",*/ "ADT^A40"/*, "ADT^A41", "ADT^A42"*/ })
+    @ValueSource(strings = { /* "ADT^A39", */ "ADT^A40"/* , "ADT^A41", "ADT^A42" */ })
     public void test_adt_a39_min_segments(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "MRG|456||||||\n"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "MRG|456||||||\n";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -463,8 +466,8 @@ public class HL7ADTMessageTest {
 
         // There should be two patient resources, the PID patient and the MRG patient.
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(2); // 1st from PID; 2nd from MRG
 
         // We currently do not support Encounters for merging,
@@ -477,18 +480,17 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
-    @ValueSource(strings = { /*"ADT^A39",*/ "ADT^A40"/*, "ADT^A41", "ADT^A42"*/ })
+    @ValueSource(strings = { /* "ADT^A39", */ "ADT^A40"/* , "ADT^A41", "ADT^A42" */ })
     public void test_adt_a39_min_with_multiple_PATIENT_groups(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1111^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "MRG|123||||||\n"
-            + "PID|||2222^^^^MR||DOE^Joe^|||F||||||||||||||||||||||\r"
-            + "MRG|456||||||\n"
-            + "PID|||3333^^^^MR||DOE^Larry^|||F||||||||||||||||||||||\r"
-            + "MRG|789||||||\n"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1111^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "MRG|123||||||\n"
+                + "PID|||2222^^^^MR||DOE^Joe^|||F||||||||||||||||||||||\r"
+                + "MRG|456||||||\n"
+                + "PID|||3333^^^^MR||DOE^Larry^|||F||||||||||||||||||||||\r"
+                + "MRG|789||||||\n";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -501,8 +503,8 @@ public class HL7ADTMessageTest {
 
         // There should be six patient resources from the PID segments and MRG segments.
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(6); // from PIDs and MRGs
 
         // We currently do not support Encounters for merging,
@@ -515,23 +517,22 @@ public class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
-    @ValueSource(strings = { /*"ADT^A39",*/ "ADT^A40"/*, "ADT^A41", "ADT^A42"*/ })
+    @ValueSource(strings = { /* "ADT^A39", */ "ADT^A40"/* , "ADT^A41", "ADT^A42" */ })
     public void test_adt_a39_full_with_multiple_PATIENT_groups(String message) throws IOException {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN|A01|20150502090000|\r"
-            + "PID|||1111^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "MRG|123||||||\n"
-            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
-            + "PID|||2222^^^^MR||DOE^Joe^|||F||||||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "MRG|456||||||\n"
-            + "PID|||3333^^^^MR||DOE^Larry^|||F||||||||||||||||||||||\r"
-            + "MRG|789||||||\n"
-            + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
-            + "PID|||4444^^^^MR||DOE^Elizabeth^|||F||||||||||||||||||||||\r"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1111^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "MRG|123||||||\n"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + "PID|||2222^^^^MR||DOE^Joe^|||F||||||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "MRG|456||||||\n"
+                + "PID|||3333^^^^MR||DOE^Larry^|||F||||||||||||||||||||||\r"
+                + "MRG|789||||||\n"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + "PID|||4444^^^^MR||DOE^Elizabeth^|||F||||||||||||||||||||||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
@@ -544,8 +545,8 @@ public class HL7ADTMessageTest {
 
         // There should be patient resources from the PID and the MRG segments.
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(7); // from PID and MRG
 
         // We currently do not support Encounters for merging, in ADT_A34 merge

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
@@ -6,6 +6,7 @@
 package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -18,9 +19,9 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.ServiceRequest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class Hl7MDMMessageTest {
@@ -330,7 +331,9 @@ public class Hl7MDMMessageTest {
                 ResourceUtils.context);
         assertThat(serviceRequest.hasNote()).isTrue();
         assertThat(serviceRequest.getNote()).hasSize(1);
-        assertThat(serviceRequest.getNote().get(0).getText())
+        // NOTE: the note contains an Annotation, which contains a MarkdownType that has the string.
+        // Must use getTextElement().getValueAsString() to see untrimmed contents.
+        assertThat(serviceRequest.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST ORC/OBR NOTE AA line 1  \nTEST NOTE AA line 2");
         assertThat(serviceRequest.getNote().get(0).hasAuthorReference()).isTrue();
 
@@ -345,7 +348,9 @@ public class Hl7MDMMessageTest {
         // Validate the note contents and reference existance.
         assertThat(observation.hasNote()).isTrue();
         assertThat(observation.getNote()).hasSize(1);
-        assertThat(observation.getNote().get(0).getText())
+        // NOTE: the note contains an Annotation, which contains a MarkdownType that has the string.
+        // Must use getTextElement().getValueAsString() to see untrimmed contents.
+        assertThat(observation.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST OBX NOTE BB line 1  \nTEST NOTE BB line 2");
         assertThat(observation.getNote().get(0).hasAuthorReference()).isTrue();
 

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -21,18 +21,18 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DiagnosticReport;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
@@ -41,18 +41,15 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class Hl7ORUMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7ORUMessageTest.class);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder()
-        .withBundleType(BundleType.COLLECTION)
-        .withValidateResource()
-        .withPrettyPrint()
-        .build();
+            .withBundleType(BundleType.COLLECTION)
+            .withValidateResource()
+            .withPrettyPrint()
+            .build();
 
     // DiagnosticReports are only created from ORU messages so the test of DiagnosticReport content is included in this test module.
 
@@ -60,13 +57,13 @@ public class Hl7ORUMessageTest {
     // Test the minimum scenario where the least possible segments and resource info are provided in the message
     public void test_oru_patient_diagReport() throws IOException {
         String hl7message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
-            + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
-            + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|1051-2^New Born Screening^LN|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^|||||\r";
+                + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
+                + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|1051-2^New Born Screening^LN|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^|||||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
@@ -74,18 +71,18 @@ public class Hl7ORUMessageTest {
 
         // Verify correct resources created
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> diagnosticReport = e.stream()
-            .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(diagnosticReport).hasSize(1);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(servReqResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -95,9 +92,9 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isZero(); // Verify category from OBR.24
-        
+
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
         List<Coding> codings = diag.getCode().getCoding();
@@ -109,13 +106,13 @@ public class Hl7ORUMessageTest {
         assertThat(coding.getCode()).hasToString("1051-2");
         assertThat(coding.hasSystem()).isTrue();
         assertThat(coding.getSystem()).hasToString("http://loinc.org");
-        
+
         assertThat(diag.getEncounter().isEmpty()).isTrue(); // Verify encounter reference
         assertThat(diag.getSubject().isEmpty()).isFalse(); // Verify subject reference
 
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue()).isEqualTo("2015-10-09T17:36:44+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
-        
+
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).isEmpty(); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
@@ -135,46 +132,45 @@ public class Hl7ORUMessageTest {
     // Observation resources are created instead of attachments in the diagReport because they are not type TX.
     public void test_oru_with_multiple_observations() throws IOException {
         String hl7message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
-            + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
-            // OBR.24 creates a DiagnosticReport.category
-            + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|1051-2^New Born Screening^LN|||20151009173644|||||||||||||002||||CUS|F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
-            + "OBX|1|ST|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
-            + "OBX|2|ST|GA-F-01-024^Galactosemia^L||ECHOCARDIOGRAPHIC REPORT||||||F\r";
-     
+                + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
+                // OBR.24 creates a DiagnosticReport.category
+                + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|1051-2^New Born Screening^LN|||20151009173644|||||||||||||002||||CUS|F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
+                + "OBX|1|ST|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
+                + "OBX|2|ST|GA-F-01-024^Galactosemia^L||ECHOCARDIOGRAPHIC REPORT||||||F\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         // Verify correct resources created
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> obsResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(obsResource).hasSize(2);
 
         List<Resource> practitionerResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(1);
 
         List<Resource> diagnosticReport = e.stream()
-            .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(diagnosticReport).hasSize(1);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(servReqResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -184,9 +180,10 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isEqualTo(1); // Verify category from OBR.24
-        DatatypeUtils.checkCommonCodeableConceptAssertions(diag.getCategoryFirstRep(), "CUS", "Cardiac Ultrasound", "http://terminology.hl7.org/CodeSystem/v2-0074", "CUS");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(diag.getCategoryFirstRep(), "CUS", "Cardiac Ultrasound",
+                "http://terminology.hl7.org/CodeSystem/v2-0074", "CUS");
 
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
@@ -205,15 +202,15 @@ public class Hl7ORUMessageTest {
 
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue())
-            .isEqualTo("2015-10-09T17:36:44+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
-        
+                .isEqualTo("2015-10-09T17:36:44+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
+
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).hasSize(1); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
         assertThat(diag.getBasedOn().get(0).getReference().substring(0, 15)).isEqualTo("ServiceRequest/");
         assertThat(diag.getSpecimen()).isEmpty(); // Verify specimen reference
 
-            // Verify result reference
+        // Verify result reference
         List<Reference> obsRef = diag.getResult();
         assertThat(obsRef.isEmpty()).isFalse();
         assertThat(obsRef).hasSize(2);
@@ -227,9 +224,9 @@ public class Hl7ORUMessageTest {
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
         ////////////////////////////////////
-        for(Resource res: obsResource) {
+        for (Resource res : obsResource) {
             // Verify encounter reference is not set
-            Observation obs = (Observation)res;
+            Observation obs = (Observation) res;
             assertThat(obs.getEncounter().isEmpty()).isTrue();
 
             //Verify subject reference to Patient exists
@@ -242,15 +239,15 @@ public class Hl7ORUMessageTest {
     @Test
     public void test_orur01_with_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20180520230000||ORU^R01|MSGID006552|T|2.6\r"
-        		+ "PID|1||000065432^^^MRN^MR||ROSTENKOWSKI^BERNADETTE^||19840823|Female||1002-5|382 OTHERSTREET AVE^^PASADENA^LA^223343||4582143248||^French|S||53811||||U|||||||\r"
-        		+ "PV1|1|O|||||9905^Adams^John|9906^Yellow^William^F|9907^Blue^Oren^J||||||||9908^Green^Mircea^||2462201|||||||||||||||||||||||||20180520230000\r"
-        		+ "OBR|1||bbf1993ab|1122^Final Echocardiogram Report|||20180520230000|||||||||||||002|||||F|||550469^Tsadok550469^Janetary~660469^Merrit660469^Darren^F~770469^Das770469^Surjya^P~880469^Winter880469^Oscar^||||770469&Das770469&Surjya&P^^^6N^1234^A|\r"
-        		+ "OBX|1|NM|2552^HRTRTMON|1|115||||||F|||20180520230000|||\r";
+                + "PID|1||000065432^^^MRN^MR||ROSTENKOWSKI^BERNADETTE^||19840823|Female||1002-5|382 OTHERSTREET AVE^^PASADENA^LA^223343||4582143248||^French|S||53811||||U|||||||\r"
+                + "PV1|1|O|||||9905^Adams^John|9906^Yellow^William^F|9907^Blue^Oren^J||||||||9908^Green^Mircea^||2462201|||||||||||||||||||||||||20180520230000\r"
+                + "OBR|1||bbf1993ab|1122^Final Echocardiogram Report|||20180520230000|||||||||||||002|||||F|||550469^Tsadok550469^Janetary~660469^Merrit660469^Darren^F~770469^Das770469^Surjya^P~880469^Winter880469^Oscar^||||770469&Das770469&Surjya&P^^^6N^1234^A|\r"
+                + "OBX|1|NM|2552^HRTRTMON|1|115||||||F|||20180520230000|||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
@@ -258,33 +255,33 @@ public class Hl7ORUMessageTest {
 
         // Verify that the right resources are created
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
-        
+
         List<Resource> obsResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(obsResource).hasSize(1);
 
         List<Resource> diagnosticReport = e.stream()
-            .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(diagnosticReport).hasSize(1);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(servReqResource).hasSize(1);
 
         List<Resource> practitionerResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(5);
 
         // Expecting only the above resources, no extras!
@@ -294,9 +291,9 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
-        
+
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
         List<Coding> codings = diag.getCode().getCoding();
@@ -313,7 +310,7 @@ public class Hl7ORUMessageTest {
 
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue()).isEqualTo("2018-05-20T23:00:00+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
-        
+
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).hasSize(1); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
@@ -334,9 +331,9 @@ public class Hl7ORUMessageTest {
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
         ////////////////////////////////////        
-        for(Resource res: obsResource) {
+        for (Resource res : obsResource) {
             // Verify encounter reference exists
-            Observation obs = (Observation)res;
+            Observation obs = (Observation) res;
             assertThat(obs.getEncounter().isEmpty()).isFalse();
             assertThat(obs.getEncounter().getReference().substring(0, 10)).isEqualTo("Encounter/");
 
@@ -361,37 +358,37 @@ public class Hl7ORUMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         // Verify that the right resources are being created
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> obsResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(obsResource).hasSize(4);
 
         List<Resource> practitionerResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(2);
 
         List<Resource> diagnosticReport = e.stream()
-            .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(diagnosticReport).hasSize(2);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(servReqResource).hasSize(2);
 
         // Expecting only the above resources, no extras!
@@ -401,9 +398,9 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the FIRST diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
-        
+
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
         List<Coding> codings = diag.getCode().getCoding();
@@ -420,7 +417,7 @@ public class Hl7ORUMessageTest {
 
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue()).isEqualTo("2015-10-09T17:36:44+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
-        
+
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).hasSize(1); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
@@ -441,9 +438,9 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the SECOND diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag2 = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
-        assertThat(diag2.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag2.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag2.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
-        
+
         // Verify code from OBR.4
         assertThat(diag2.hasCode()).isTrue();
         List<Coding> codings2 = diag2.getCode().getCoding();
@@ -460,7 +457,7 @@ public class Hl7ORUMessageTest {
 
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag2.getEffectiveDateTimeType().asStringValue()).isEqualTo("2015-10-09T17:36:44+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
-        
+
         assertThat(diag2.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag2.getResultsInterpreter()).hasSize(1); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
@@ -480,9 +477,9 @@ public class Hl7ORUMessageTest {
         ////////////////////////////////////        
         // Check the references that aren't covered in Observation tests
         ////////////////////////////////////
-        for(Resource res: obsResource) {
+        for (Resource res : obsResource) {
             // Verify encounter reference is not set
-            Observation obs = (Observation)res;
+            Observation obs = (Observation) res;
             assertThat(obs.getEncounter().isEmpty()).isTrue();
 
             // Verify subject reference to Patient exists
@@ -499,10 +496,10 @@ public class Hl7ORUMessageTest {
                 + "OBX|1|ST|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
                 + "SPM|1|SpecimenID||BLD|||||||P||||||201410060535|201410060821||Y||||||1\r";
 
-                HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
@@ -510,33 +507,33 @@ public class Hl7ORUMessageTest {
 
         // Verify that the right resources are created
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> diagnosticReport = e.stream()
-            .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(diagnosticReport).hasSize(1);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(servReqResource).hasSize(1);
 
         List<Resource> obsResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(obsResource).hasSize(1);
 
         List<Resource> practitionerResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(1);
 
         List<Resource> specimenResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(specimenResource).hasSize(1);
 
         // Expecting only the above resources, no extras! 
@@ -546,7 +543,7 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
 
         // Verify code from OBR.4
@@ -563,20 +560,20 @@ public class Hl7ORUMessageTest {
 
         assertThat(diag.getEncounter().isEmpty()).isTrue(); // Verify encounter reference
         assertThat(diag.getSubject().isEmpty()).isFalse(); // Verify subject reference
-        
+
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue()).isEqualTo("2015-10-09T17:36:44+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).hasSize(1); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
         assertThat(diag.getBasedOn().get(0).getReference().substring(0, 15)).isEqualTo("ServiceRequest/");
-        
+
         // Verify specimen reference
         List<Reference> spmRef = diag.getSpecimen();
         assertThat(spmRef.isEmpty()).isFalse();
         assertThat(spmRef).hasSize(1);
         assertThat(spmRef.get(0).isEmpty()).isFalse();
-        
+
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
         assertThat(obsRef.isEmpty()).isFalse();
@@ -586,13 +583,12 @@ public class Hl7ORUMessageTest {
         List<Attachment> attachments = diag.getPresentedForm();
         Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
 
-
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
         ////////////////////////////////////        
-        for(Resource res: obsResource) {
+        for (Resource res : obsResource) {
             // Verify encounter reference
-            Observation obs = (Observation)res;
+            Observation obs = (Observation) res;
             assertThat(obs.getEncounter().isEmpty()).isTrue();
 
             //Verify subject reference to Patient exists
@@ -612,8 +608,8 @@ public class Hl7ORUMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(new File("src/test/resources/ORU-multiline-short.hl7"), OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
-       
+        LOGGER.debug("FHIR json result:\n" + json);
+
         // Verify conversion
         FHIRContext context = new FHIRContext();
         IBaseResource bundleResource = context.getParser().parseResource(json);
@@ -656,9 +652,9 @@ public class Hl7ORUMessageTest {
         assertThat(reportResource).hasSize(1);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(servReqResource).hasSize(1);        
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(servReqResource).hasSize(1);
 
         // Verify there are no extra resources created
         assertThat(e.size()).isEqualTo(10);
@@ -667,15 +663,16 @@ public class Hl7ORUMessageTest {
         List<Resource> obsResource = e.stream()
                 .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(obsResource).hasSize(0);  // TODO: When NTE is implemented, then update this to one.
+        assertThat(obsResource).hasSize(0); // TODO: When NTE is implemented, then update this to one.
 
         ///////////////////////////////////////////
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(reportResource.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isEqualTo(1); // Verify category from OBR.24
-        DatatypeUtils.checkCommonCodeableConceptAssertions(diag.getCategoryFirstRep(), "CT", "CAT Scan", "http://terminology.hl7.org/CodeSystem/v2-0074", "CT");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(diag.getCategoryFirstRep(), "CT", "CAT Scan",
+                "http://terminology.hl7.org/CodeSystem/v2-0074", "CT");
 
         // Verify code from OBR.4; This tests scenario of the code not being in the default loinc system.
         assertThat(diag.hasCode()).isTrue();
@@ -690,18 +687,18 @@ public class Hl7ORUMessageTest {
 
         assertThat(diag.getEncounter().isEmpty()).isFalse(); // Verify encounter reference
         assertThat(diag.getSubject().isEmpty()).isFalse(); // Verify subject reference
-        
+
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue()).isEqualTo("2020-08-02T12:44:55+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).isEmpty(); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
         assertThat(diag.getBasedOn().get(0).getReference().substring(0, 15)).isEqualTo("ServiceRequest/");
-        
+
         // Verify specimen reference
         List<Reference> spmRef = diag.getSpecimen();
         assertThat(spmRef.isEmpty());
-        
+
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
         assertThat(obsRef.isEmpty()).isTrue();
@@ -714,7 +711,10 @@ public class Hl7ORUMessageTest {
         Assertions.assertTrue(a.getLanguage().equalsIgnoreCase("en"), "Incorrect language");
         //Verify data attachment after decoding
         String decoded = new String(Base64.getDecoder().decode(a.getDataElement().getValueAsString()));
-        Assertions.assertTrue(decoded.equals("\n[PII] Emergency Department\nED Encounter Arrival Date: [ADDRESS] [PERSONALNAME]:\n"), "Incorrect data");
+        System.out.println("Decoded: '" + decoded + "'");
+        Assertions.assertTrue(
+                decoded.equals("\n[PII] Emergency Department\nED Encounter Arrival Date: [ADDRESS] [PERSONALNAME]:"),
+                "Incorrect data");
         Assertions.assertTrue(a.getTitle().equalsIgnoreCase("ECHO CARDIOGRAM COMPLETE"), "Incorrect title");
         //Verify creation data is persisted correctly - 2020-08-02T12:44:55+08:00
         Calendar c = Calendar.getInstance();
@@ -723,13 +723,13 @@ public class Hl7ORUMessageTest {
         c.setTimeZone(TimeZone.getTimeZone(ZoneId.of("+08:00")));
         Date d = c.getTime();
         Assertions.assertTrue(a.getCreation().equals(d), "Incorrect creation date");
-        
+
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
         ////////////////////////////////////        
-        for(Resource res: obsResource) {
+        for (Resource res : obsResource) {
             // Verify encounter reference exists
-            Observation obs = (Observation)res;
+            Observation obs = (Observation) res;
             assertThat(obs.getEncounter().isEmpty()).isFalse();
             assertThat(obs.getEncounter().getReference().substring(0, 10)).isEqualTo("Encounter/");
 
@@ -750,7 +750,7 @@ public class Hl7ORUMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(new File("src/test/resources/ORU-multiline-short-mixed.hl7"), OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         // Verify conversion
         FHIRContext context = new FHIRContext();
         IBaseResource bundleResource = context.getParser().parseResource(json);
@@ -766,8 +766,8 @@ public class Hl7ORUMessageTest {
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         List<Resource> organizationResource = e.stream()
@@ -777,8 +777,8 @@ public class Hl7ORUMessageTest {
         assertThat(organizationResource).hasSize(1);
 
         List<Resource> practitionerResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(4);
 
         List<Resource> messageHeader = e.stream()
@@ -790,7 +790,7 @@ public class Hl7ORUMessageTest {
         List<Resource> obsResource = e.stream()
                 .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-         assertThat(obsResource).hasSize(1);  // TODO: When NTE is implemented, then update this.
+        assertThat(obsResource).hasSize(1); // TODO: When NTE is implemented, then update this.
 
         // Verify Diagnostic Report is created as expected
         List<Resource> reportResource = e.stream()
@@ -799,8 +799,8 @@ public class Hl7ORUMessageTest {
         assertThat(reportResource).hasSize(1);
 
         List<Resource> servReqResource = e.stream()
-            .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(servReqResource).hasSize(1);
 
         // Verify there are no extra resources created
@@ -810,10 +810,11 @@ public class Hl7ORUMessageTest {
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(reportResource.get(0), context);
-        assertThat(diag.getStatus().toCode()).isEqualTo("final");  // Verify status from OBR.25
+        assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
         assertThat(diag.getCategory().size()).isEqualTo(1); // Verify category from OBR.24
         assertThat(diag.getCategory().get(0).getCoding().size()).isEqualTo(1);
-        assertThat(diag.getCategory().get(0).getCoding().get(0).getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0074");
+        assertThat(diag.getCategory().get(0).getCoding().get(0).getSystem())
+                .isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0074");
         assertThat(diag.getCategory().get(0).getCoding().get(0).getCode()).isEqualTo("CT");
         assertThat(diag.getCategory().get(0).getCoding().get(0).getDisplay()).isEqualTo("CAT Scan");
         assertThat(diag.getCategory().get(0).getText()).isEqualTo("CT");
@@ -831,18 +832,18 @@ public class Hl7ORUMessageTest {
 
         assertThat(diag.getEncounter().isEmpty()).isFalse(); // Verify encounter reference
         assertThat(diag.getSubject().isEmpty()).isFalse(); // Verify subject reference
-        
+
         // Verify effectiveDateTime from OBR.7 and OBR.8
         assertThat(diag.getEffectiveDateTimeType().asStringValue()).isEqualTo("2020-08-02T12:44:55+08:00"); // This also verifies the type, confirming effectiveDateTime was set rather than effectivePeriod
         assertThat(diag.getIssued()).isNull(); // Verify issued from OBR.22
         assertThat(diag.getResultsInterpreter()).isEmpty(); // Verify resultsInterpreter from OBR.32
         assertThat(diag.getBasedOn()).hasSize(1); // Verify basedOn is ref to the ServiceRequest created for ORC or OBR
         assertThat(diag.getBasedOn().get(0).getReference().substring(0, 15)).isEqualTo("ServiceRequest/");
-        
+
         // Verify specimen reference
         List<Reference> spmRef = diag.getSpecimen();
         assertThat(spmRef.isEmpty());
-        
+
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
         assertThat(obsRef.isEmpty()).isFalse();
@@ -851,13 +852,13 @@ public class Hl7ORUMessageTest {
         // No attachment created since OBX with TX and no id is not first
         List<Attachment> attachments = diag.getPresentedForm();
         Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
-        
+
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
         ////////////////////////////////////        
-        for(Resource res: obsResource) {
+        for (Resource res : obsResource) {
             // Verify encounter reference exists
-            Observation obs = (Observation)res;
+            Observation obs = (Observation) res;
             assertThat(obs.getEncounter().isEmpty()).isFalse();
             assertThat(obs.getEncounter().getReference().substring(0, 10)).isEqualTo("Encounter/");
 
@@ -869,33 +870,33 @@ public class Hl7ORUMessageTest {
 
     @Test
     public void test_ORU_r01_without_status() throws IOException {
-      String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
-          + "PID|1||PATID5421^^^NISTMPI^MR||Wilson^Patrice^Natasha^^^^L||19820304|F||2106-3^White^HL70005|144 East 12th Street^^Los Angeles^CA^90012^^H||^PRN^PH^^^203^2290210|||||||||N^Not Hispanic or Latino^HL70189\r"
-          + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
-          + "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
-          + "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
-          + "OBX|2|CWE|20575-7^Hepatitis A virus Ab [Presence] in Serum^LN^HAVAB^Hepatitis A antibodies (anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
-          + "OBX|3|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
-  
-      HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-      String json = ftv.convert(ORU_r01, OPTIONS);
-  
-      FHIRContext context = new FHIRContext();
-      IBaseResource bundleResource = context.getParser().parseResource(json);
-      assertThat(bundleResource).isNotNull();
-      Bundle b = (Bundle) bundleResource;
-      List<BundleEntryComponent> e = b.getEntry();
-      List<Resource> diagnosticReport = e.stream()
-          .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-          .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-      assertThat(diagnosticReport).hasSize(1);
-  
-      String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));
-      Class<? extends IBaseResource> klass = DiagnosticReport.class;
-      DiagnosticReport expectStatusUnknown = (DiagnosticReport) context.getParser().parseResource(klass, s);
-      DiagnosticReport.DiagnosticReportStatus status = expectStatusUnknown.getStatus();
-  
-      assertThat(expectStatusUnknown.hasStatus()).isTrue();
-      assertThat(status).isEqualTo(DiagnosticReport.DiagnosticReportStatus.UNKNOWN);
+        String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
+                + "PID|1||PATID5421^^^NISTMPI^MR||Wilson^Patrice^Natasha^^^^L||19820304|F||2106-3^White^HL70005|144 East 12th Street^^Los Angeles^CA^90012^^H||^PRN^PH^^^203^2290210|||||||||N^Not Hispanic or Latino^HL70189\r"
+                + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
+                + "OBR|1|ORD448811^NIST EHR|R-511^NIST Lab Filler|1000^Hepatitis A B C Panel^99USL|||20120628070100|||||||||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
+                + "OBX|1|CWE|22314-9^Hepatitis A virus IgM Ab [Presence] in Serum^LN^HAVM^Hepatitis A IgM antibodies (IgM anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
+                + "OBX|2|CWE|20575-7^Hepatitis A virus Ab [Presence] in Serum^LN^HAVAB^Hepatitis A antibodies (anti-HAV)^L^2.52||260385009^Negative (qualifier value)^SCT^NEG^NEGATIVE^L^201509USEd^^Negative (qualifier value)||Negative|N|||F|||20150925|||||201509261400\r"
+                + "OBX|3|NM|22316-4^Hepatitis B virus core Ab [Units/volume] in Serum^LN^HBcAbQ^Hepatitis B core antibodies (anti-HBVc) Quant^L^2.52||0.70|[IU]/mL^international unit per milliliter^UCUM^IU/ml^^L^1.9|<0.50 IU/mL|H|||F|||20150925|||||201509261400";
+
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(ORU_r01, OPTIONS);
+
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        List<Resource> diagnosticReport = e.stream()
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(diagnosticReport).hasSize(1);
+
+        String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));
+        Class<? extends IBaseResource> klass = DiagnosticReport.class;
+        DiagnosticReport expectStatusUnknown = (DiagnosticReport) context.getParser().parseResource(klass, s);
+        DiagnosticReport.DiagnosticReportStatus status = expectStatusUnknown.getStatus();
+
+        assertThat(expectStatusUnknown.hasStatus()).isTrue();
+        assertThat(status).isEqualTo(DiagnosticReport.DiagnosticReportStatus.UNKNOWN);
     }
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7RDEMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7RDEMessageTest.java
@@ -6,9 +6,11 @@
 package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -17,50 +19,49 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Hl7RDEMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
-        .withValidateResource().withPrettyPrint().build();
+            .withValidateResource().withPrettyPrint().build();
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7RDEMessageTest.class);
 
-
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     public void test_RDE_medRequest_patient_present(String msh) throws IOException {
-	    String hl7message = msh
-		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-		    + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-		    + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "RXR|IM\r";
+        String hl7message = msh
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "RXR|IM\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-      
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -68,34 +69,34 @@ public class Hl7RDEMessageTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     // In the HL7 spec RXR is required for these messages, however, we can handle having no RXR.
     public void test_RDE_medRequest_patient_present_withoutRXR(String msh) throws IOException {
-	    String hl7message = msh
-		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-		    + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r";
+        String hl7message = msh
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-        .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -103,40 +104,40 @@ public class Hl7RDEMessageTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
     public void test_RDE_medRequest_patient_encounter_present(String msh) throws IOException {
-	    String hl7message = msh
-		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-		    + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-		    + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "RXR|IM\r";
+        String hl7message = msh
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "RXR|IM\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -144,42 +145,42 @@ public class Hl7RDEMessageTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     public void test_RDE_medRequest_patient_encounter_withExtraSegments_present(String msh) throws IOException {
-	    String hl7message = msh
-		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-		    + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
-            + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-		    + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "RXR|IM\r";
+        String hl7message = msh
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
+                + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "RXR|IM\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -187,46 +188,46 @@ public class Hl7RDEMessageTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     public void test_RDE_medRequest_patient_encounter_allergy_present(String msh) throws IOException {
         String hl7message = msh
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
-            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-            + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "RXR|IM\r";
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "RXR|IM\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         List<Resource> allergyIntoleranceResource = e.stream()
-            .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(allergyIntoleranceResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -234,144 +235,142 @@ public class Hl7RDEMessageTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     public void test_RDE_medRequest_patient_observation_present(String msh) throws IOException {
         String hl7message = msh
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-            + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> observationResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(observationResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
         assertThat(e.size()).isEqualTo(3);
-        }
+    }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     public void test_RDE_medRequest_patient_encounter_observation_present(String msh) throws IOException {
         String hl7message = msh
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-            + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         List<Resource> observationResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(observationResource).hasSize(1);
-
 
         // Expecting only the above resources, no extras!
         assertThat(e.size()).isEqualTo(4);
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
-        "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
-    })  
+    @ValueSource(strings = {
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
+            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
+    })
     public void test_RDE_medRequest_patient_encounter_allergy_observation_present(String msh) throws IOException {
         String hl7message = msh
-            + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
-            + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
-            + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
-            + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
-            + "RXR|IM\r"
-            + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
+                + "RXE|^Q24H&0600^^20210407191342^^ROU|DEFAULTMED^cefTRIAXone (ROCEPHIN) 2 g in sodium chloride 0.9 % 50 mL IVPB|2||g||||||||\r"
+                + "RXR|IM\r"
+                + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        
+
         List<Resource> medicationRequestResource = e.stream()
-            .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(medicationRequestResource).hasSize(1);
 
         List<Resource> patientResource = e.stream()
-            .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         List<Resource> allergyIntoleranceResource = e.stream()
-            .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(allergyIntoleranceResource).hasSize(1);
 
         List<Resource> observationResource = e.stream()
-            .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(observationResource).hasSize(1);
-
 
         // Expecting only the above resources, no extras!
         assertThat(e.size()).isEqualTo(5);
     }
-  
+
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
@@ -7,12 +7,13 @@ package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.Base64;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.Identifier;
@@ -20,10 +21,7 @@ import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
-import org.hl7.fhir.r4.model.ServiceRequest;
-import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -31,8 +29,6 @@ import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
-import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
-
 
 public class Hl7DocumentReferenceFHIRConversionTest {
 
@@ -40,12 +36,13 @@ public class Hl7DocumentReferenceFHIRConversionTest {
 
     // Note: All tests for MDM_T02 and MDM_T06 are the same. Use parameters.
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_has_all_fields_in_yaml(String segment) {
         //every field covered in the yaml should be listed here
-        String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -71,18 +68,18 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_authenticator_and_author_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
                 + "OBR|1||||||20170825010500|||||||||||||002|||||F||||||||\n"
                 + "TXA|1||TEXT||||201801180346||<PHYSID1>^DOE^JANE^J^^MD||||||||||AV|||<PHYSID2>^DOE^JOHN^K^^MD||\n"
-                + "OBX|1|ST|100||This is content|||||||X\n"
-                ;
+                + "OBX|1|ST|100||This is content|||||||X\n";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(documentReferenceMessage, PatientUtils.OPTIONS);
@@ -117,11 +114,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_content_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -137,12 +135,15 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(content.getAttachment().getContentType()).isEqualTo("text/plain"); // Future TXA.3, currently always defaults to text/plain
         assertThat(content.getAttachment().getCreationElement().toString()).containsPattern("2018-01-18T03:46:00"); // TXA.7 date
         assertThat(content.getAttachment().hasData()).isTrue();
-        String decodedData = new String(Base64.getDecoder().decode(content.getAttachment().getDataElement().getValueAsString()));
-        assertThat(decodedData).isEqualTo("ECHOCARDIOGRAPHIC REPORT\nNORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH\nHYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%\n");
+        String decodedData = new String(
+                Base64.getDecoder().decode(content.getAttachment().getDataElement().getValueAsString()));
+        assertThat(decodedData).isEqualTo(
+                "ECHOCARDIOGRAPHIC REPORT\nNORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH\nHYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
 
         // TODO: Determine if we need to look at anything other than OBX.2 when it is TX
         // Leave this test in place as a reminder
-        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -160,7 +161,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(content.getAttachment().hasData()).isFalse();
 
         // Test that content is created even if TXA.7 is empty
-        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -179,11 +181,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
-    public void docRefContextAndServiceRequestPresenceTest(String segment) { 
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
+    public void docRefContextAndServiceRequestPresenceTest(String segment) {
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 // ORC required for ServiceRequest test
@@ -215,9 +218,9 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         Practitioner practBundle = ResourceUtils.getSpecificPractitionerFromBundle(bundle, requesterRef);
 
         DocumentReference.DocumentReferenceContextComponent refContext = documentReference.getContext();
-        assertThat(refContext.getPeriod().getStartElement().toString()).containsPattern("2018-01-17T14:42:00");  // TXA.4
+        assertThat(refContext.getPeriod().getStartElement().toString()).containsPattern("2018-01-17T14:42:00"); // TXA.4
         assertThat(refContext.hasRelated()).isTrue();
-        assertThat(refContext.hasPracticeSetting()).isFalse(); 
+        assertThat(refContext.hasPracticeSetting()).isFalse();
 
         assertThat(practBundle.getIdentifierFirstRep().getValue()).isEqualTo("5566");
         // Value passed to Context(TXA.5) is used as Identifier value in practitioner
@@ -235,34 +238,35 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(patientResource).hasSize(1);
 
         List<Resource> encounterResource = e.stream()
-            .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(encounterResource).hasSize(1);
 
         List<Resource> practitionerResource = e.stream()
-            .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-            .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(practitionerResource).hasSize(3);
 
         // Verify one Observation is created (from the ST)
         List<Resource> obsResource = e.stream()
                 .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
                 .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-         assertThat(obsResource).hasSize(1);  // TODO: When NTE is implemented, then update this.
+        assertThat(obsResource).hasSize(1); // TODO: When NTE is implemented, then update this.
 
         // Confirm that associated ServiceRequest is created.
         List<Resource> serviceRequestList = e.stream()
-        .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList()); 
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
         assertThat(serviceRequestList).hasSize(1);
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_date_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -276,11 +280,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_description_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -294,11 +299,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_doc_status_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -313,7 +319,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(docStatus.getSystem()).isEqualTo("http://hl7.org/fhir/composition-status");
 
         // Check OBX.11 as fallback
-        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -328,7 +335,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(docStatus.getSystem()).isEqualTo("http://hl7.org/fhir/composition-status");
 
         // Check a value that is not mapped results is no docStatus
-        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS\n"
@@ -340,13 +348,14 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     @Disabled
     // TODO: TXA-13 is not yet mapped in DocumentReference.yml
     public void doc_ref_relates_to_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -379,11 +388,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_security_label_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -400,13 +410,14 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_status_test(String segment) {
         // Check TXA.19
         // TXA.19 value maps to status; OBR.25 is ignored
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -420,7 +431,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
 
         // Check OBR.25 as fallback
         // TXA.19 value is empty so OBR.25 is used
-        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS\n"
@@ -434,7 +446,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
 
         // Check default value case
         // TXA.19 and OBR.25 values are empty so should fallback to "current"
-        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -448,11 +461,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_subject_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n" + "OBR|1||||||20170825010500|||||||||||||002|||||F||||||||\n"
@@ -480,17 +494,18 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_master_identifier_test(String segment) {
         // Test masterIdentifier uses the value(12.1) but does not require a system if 12.2 is empty
-        String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
                 + "OBR|1||||||20170825010500|||||||||||||002|||||F||||||||\n"
-                + "TXA|1||TEXT||||201801180346|||||<MESSAGEID>|||||PA|R|AV|||||\n"                
+                + "TXA|1||TEXT||||201801180346|||||<MESSAGEID>|||||PA|R|AV|||||\n"
                 + "OBX|1|SN|||||||||X";
         DocumentReference report = ResourceUtils.getDocumentReference(documentReference);
         assertThat(report.hasMasterIdentifier()).isTrue();
@@ -499,7 +514,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(masterID.getSystem()).isNull();
 
         // Test masterIdentifier uses the value(12.1) and pulls systemID from 12.2
-        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -513,7 +529,8 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(masterID.getSystem()).isEqualTo("urn:id:SYSTEM");
 
         // Test masterIdentifier uses the backup value(12.3) and does not have a system
-        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -528,11 +545,12 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "MDM^T02", "MDM^T06"
-    }) 
+    @ValueSource(strings = {
+            "MDM^T02", "MDM^T06"
+    })
     public void doc_ref_type_test(String segment) {
-        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
+                + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
                 + "PV1|1|I||||||||||||||||||||||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1|||MS|MS|||||\n"
@@ -549,23 +567,23 @@ public class Hl7DocumentReferenceFHIRConversionTest {
 
     @ParameterizedTest
     // Spot check for PPR messages
-    @ValueSource(strings = { 
-        "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ 
+    @ValueSource(strings = {
+            "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */
     })
     public void doc_ref_ppr_test(String messageType) {
-        String documentReferenceMessage =
-        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|"+ messageType + "|1|P^I|2.6||||||ASCII||\r"
-            + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r"
-            + "PV1||I|6N^1234^A^GENHOS|||||||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-            + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\r"
-            + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r"
-            + "NTE|1|P|Problem Comments\r"
-            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
-            + "OBR|1|TESTID|TESTID|||201801180346|201801180347||||||||||||||||||F||||||WEAKNESS||||||||||||\r"
-            // Next three lines create an attachment because OBX type TX
-            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\r"
-            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\r"
-            + "OBX|3|TX|||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F|||202101010000|||\n";
+        String documentReferenceMessage = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|"
+                + messageType + "|1|P^I|2.6||||||ASCII||\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r"
+                + "PV1||I|6N^1234^A^GENHOS|||||||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|AD||202101010000|aortic stenosis|53692||2|||202101010000\r"
+                + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r"
+                + "NTE|1|P|Problem Comments\r"
+                + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
+                + "OBR|1|TESTID|TESTID|||201801180346|201801180347||||||||||||||||||F||||||WEAKNESS||||||||||||\r"
+                // Next three lines create an attachment because OBX type TX
+                + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||202101010000|||\r"
+                + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||202101010000|||\r"
+                + "OBX|3|TX|||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F|||202101010000|||\n";
 
         DocumentReference documentRef = ResourceUtils.getDocumentReference(documentReferenceMessage);
         DocumentReference.DocumentReferenceContextComponent drContext = documentRef.getContext();
@@ -574,7 +592,9 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         assertThat(content.getAttachment().getContentType()).isEqualTo("text/plain"); // Currently always defaults to text/plain
         assertThat(content.getAttachment().getCreation()).isNull(); // No TXA.7 in message
         assertThat(content.getAttachment().hasData()).isTrue();
-        String decodedData = new String(Base64.getDecoder().decode(content.getAttachment().getDataElement().getValueAsString()));
-        assertThat(decodedData).isEqualTo("ECHOCARDIOGRAPHIC REPORT\nNORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH\nHYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%\n");
+        String decodedData = new String(
+                Base64.getDecoder().decode(content.getAttachment().getDataElement().getValueAsString()));
+        assertThat(decodedData).isEqualTo(
+                "ECHOCARDIOGRAPHIC REPORT\nNORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH\nHYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%");
     }
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -44,8 +44,8 @@ import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class Hl7EncounterFHIRConversionTest {
 
@@ -77,8 +77,8 @@ public class Hl7EncounterFHIRConversionTest {
         Encounter encounter = ResourceUtils.getResourceEncounter(encounterResource.get(0), context); //Encounter.Type comes from  PV1.4
         assertThat(encounter.getTypeFirstRep().getCodingFirstRep().getCode()).isEqualTo("A");
         assertThat(encounter.getTypeFirstRep().getCodingFirstRep().getDisplay()).isEqualTo("Accident");
-        assertThat(encounter.getTypeFirstRep().getCodingFirstRep().getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0007");
-
+        assertThat(encounter.getTypeFirstRep().getCodingFirstRep().getSystem())
+                .isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0007");
 
         //
         // "text": {
@@ -127,28 +127,27 @@ public class Hl7EncounterFHIRConversionTest {
     // Test for serviceProvider reference in messages with both PV1 and PV2 segments
     // Part 1: use serviceProvider from PV2.23 subfields
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
-        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-        // MDM messages are not tested here because they do not have PV2 segments
-        "OMP^O09",
-        "ORU^R01",
-        "RDE^O11","RDE^O25",
-        "VXU^V04"
+    @ValueSource(strings = {
+            "ADT^A01", /* "ADT^A02", "ADT^A03", "ADT^A04", */ "ADT^A08", /* "ADT^A28", "ADT^A31", */
+            // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+            // MDM messages are not tested here because they do not have PV2 segments
+            "OMP^O09",
+            "ORU^R01",
+            "RDE^O11", "RDE^O25",
+            "VXU^V04"
     })
     public void test_encounter_with_serviceProvider_from_PV2(String message) {
-        String hl7message = 
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
-            + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
-            + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
-            + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth^SSHW^^^^^^SSH_WEYMOUTH|||||||||N||||||\r"
-            ;
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
+                + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
+                + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
+                + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth^SSHW^^^^^^SSH_WEYMOUTH|||||||||N||||||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
 
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
@@ -175,27 +174,27 @@ public class Hl7EncounterFHIRConversionTest {
     // Test for serviceProvider reference in messages with both PV1 and PV2 segments
     // Part 2: Field PV2.23 is provided but no PV2.23.8; serviceProvider id should use backup field PV1.3.4.1
     @ParameterizedTest
-    @ValueSource(strings = { 
-        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
-        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-        // MDM messages are not tested here because they do not have PV2 segments
-        "OMP^O09",
-        "ORU^R01",
-        "RDE^O11","RDE^O25",
-        "VXU^V04"
+    @ValueSource(strings = {
+            "ADT^A01", /* "ADT^A02", "ADT^A03", "ADT^A04", */ "ADT^A08", /* "ADT^A28", "ADT^A31", */
+            // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+            // MDM messages are not tested here because they do not have PV2 segments
+            "OMP^O09",
+            "ORU^R01",
+            "RDE^O11", "RDE^O25",
+            "VXU^V04"
     })
     public void test_encounter_PV1_serviceProvider(String message) {
-        String hl7message =
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
-            + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
-            + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
-            + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth|||||||||N||||||\r";
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
+                + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\r"
+                + "PV1||I|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\r"
+                + "PV2||TEL||||X-5546||20210330144208|20210309||||||||||||n|N|South Shore Hosptial Weymouth|||||||||N||||||\r";
 
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
 
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
@@ -222,26 +221,26 @@ public class Hl7EncounterFHIRConversionTest {
     // Use serviceProvider from PV1-3.4.1
     @ParameterizedTest
     @ValueSource(strings = {
-        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
-        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-        // MDM messages are not tested here because they do not have PV2 segments
-        "OMP^O09",
-        "ORU^R01",
-        "RDE^O11","RDE^O25",
-        "VXU^V04"
+            "ADT^A01", /* "ADT^A02", "ADT^A03", "ADT^A04", */ "ADT^A08", /* "ADT^A28", "ADT^A31", */
+            // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+            // MDM messages are not tested here because they do not have PV2 segments
+            "OMP^O09",
+            "ORU^R01",
+            "RDE^O11", "RDE^O25",
+            "VXU^V04"
     })
     public void test_encounter_with_serviceProvider_from_PV1_3_4(String message) {
-        String hl7message =
-            "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message + "|controlID|P|2.6\r"
-            +"EVN|A01|20150502090000|\r"
-            +"PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
-            // PV1-3.4 used for serviceProvider reference; used for both id and name
-            +"PV1||I|INT^0001^02^Toronto East|||||||SUR||||||||S|VisitNumber^^^Toronto North|A|||||||||||||||||||Toronto West||||||\r";
- 
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
+                + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                // PV1-3.4 used for serviceProvider reference; used for both id and name
+                + "PV1||I|INT^0001^02^Toronto East|||||||SUR||||||||S|VisitNumber^^^Toronto North|A|||||||||||||||||||Toronto West||||||\r";
+
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
 
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
@@ -259,11 +258,10 @@ public class Hl7EncounterFHIRConversionTest {
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
         assertThat(organizations).hasSize(1);
 
-        Organization orgResource = ResourceUtils.getResourceOrganization(organizations.get(0),context);
+        Organization orgResource = ResourceUtils.getResourceOrganization(organizations.get(0), context);
         assertThat(orgResource.getId()).isEqualTo(providerString);
         assertThat(orgResource.getName()).isEqualTo("Toronto East");
     }
-
 
     @Test
     public void test_encounter_PV2_serviceProvider_idfix() {
@@ -276,7 +274,7 @@ public class Hl7EncounterFHIRConversionTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
+        LOGGER.debug("FHIR json result:\n" + json);
 
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
@@ -348,11 +346,13 @@ public class Hl7EncounterFHIRConversionTest {
         CodeableConcept encounterReasonEVN = reasonCodes.get(0);
         CodeableConcept encounterReasonPV2 = reasonCodes.get(1);
         if (encounterReasonPV2.getTextElement().toString() != "Fatigue") {
-                encounterReasonEVN = reasonCodes.get(1);
-                encounterReasonPV2 = reasonCodes.get(0);
+            encounterReasonEVN = reasonCodes.get(1);
+            encounterReasonPV2 = reasonCodes.get(0);
         }
-        DatatypeUtils.checkCommonCodeableConceptAssertions(encounterReasonPV2, "01.4", "Fatigue", "http://terminology.hl7.org/CodeSystem/CCC", "Fatigue");
-        DatatypeUtils.checkCommonCodeableConceptAssertions(encounterReasonEVN, "O", "Other", "http://terminology.hl7.org/CodeSystem/v2-0062", null);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(encounterReasonPV2, "01.4", "Fatigue",
+                "http://terminology.hl7.org/CodeSystem/CCC", "Fatigue");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(encounterReasonEVN, "O", "Other",
+                "http://terminology.hl7.org/CodeSystem/v2-0062", null);
 
         // Using EVN-4 and PV2.3 for reasonCode BOTH with with unknown codes
         hl7message = "MSH|^~\\&|||||20151008111200||ADT^A01^ADT_A01|MSGID000001|T|2.6|||||||||\n"
@@ -369,8 +369,8 @@ public class Hl7EncounterFHIRConversionTest {
         encounterReasonEVN = reasonCodes.get(0);
         encounterReasonPV2 = reasonCodes.get(1);
         if (encounterReasonPV2.getCodingFirstRep().getCode() != "vomits") {
-                encounterReasonEVN = reasonCodes.get(1);
-                encounterReasonPV2 = reasonCodes.get(0);
+            encounterReasonEVN = reasonCodes.get(1);
+            encounterReasonPV2 = reasonCodes.get(0);
         }
         DatatypeUtils.checkCommonCodeableConceptAssertions(encounterReasonPV2, "vomits", null, null, null);
         DatatypeUtils.checkCommonCodeableConceptAssertions(encounterReasonEVN, "REG_UPDATE", null, null, null);
@@ -542,20 +542,20 @@ public class Hl7EncounterFHIRConversionTest {
     // Extension list should be empty and serviceProvider should be null
     @ParameterizedTest
     @ValueSource(strings = {
-        "ADT^A01", /*"ADT^A02", "ADT^A03", "ADT^A04",*/ "ADT^A08", /*"ADT^A28", "ADT^A31",*/
-        // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
-        // MDM messages are not tested here because they do not have PV2 segments
-        "OMP^O09",
-        "ORU^R01",
-        "RDE^O11","RDE^O25",
-        "VXU^V04"
+            "ADT^A01", /* "ADT^A02", "ADT^A03", "ADT^A04", */ "ADT^A08", /* "ADT^A28", "ADT^A31", */
+            // ADT_A34 and ADT_A40 do not create encounters so they do not need to be tested here
+            // MDM messages are not tested here because they do not have PV2 segments
+            "OMP^O09",
+            "ORU^R01",
+            "RDE^O11", "RDE^O25",
+            "VXU^V04"
     })
     public void test_encounter_PV2segment_missing(String message) {
-        String hl7message =
-            "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|" + message + "|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
-            + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
-            + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
-            + "PV1||I|^^^^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n";
+        String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|" + message
+                + "|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
+                + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
+                + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
+                + "PV1||I|^^^^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting||Visit_0a3be81e-144b-4885-9b4e-c5cd33c8f038|||||||||||||||||||||||||20210407191342\n";
         Encounter encounter = ResourceUtils.getEncounter(hl7message);
         Narrative encText = encounter.getText();
         assertNull(encText.getStatus());
@@ -599,7 +599,8 @@ public class Hl7EncounterFHIRConversionTest {
 
         HashMap<String, List<String>> practionerMap = new HashMap<String, List<String>>();
         //Make sure that practitioners found are matching the HL7 by using known ID as check
-        List<String> practionerIds = Arrays.asList("2905", "2905-2", "5755", "5755-2", "770542", "770542-2", "59367", "59367-2");
+        List<String> practionerIds = Arrays.asList("2905", "2905-2", "5755", "5755-2", "770542", "770542-2", "59367",
+                "59367-2");
         for (Resource r : practioners) {
             Practitioner p = ResourceUtils.getResourcePractitioner(r, context);
             assertThat(p.getIdentifier()).hasSize(1);
@@ -623,7 +624,7 @@ public class Hl7EncounterFHIRConversionTest {
                 case "5755-2":
                     values.add("Referring2 DoctorB2 Sr2");
                     values.add("REF");
-                    break;    
+                    break;
                 case "770542":
                     values.add("Consulting DoctorC Jr");
                     values.add("CON");
@@ -631,7 +632,7 @@ public class Hl7EncounterFHIRConversionTest {
                 case "770542-2":
                     values.add("Consulting2 DoctorC2 Sr");
                     values.add("CON");
-                    break;    
+                    break;
                 case "59367":
                     values.add("Admitting DoctorD");
                     values.add("ADM");
@@ -639,7 +640,7 @@ public class Hl7EncounterFHIRConversionTest {
                 case "59367-2":
                     values.add("Admitting2 DoctorD2");
                     values.add("ADM");
-                    break;    
+                    break;
             }
             practionerMap.put(p.getId(), values);
         }
@@ -650,7 +651,8 @@ public class Hl7EncounterFHIRConversionTest {
             // Use the Id to look up the expected Participant name and Participant code
             // In map, first value is Participant name , second is Participant code
             assertEquals(practionerMap.get(id).get(0), participantComponent.getIndividual().getDisplay());
-            assertEquals(practionerMap.get(id).get(1), participantComponent.getType().get(0).getCoding().get(0).getCode());
+            assertEquals(practionerMap.get(id).get(1),
+                    participantComponent.getType().get(0).getCoding().get(0).getCode());
         }
     }
 
@@ -688,9 +690,9 @@ public class Hl7EncounterFHIRConversionTest {
         Practitioner practitioner = ResourceUtils.getResourcePractitioner(practioners.get(0), context);
 
         // With one practitioner and one participant, confirm the ID's match, the code and name are expected.
-        assertThat( participantComponent.getIndividual().getReference()).isEqualTo(practitioner.getId());
-        assertThat( participantComponent.getType().get(0).getCoding().get(0).getCode()).isEqualTo("ADM");
-        assertThat( participantComponent.getIndividual().getDisplay()).isEqualTo("Admitting Doctor");
+        assertThat(participantComponent.getIndividual().getReference()).isEqualTo(practitioner.getId());
+        assertThat(participantComponent.getType().get(0).getCoding().get(0).getCode()).isEqualTo("ADM");
+        assertThat(participantComponent.getIndividual().getDisplay()).isEqualTo("Admitting Doctor");
 
     }
 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -14,9 +14,9 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.Condition.ConditionEvidenceComponent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Condition.ConditionEvidenceComponent;
 import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Practitioner;
@@ -87,9 +87,11 @@ public class Hl7NoteFHIRConverterTest {
                 ResourceUtils.context);
         assertThat(serviceRequest.hasNote()).isTrue();
         assertThat(serviceRequest.getNote()).hasSize(1);
-        // Processing adds "  \n" two spaces and a line feed
-        assertThat(serviceRequest.getNote().get(0).getText())
-                .isEqualTo("TEST ORC/OBR NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
+        // Processing adds "  \n" two spaces and a line feed between each line.
+        // NOTE: the note contains an Annotation, which contains a MarkdownType that has the string.
+        // Must use getTextElement().getValueAsString() to see untrimmed contents.
+        assertThat(serviceRequest.getNote().get(0).getTextElement().getValueAsString()).isEqualTo(
+                "TEST ORC/OBR NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
         assertThat(serviceRequest.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerServReqRefId = serviceRequest.getNote().get(0).getAuthorReference().getReference();
 
@@ -107,14 +109,14 @@ public class Hl7NoteFHIRConverterTest {
         // Validate the note contents and references 
         assertThat(obsHemoglobin.hasNote()).isTrue();
         assertThat(obsHemoglobin.getNote()).hasSize(1);
-        assertThat(obsHemoglobin.getNote().get(0).getText())
+        assertThat(obsHemoglobin.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST OBXa NOTE BB line 1  \nTEST NOTE BB line 2  \nTEST NOTE BB line 3");
         assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();
 
         assertThat(obsGlucose.hasNote()).isTrue();
         assertThat(obsGlucose.getNote()).hasSize(1);
-        assertThat(obsGlucose.getNote().get(0).getText()).isEqualTo(
+        assertThat(obsGlucose.getNote().get(0).getTextElement().getValueAsString()).isEqualTo(
                 "TEST OBXb NOTE CC line 1  \nTEST NOTE CC line 2  \n   \nTEST NOTE CC line 4"); // Test that blank lines are preserved.
         assertThat(obsGlucose.getNote().get(0).hasAuthorReference()).isFalse();
 
@@ -202,7 +204,9 @@ public class Hl7NoteFHIRConverterTest {
                 ResourceUtils.context);
         assertThat(medicationRequest.hasNote()).isTrue();
         assertThat(medicationRequest.getNote()).hasSize(1);
-        assertThat(medicationRequest.getNote().get(0).getText())
+        // NOTE: the note contains an Annotation, which contains a MarkdownType that has the string.
+        // Must use getTextElement().getValueAsString() to see untrimmed contents.
+        assertThat(medicationRequest.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST MedReq NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
         assertThat(medicationRequest.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerServReqRefId = medicationRequest.getNote().get(0).getAuthorReference().getReference();
@@ -221,14 +225,14 @@ public class Hl7NoteFHIRConverterTest {
         // Validate the note contents and references 
         assertThat(obsHemoglobin.hasNote()).isTrue();
         assertThat(obsHemoglobin.getNote()).hasSize(1);
-        assertThat(obsHemoglobin.getNote().get(0).getText())
+        assertThat(obsHemoglobin.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST OBXa NOTE BB line 1  \nTEST NOTE BB line 2  \nTEST NOTE BB line 3");
         assertThat(obsHemoglobin.getNote().get(0).hasAuthorReference()).isTrue();
         String practitionerObsHemoglobinRefId = obsHemoglobin.getNote().get(0).getAuthorReference().getReference();
 
         assertThat(obsGlucose.hasNote()).isTrue();
         assertThat(obsGlucose.getNote()).hasSize(1);
-        assertThat(obsGlucose.getNote().get(0).getText()).isEqualTo(
+        assertThat(obsGlucose.getNote().get(0).getTextElement().getValueAsString()).isEqualTo(
                 "TEST OBXb NOTE CC line 1  \nTEST NOTE CC line 2  \n   \nTEST NOTE CC line 4"); // Test that blank lines are preserved.
         assertThat(obsGlucose.getNote().get(0).hasAuthorReference()).isFalse();
 
@@ -314,13 +318,15 @@ public class Hl7NoteFHIRConverterTest {
             condTachy = temp;
         }
         // Test the conditions have the correct NTE's associated and have correct content.
+        // NOTE: the note contains an Annotation, which contains a MarkdownType that has the string.
+        // Must use getTextElement().getValueAsString() to see untrimmed contents.
         assertThat(condStenosis.hasNote()).isTrue();
         assertThat(condStenosis.getNote()).hasSize(1);
-        assertThat(condStenosis.getNote().get(0).getText())
+        assertThat(condStenosis.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST PRBa NOTE AA line 1  \nTEST NOTE AA line 2  \nTEST NOTE AA line 3");
         assertThat(condTachy.hasNote()).isTrue();
         assertThat(condTachy.getNote()).hasSize(1);
-        assertThat(condTachy.getNote().get(0).getText())
+        assertThat(condTachy.getNote().get(0).getTextElement().getValueAsString())
                 .isEqualTo("TEST PRBd NOTE DD line 1  \nTEST NOTE DD line 2  \nTEST NOTE DD line 3");
 
         // Four observations.  Two associated with the first problem and two with the second

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -5,317 +5,337 @@
  */
 package io.github.linuxforhealth.hl7.segments.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Device;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Immunization;
+import org.hl7.fhir.r4.model.MedicationAdministration;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.Procedure;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.*;
-import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.ArrayList;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResourceUtils {
 
-  public static FHIRContext context = new FHIRContext();
-  private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtils.class);
-  private static final ConverterOptions OPTIONS =
-    new Builder().withValidateResource().withPrettyPrint().build();
+    public static FHIRContext context = new FHIRContext();
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtils.class);
+    private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
 
-  public static List<BundleEntryComponent> createFHIRBundleFromHL7MessageReturnEntryList(String inputSegment){
-    HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-    String json = ftv.convert(inputSegment, OPTIONS);
-    assertThat(json).isNotBlank();
-    LOGGER.info("FHIR json result:\n" + json);
-    FHIRContext context = new FHIRContext();
-    IBaseResource bundleResource = context.getParser().parseResource(json);
-    assertThat(bundleResource).isNotNull();
-    Bundle b = (Bundle) bundleResource;
-    List<BundleEntryComponent> e = b.getEntry();
-    return e;
-  }
-
-  // Helper method that gets the first (and usually only) value of the property out of a FHIR Base object.
-  public static Base getValue(Base obj, String name) {
-    Base value = obj.getNamedProperty(name).getValues().get(0);
-    return value;
-  }
-
-  // Helper method that gets the first (and usually only) value of the property out of a FHIR Base object and returns it as string.
-  public static String getValueAsString(Base obj, String name) {
-    String value = obj.getNamedProperty(name).getValues().get(0).toString();
-    return value;
-  }
-
-  public static AllergyIntolerance getAllergyResource(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> allergy =
-            resource.stream().filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(allergy.get(0));
-    Class<? extends IBaseResource> klass = AllergyIntolerance.class;
-    return (AllergyIntolerance) context.getParser().parseResource(klass, s);
-  }
-
-  public static Condition getCondition(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> condition =
-            resource.stream().filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(condition.get(0));
-    Class<? extends IBaseResource> klass = Condition.class;
-
-    return (Condition) context.getParser().parseResource(klass, s);
-  }
-
-  public static DiagnosticReport getDiagnosticReport(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> diagnosticReport =
-            resource.stream().filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));
-    Class<? extends IBaseResource> klass = DiagnosticReport.class;
-
-    return (DiagnosticReport) context.getParser().parseResource(klass, s);
-  }
-
-  public static DocumentReference getDocumentReference(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> documentReference =
-            resource.stream().filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(documentReference.get(0));
-    Class<? extends IBaseResource> klass = DocumentReference.class;
-
-    return (DocumentReference) context.getParser().parseResource(klass, s);
-  }
-
-  public static Encounter getEncounter(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> encounter =
-            resource.stream().filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(encounter.get(0));
-    Class<? extends IBaseResource> klass = Encounter.class;
-
-    return (Encounter) context.getParser().parseResource(klass, s);
-  }
-
-  public static Immunization getImmunization(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> immunization =
-            resource.stream().filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(immunization.get(0));
-    Class<? extends IBaseResource> klass = Immunization.class;
-
-    return (Immunization) context.getParser().parseResource(klass, s);
-  }
-
-  public static Observation getObservation(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> observation =
-            resource.stream().filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(observation.get(0));
-    Class<? extends IBaseResource> klass = Observation.class;
-
-    return (Observation) context.getParser().parseResource(klass, s);
-  }
-
-  public static Procedure getProcedure(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> procedure =
-            resource.stream().filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(procedure.get(0));
-    Class<? extends IBaseResource> klass = Procedure.class;
-
-    return (Procedure) context.getParser().parseResource(klass, s);
-  }
-
-  public static ServiceRequest getServiceRequest(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> serviceRequest =
-            resource.stream().filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(serviceRequest.get(0));
-    Class<? extends IBaseResource> klass = ServiceRequest.class;
-
-    return (ServiceRequest) context.getParser().parseResource(klass, s);
-  }
-
-  public static Patient getPatient(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> patient =
-            resource.stream().filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(patient).hasSize(1);
-
-    String s = context.getParser().encodeResourceToString(patient.get(0));
-    Class<? extends IBaseResource> klass = ServiceRequest.class;
-
-    return (Patient) context.getParser().parseResource(klass, s);
-  }
-
-  public static MedicationRequest getMedicationRequest(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> medicationRequest =
-            resource.stream().filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(medicationRequest.get(0));
-    Class<? extends IBaseResource> klass = MedicationRequest.class;
-
-    return (MedicationRequest) context.getParser().parseResource(klass, s);
-  }
-
-  public static MedicationAdministration getMedicationAdministration(String inputSegment) {
-    List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
-
-    List<Resource> medicationAdministration =
-            resource.stream().filter(v -> ResourceType.MedicationAdministration == v.getResource().getResourceType())
-                    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-
-    String s = context.getParser().encodeResourceToString(medicationAdministration.get(0));
-    Class<? extends IBaseResource> klass = MedicationAdministration.class;
-
-    return (MedicationAdministration) context.getParser().parseResource(klass, s);
-  }
-
-  // Given a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
-  // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
-  public static Practitioner getSpecificPractitionerFromBundle(Bundle bundle, String practitionerRef) {
-    return getSpecificPractitionerFromBundleEntriesList(bundle.getEntry(), practitionerRef);
-  }
-
-  // Given a list of entries from a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
-  // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
-  public static Practitioner getSpecificPractitionerFromBundleEntriesList(List<BundleEntryComponent> entries, String practitionerRef) {
-    // Find the practitioner resources from the FHIR bundle.
-    List<Resource> practitioners = entries.stream()
-        .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-        .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-    assertThat(practitioners.size()).isPositive(); // Confirm there is at least one practitioner
-    // Find all practitioners with matching Id's in the list of practitioners.
-    List<Resource> matchingPractitioners = new ArrayList<Resource>();
-    for (int i = 0; i < practitioners.size(); i++) {
-      if (practitioners.get(i).getId().equalsIgnoreCase(practitionerRef)) {
-        matchingPractitioners.add(practitioners.get(i));
-      }
+    public static List<BundleEntryComponent> createFHIRBundleFromHL7MessageReturnEntryList(String inputSegment) {
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String json = ftv.convert(inputSegment, OPTIONS);
+        assertThat(json).isNotBlank();
+        LOGGER.debug("FHIR json result:\n" + json);
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        List<BundleEntryComponent> e = b.getEntry();
+        return e;
     }
-    assertThat(matchingPractitioners).hasSize(1); // Count must be exactly 1.  
-    Practitioner pract = (Practitioner) matchingPractitioners.get(0);
-    return pract;
-  }
- 
-  public static ServiceRequest getResourceServiceRequest(Resource resource, FHIRContext context ) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = ServiceRequest.class;
-    return (ServiceRequest) context.getParser().parseResource(klass, s);
-  }
 
-  public static DiagnosticReport getResourceDiagnosticReport(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = DiagnosticReport.class;
-    return (DiagnosticReport) context.getParser().parseResource(klass, s);
-  }
+    // Helper method that gets the first (and usually only) value of the property out of a FHIR Base object.
+    public static Base getValue(Base obj, String name) {
+        Base value = obj.getNamedProperty(name).getValues().get(0);
+        return value;
+    }
 
-  public static DocumentReference getResourceDocumentReference(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = DocumentReference.class;
-    return (DocumentReference) context.getParser().parseResource(klass, s);
-  }
+    // Helper method that gets the first (and usually only) value of the property out of a FHIR Base object and returns it as string.
+    public static String getValueAsString(Base obj, String name) {
+        String value = obj.getNamedProperty(name).getValues().get(0).toString();
+        return value;
+    }
 
-  public static MedicationRequest getResourceMedicationRequest(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = MedicationRequest.class;
-    return (MedicationRequest) context.getParser().parseResource(klass, s);
-  }
+    public static AllergyIntolerance getAllergyResource(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
-  public static Patient getResourcePatient(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Patient.class;
-    return (Patient) context.getParser().parseResource(klass, s);
-  }
+        List<Resource> allergy = resource.stream()
+                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
 
-  public static Immunization getResourceImmunization(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Immunization.class;
-    return (Immunization) context.getParser().parseResource(klass, s);
-  }
+        String s = context.getParser().encodeResourceToString(allergy.get(0));
+        Class<? extends IBaseResource> klass = AllergyIntolerance.class;
+        return (AllergyIntolerance) context.getParser().parseResource(klass, s);
+    }
 
-  public static Encounter getResourceEncounter(Resource resource, FHIRContext context) {
-      String s = context.getParser().encodeResourceToString(resource);
-      Class<? extends IBaseResource> klass = Encounter.class;
-      return (Encounter) context.getParser().parseResource(klass, s);
-  }
+    public static Condition getCondition(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
-  public static Practitioner getResourcePractitioner(Resource resource, FHIRContext context) {
-      String s = context.getParser().encodeResourceToString(resource);
-      Class<? extends IBaseResource> klass = Practitioner.class;
-      return (Practitioner) context.getParser().parseResource(klass, s);
-  }
+        List<Resource> condition = resource.stream()
+                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
 
-  public static Organization getResourceOrganization(Resource resource, FHIRContext context) {
-      String s = context.getParser().encodeResourceToString(resource);
-      Class<? extends IBaseResource> klass = Organization.class;
-      return (Organization) context.getParser().parseResource(klass, s);
-  }
+        String s = context.getParser().encodeResourceToString(condition.get(0));
+        Class<? extends IBaseResource> klass = Condition.class;
 
-  public static MessageHeader getResourceMessageHeader(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = MessageHeader.class;
-    return (MessageHeader) context.getParser().parseResource(klass, s);
-  }
-  
-  public static Condition getResourceCondition(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Condition.class;
-    return (Condition) context.getParser().parseResource(klass, s);
-  }
+        return (Condition) context.getParser().parseResource(klass, s);
+    }
 
-  public static Observation getResourceObservation(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Observation.class;
-    return (Observation) context.getParser().parseResource(klass, s);
-  }
+    public static DiagnosticReport getDiagnosticReport(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
 
-  public static Device getResourceDevice(Resource resource, FHIRContext context) {
-    String s = context.getParser().encodeResourceToString(resource);
-    Class<? extends IBaseResource> klass = Device.class;
-    return (Device) context.getParser().parseResource(klass, s);
-  }
+        List<Resource> diagnosticReport = resource.stream()
+                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
 
-  public static List<Resource> getResourceList(List<BundleEntryComponent> e, ResourceType resourceType){
-    return e.stream()
-    .filter(v -> resourceType == v.getResource().getResourceType())
-    .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-  } 
+        String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));
+        Class<? extends IBaseResource> klass = DiagnosticReport.class;
+
+        return (DiagnosticReport) context.getParser().parseResource(klass, s);
+    }
+
+    public static DocumentReference getDocumentReference(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> documentReference = resource.stream()
+                .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(documentReference.get(0));
+        Class<? extends IBaseResource> klass = DocumentReference.class;
+
+        return (DocumentReference) context.getParser().parseResource(klass, s);
+    }
+
+    public static Encounter getEncounter(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> encounter = resource.stream()
+                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(encounter.get(0));
+        Class<? extends IBaseResource> klass = Encounter.class;
+
+        return (Encounter) context.getParser().parseResource(klass, s);
+    }
+
+    public static Immunization getImmunization(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> immunization = resource.stream()
+                .filter(v -> ResourceType.Immunization == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(immunization.get(0));
+        Class<? extends IBaseResource> klass = Immunization.class;
+
+        return (Immunization) context.getParser().parseResource(klass, s);
+    }
+
+    public static Observation getObservation(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> observation = resource.stream()
+                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(observation.get(0));
+        Class<? extends IBaseResource> klass = Observation.class;
+
+        return (Observation) context.getParser().parseResource(klass, s);
+    }
+
+    public static Procedure getProcedure(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> procedure = resource.stream()
+                .filter(v -> ResourceType.Procedure == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(procedure.get(0));
+        Class<? extends IBaseResource> klass = Procedure.class;
+
+        return (Procedure) context.getParser().parseResource(klass, s);
+    }
+
+    public static ServiceRequest getServiceRequest(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> serviceRequest = resource.stream()
+                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(serviceRequest.get(0));
+        Class<? extends IBaseResource> klass = ServiceRequest.class;
+
+        return (ServiceRequest) context.getParser().parseResource(klass, s);
+    }
+
+    public static Patient getPatient(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> patient = resource.stream()
+                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(patient).hasSize(1);
+
+        String s = context.getParser().encodeResourceToString(patient.get(0));
+        Class<? extends IBaseResource> klass = ServiceRequest.class;
+
+        return (Patient) context.getParser().parseResource(klass, s);
+    }
+
+    public static MedicationRequest getMedicationRequest(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> medicationRequest = resource.stream()
+                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(medicationRequest.get(0));
+        Class<? extends IBaseResource> klass = MedicationRequest.class;
+
+        return (MedicationRequest) context.getParser().parseResource(klass, s);
+    }
+
+    public static MedicationAdministration getMedicationAdministration(String inputSegment) {
+        List<BundleEntryComponent> resource = createFHIRBundleFromHL7MessageReturnEntryList(inputSegment);
+
+        List<Resource> medicationAdministration = resource.stream()
+                .filter(v -> ResourceType.MedicationAdministration == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+
+        String s = context.getParser().encodeResourceToString(medicationAdministration.get(0));
+        Class<? extends IBaseResource> klass = MedicationAdministration.class;
+
+        return (MedicationAdministration) context.getParser().parseResource(klass, s);
+    }
+
+    // Given a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
+    // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
+    public static Practitioner getSpecificPractitionerFromBundle(Bundle bundle, String practitionerRef) {
+        return getSpecificPractitionerFromBundleEntriesList(bundle.getEntry(), practitionerRef);
+    }
+
+    // Given a list of entries from a bundle and practioner reference, returns the matching referenced Practitioner from the bundle
+    // Asserts that there is at least one practitioner in the bundle and exactly one match for the reference
+    public static Practitioner getSpecificPractitionerFromBundleEntriesList(List<BundleEntryComponent> entries,
+            String practitionerRef) {
+        // Find the practitioner resources from the FHIR bundle.
+        List<Resource> practitioners = entries.stream()
+                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        assertThat(practitioners.size()).isPositive(); // Confirm there is at least one practitioner
+        // Find all practitioners with matching Id's in the list of practitioners.
+        List<Resource> matchingPractitioners = new ArrayList<Resource>();
+        for (int i = 0; i < practitioners.size(); i++) {
+            if (practitioners.get(i).getId().equalsIgnoreCase(practitionerRef)) {
+                matchingPractitioners.add(practitioners.get(i));
+            }
+        }
+        assertThat(matchingPractitioners).hasSize(1); // Count must be exactly 1.  
+        Practitioner pract = (Practitioner) matchingPractitioners.get(0);
+        return pract;
+    }
+
+    public static ServiceRequest getResourceServiceRequest(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = ServiceRequest.class;
+        return (ServiceRequest) context.getParser().parseResource(klass, s);
+    }
+
+    public static DiagnosticReport getResourceDiagnosticReport(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = DiagnosticReport.class;
+        return (DiagnosticReport) context.getParser().parseResource(klass, s);
+    }
+
+    public static DocumentReference getResourceDocumentReference(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = DocumentReference.class;
+        return (DocumentReference) context.getParser().parseResource(klass, s);
+    }
+
+    public static MedicationRequest getResourceMedicationRequest(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = MedicationRequest.class;
+        return (MedicationRequest) context.getParser().parseResource(klass, s);
+    }
+
+    public static Patient getResourcePatient(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Patient.class;
+        return (Patient) context.getParser().parseResource(klass, s);
+    }
+
+    public static Immunization getResourceImmunization(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Immunization.class;
+        return (Immunization) context.getParser().parseResource(klass, s);
+    }
+
+    public static Encounter getResourceEncounter(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Encounter.class;
+        return (Encounter) context.getParser().parseResource(klass, s);
+    }
+
+    public static Practitioner getResourcePractitioner(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Practitioner.class;
+        return (Practitioner) context.getParser().parseResource(klass, s);
+    }
+
+    public static Organization getResourceOrganization(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Organization.class;
+        return (Organization) context.getParser().parseResource(klass, s);
+    }
+
+    public static MessageHeader getResourceMessageHeader(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = MessageHeader.class;
+        return (MessageHeader) context.getParser().parseResource(klass, s);
+    }
+
+    public static Condition getResourceCondition(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Condition.class;
+        return (Condition) context.getParser().parseResource(klass, s);
+    }
+
+    public static Observation getResourceObservation(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Observation.class;
+        return (Observation) context.getParser().parseResource(klass, s);
+    }
+
+    public static Device getResourceDevice(Resource resource, FHIRContext context) {
+        String s = context.getParser().encodeResourceToString(resource);
+        Class<? extends IBaseResource> klass = Device.class;
+        return (Device) context.getParser().parseResource(klass, s);
+    }
+
+    public static List<Resource> getResourceList(List<BundleEntryComponent> e, ResourceType resourceType) {
+        return e.stream()
+                .filter(v -> resourceType == v.getResource().getResourceType())
+                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
The separator string was being added at the end of multi-line reports.  This eliminates that, while preserving the capability to add the separator char after the last element when it is desired.

Also changed remaining tests that output the json to be debug log statement instead of info.

Signed-off-by: Lisa S. Wellman <peace@us.ibm.com>