### PR TITLE
Fix missing mfg ref  in Imm on multiples

### DIFF
--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -61,9 +61,12 @@ reportOrigin:
    expressionType: resource
    specs: RXA.9
 manufacturer:
+   condition: rxa17 NOT_NULL
    valueOf: resource/Organization
    expressionType: reference
    specs: RXA.17
+   vars: 
+      rxa17: RXA.17
 lotNumber:
    type: STRING
    valueOf: RXA.15


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This fixes the missing Immunization manufacturer (and ref Id) when there are multiple RXAs.
Adds tests.