### PR TITLE
Fixes for sonarqube code smells + javadoc change to not create index

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ javadoc.failOnError = false
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
-    javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+    javadoc.options.addStringOption('noindex', '-quiet')
 }
 
 artifacts {

--- a/src/test/java/io/github/linuxforhealth/core/data/GeneralUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/data/GeneralUtilTest.java
@@ -1,7 +1,9 @@
 package io.github.linuxforhealth.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
+
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.Varies;
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
@@ -12,49 +14,48 @@ import ca.uhn.hl7v2.model.v26.message.ORU_R01;
 import ca.uhn.hl7v2.model.v26.segment.OBX;
 
 public class GeneralUtilTest {
-  private static final String SOME_TEXT_VALUE = "SOME TEXT VALUE";
+    private static final String SOME_TEXT_VALUE = "SOME TEXT VALUE";
 
-  @Test
-  public void test_getDataType_returns_value() {
-    String value = "any string value";
-    assertThat(DataTypeUtil.getDataType(value)).isEqualTo(String.class.getSimpleName());
-  }
+    @Test
+    public void test_getDataType_returns_value() {
+        String value = "any string value";
+        assertThat(DataTypeUtil.getDataType(value)).isEqualTo(String.class.getSimpleName());
+    }
 
+    @Test
+    public void test_getDataType_returns_null_for_null_input() {
+        assertThat(DataTypeUtil.getDataType(null)).isNull();
+    }
 
-  @Test
-  public void test_getDataType_returns_null_for_null_input() {
-    assertThat(DataTypeUtil.getDataType(null)).isEqualTo(null);
-  }
+    @Test
+    public void test_getDataType_returns_value_for_hl7_primitive() throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        TX tx = new TX(message);
+        tx.setValue(SOME_TEXT_VALUE);
+        assertThat(DataTypeUtil.getDataType(tx)).isEqualTo("TX");
+    }
 
-  @Test
-  public void test_getDataType_returns_value_for_hl7_primitive() throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    TX tx = new TX(message);
-    tx.setValue(SOME_TEXT_VALUE);
-    assertThat(DataTypeUtil.getDataType(tx)).isEqualTo("TX");
-  }
+    @Test
+    public void test_getDataTypee_returns_value_for_hl7_compositive() throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        CWE ce = new CWE(message);
+        ce.getIdentifier().setValue("SOME Identifier");
+        ce.getText().setValue("Some Value");
+        ce.getNameOfCodingSystem().setValue("SNM");
+        assertThat(DataTypeUtil.getDataType(ce)).isEqualTo("CWE");
+    }
 
-  @Test
-  public void test_getDataTypee_returns_value_for_hl7_compositive() throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    CWE ce = new CWE(message);
-    ce.getIdentifier().setValue("SOME Identifier");
-    ce.getText().setValue("Some Value");
-    ce.getNameOfCodingSystem().setValue("SNM");
-    assertThat(DataTypeUtil.getDataType(ce)).isEqualTo("CWE");
-  }
-
-  @Test
-  public void test_getDataType_returns_value_for_hl7_varies() throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    ORU_R01_ORDER_OBSERVATION orderObservation = message.getPATIENT_RESULT().getORDER_OBSERVATION();
-    ORU_R01_OBSERVATION observation = orderObservation.getOBSERVATION(0);
-    OBX obx = observation.getOBX();
-    TX tx = new TX(message);
-    tx.setValue(SOME_TEXT_VALUE);
-    Varies value = obx.getObservationValue(0);
-    value.setData(tx);
-    assertThat(DataTypeUtil.getDataType(value)).isEqualTo("TX");
-  }
+    @Test
+    public void test_getDataType_returns_value_for_hl7_varies() throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        ORU_R01_ORDER_OBSERVATION orderObservation = message.getPATIENT_RESULT().getORDER_OBSERVATION();
+        ORU_R01_OBSERVATION observation = orderObservation.getOBSERVATION(0);
+        OBX obx = observation.getOBX();
+        TX tx = new TX(message);
+        tx.setValue(SOME_TEXT_VALUE);
+        Varies value = obx.getObservationValue(0);
+        value.setData(tx);
+        assertThat(DataTypeUtil.getDataType(value)).isEqualTo("TX");
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7DataHandlerUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7DataHandlerUtilTest.java
@@ -6,8 +6,11 @@
 package io.github.linuxforhealth.hl7.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
+
 import com.google.common.collect.Lists;
+
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.Varies;
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
@@ -16,104 +19,99 @@ import ca.uhn.hl7v2.model.v26.group.ORU_R01_OBSERVATION;
 import ca.uhn.hl7v2.model.v26.group.ORU_R01_ORDER_OBSERVATION;
 import ca.uhn.hl7v2.model.v26.message.ORU_R01;
 import ca.uhn.hl7v2.model.v26.segment.OBX;
-import io.github.linuxforhealth.hl7.data.Hl7DataHandlerUtil;
 
 public class Hl7DataHandlerUtilTest {
 
-  private static final String SOME_TEXT_VALUE = "SOME TEXT VALUE";
-  private static final String SOME_OTHER_TEXT_VALUE = "SOME OTHER TEXT VALUE";
+    private static final String SOME_TEXT_VALUE = "SOME TEXT VALUE";
+    private static final String SOME_OTHER_TEXT_VALUE = "SOME OTHER TEXT VALUE";
 
-  @Test
-  public void test_getStringValue_returns_value() {
-    String value = "any string value";
-    assertThat(Hl7DataHandlerUtil.getStringValue(value)).isEqualTo(value);
-  }
+    @Test
+    public void test_getStringValue_returns_value() {
+        String value = "any string value";
+        assertThat(Hl7DataHandlerUtil.getStringValue(value)).isEqualTo(value);
+    }
 
+    @Test
+    public void test_getStringValue_returns_null_for_null_input() {
+        assertThat(Hl7DataHandlerUtil.getStringValue(null)).isNull();
+    }
 
-  @Test
-  public void test_getStringValue_returns_null_for_null_input() {
-    assertThat(Hl7DataHandlerUtil.getStringValue(null)).isEqualTo(null);
-  }
+    @Test
+    public void test_getStringValue_returns_value_for_hl7_primitive() throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        TX tx = new TX(message);
+        tx.setValue(SOME_TEXT_VALUE);
+        assertThat(Hl7DataHandlerUtil.getStringValue(tx)).isEqualTo(SOME_TEXT_VALUE);
+    }
 
-  @Test
-  public void test_getStringValue_returns_value_for_hl7_primitive() throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    TX tx = new TX(message);
-    tx.setValue(SOME_TEXT_VALUE);
-    assertThat(Hl7DataHandlerUtil.getStringValue(tx)).isEqualTo(SOME_TEXT_VALUE);
-  }
+    @Test
+    public void test_getStringValue_returns_value_for_hl7_compositive() throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        CWE ce = new CWE(message);
+        ce.getIdentifier().setValue(SOME_TEXT_VALUE);
+        ce.getText().setValue("Some Value");
+        ce.getNameOfCodingSystem().setValue("SNM");
+        assertThat(Hl7DataHandlerUtil.getStringValue(ce)).isEqualTo(SOME_TEXT_VALUE);
+    }
 
-  @Test
-  public void test_getStringValue_returns_value_for_hl7_compositive() throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    CWE ce = new CWE(message);
-    ce.getIdentifier().setValue(SOME_TEXT_VALUE);
-    ce.getText().setValue("Some Value");
-    ce.getNameOfCodingSystem().setValue("SNM");
-    assertThat(Hl7DataHandlerUtil.getStringValue(ce)).isEqualTo(SOME_TEXT_VALUE);
-  }
+    @Test
+    public void test_getStringValue_returns_value_for_hl7_compositive_all_components()
+            throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        CWE ce = new CWE(message);
+        ce.getIdentifier().setValue(SOME_TEXT_VALUE);
+        ce.getText().setValue("Some Value");
+        ce.getNameOfCodingSystem().setValue("SNM");
+        assertThat(Hl7DataHandlerUtil.getStringValue(ce, true))
+                .isEqualTo(SOME_TEXT_VALUE + ", Some Value, SNM");
+    }
 
+    @Test
+    public void test_getStringValue_returns_value_for_hl7_varies() throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        ORU_R01_ORDER_OBSERVATION orderObservation = message.getPATIENT_RESULT().getORDER_OBSERVATION();
+        ORU_R01_OBSERVATION observation = orderObservation.getOBSERVATION(0);
+        OBX obx = observation.getOBX();
+        TX tx = new TX(message);
+        tx.setValue(SOME_TEXT_VALUE);
+        Varies value = obx.getObservationValue(0);
+        value.setData(tx);
+        assertThat(Hl7DataHandlerUtil.getStringValue(value)).isEqualTo(SOME_TEXT_VALUE);
+    }
 
-  @Test
-  public void test_getStringValue_returns_value_for_hl7_compositive_all_components()
-      throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    CWE ce = new CWE(message);
-    ce.getIdentifier().setValue(SOME_TEXT_VALUE);
-    ce.getText().setValue("Some Value");
-    ce.getNameOfCodingSystem().setValue("SNM");
-    assertThat(Hl7DataHandlerUtil.getStringValue(ce, true))
-        .isEqualTo(SOME_TEXT_VALUE + ", Some Value, SNM");
-  }
+    @Test
+    public void test_getStringValue_returns_value_for_list_of_hl7_compositive()
+            throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        CWE ce = new CWE(message);
+        ce.getIdentifier().setValue(SOME_TEXT_VALUE);
+        ce.getText().setValue("Some Value");
+        ce.getNameOfCodingSystem().setValue("SNM");
 
-  @Test
-  public void test_getStringValue_returns_value_for_hl7_varies() throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    ORU_R01_ORDER_OBSERVATION orderObservation = message.getPATIENT_RESULT().getORDER_OBSERVATION();
-    ORU_R01_OBSERVATION observation = orderObservation.getOBSERVATION(0);
-    OBX obx = observation.getOBX();
-    TX tx = new TX(message);
-    tx.setValue(SOME_TEXT_VALUE);
-    Varies value = obx.getObservationValue(0);
-    value.setData(tx);
-    assertThat(Hl7DataHandlerUtil.getStringValue(value)).isEqualTo(SOME_TEXT_VALUE);
-  }
+        CWE ce2 = new CWE(message);
+        ce2.getIdentifier().setValue(SOME_OTHER_TEXT_VALUE);
+        ce2.getText().setValue("Some other Value");
+        ce2.getNameOfCodingSystem().setValue("OTH");
+        assertThat(Hl7DataHandlerUtil.getStringValue(Lists.newArrayList(ce, ce2)))
+                .isEqualTo(SOME_TEXT_VALUE + ". " + SOME_OTHER_TEXT_VALUE + ".");
+    }
 
+    @Test
+    public void test_getStringValue_returns_value_for_list_of_hl7_compositive_all_components()
+            throws DataTypeException {
+        ORU_R01 message = new ORU_R01();
+        CWE ce = new CWE(message);
+        ce.getIdentifier().setValue(SOME_TEXT_VALUE);
+        ce.getText().setValue("Some Value");
+        ce.getNameOfCodingSystem().setValue("SNM");
 
-  @Test
-  public void test_getStringValue_returns_value_for_list_of_hl7_compositive()
-      throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    CWE ce = new CWE(message);
-    ce.getIdentifier().setValue(SOME_TEXT_VALUE);
-    ce.getText().setValue("Some Value");
-    ce.getNameOfCodingSystem().setValue("SNM");
-
-    CWE ce2 = new CWE(message);
-    ce2.getIdentifier().setValue(SOME_OTHER_TEXT_VALUE);
-    ce2.getText().setValue("Some other Value");
-    ce2.getNameOfCodingSystem().setValue("OTH");
-    assertThat(Hl7DataHandlerUtil.getStringValue(Lists.newArrayList(ce, ce2)))
-        .isEqualTo(SOME_TEXT_VALUE + ". " + SOME_OTHER_TEXT_VALUE + ".");
-  }
-
-
-  @Test
-  public void test_getStringValue_returns_value_for_list_of_hl7_compositive_all_components()
-      throws DataTypeException {
-    ORU_R01 message = new ORU_R01();
-    CWE ce = new CWE(message);
-    ce.getIdentifier().setValue(SOME_TEXT_VALUE);
-    ce.getText().setValue("Some Value");
-    ce.getNameOfCodingSystem().setValue("SNM");
-
-    CWE ce2 = new CWE(message);
-    ce2.getIdentifier().setValue(SOME_OTHER_TEXT_VALUE);
-    ce2.getText().setValue("Some other Value");
-    ce2.getNameOfCodingSystem().setValue("OTH");
-    assertThat(Hl7DataHandlerUtil.getStringValue(Lists.newArrayList(ce, ce2), true))
-        .isEqualTo(SOME_TEXT_VALUE + ", Some Value, SNM. " + SOME_OTHER_TEXT_VALUE
-            + ", Some other Value, OTH.");
-  }
+        CWE ce2 = new CWE(message);
+        ce2.getIdentifier().setValue(SOME_OTHER_TEXT_VALUE);
+        ce2.getText().setValue("Some other Value");
+        ce2.getNameOfCodingSystem().setValue("OTH");
+        assertThat(Hl7DataHandlerUtil.getStringValue(Lists.newArrayList(ce, ce2), true))
+                .isEqualTo(SOME_TEXT_VALUE + ", Some Value, SNM. " + SOME_OTHER_TEXT_VALUE
+                        + ", Some other Value, OTH.");
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -96,7 +96,7 @@ public class Hl7RelatedGeneralUtilsTest {
 
         long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
                 "2007-11-04T01:32:06.345+09:00");
-        assertThat(diff).isEqualTo(0);
+        assertThat(diff).isZero();
     }
 
     @Test
@@ -204,7 +204,7 @@ public class Hl7RelatedGeneralUtilsTest {
         assertThat(stringArray.get(0)).isEqualTo("apple");
         // Test for 0; expect an empty array
         stringArray = Hl7RelatedGeneralUtils.makeStringArray();
-        assertThat(stringArray.size()).isEqualTo(0);
+        assertThat(stringArray.size()).isZero();
     }
 
     @Test
@@ -219,8 +219,8 @@ public class Hl7RelatedGeneralUtilsTest {
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, "Y", null)).isEqualTo("temp");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", ANYTHING)).isEqualTo("temp");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, "Y", null)).isEqualTo("temp");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, null)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", ANYTHING, null)).isEmpty();
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, "")).isEqualTo("old");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, null)).isEqualTo("old");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, "")).isEqualTo("old");
@@ -229,8 +229,8 @@ public class Hl7RelatedGeneralUtilsTest {
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, "Y")).isEqualTo("old");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, "Y")).isEqualTo("old");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, "Y")).isEqualTo("old");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, ANYTHING)).isEmpty();
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, ANYTHING)).isEqualTo("home");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", null, ANYTHING)).isEqualTo("home");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, null)).isEqualTo("home");
@@ -247,11 +247,11 @@ public class Hl7RelatedGeneralUtilsTest {
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, ANYTHING)).isEqualTo("billing");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", ANYTHING, null)).isEqualTo("billing");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BI", null, null)).isEqualTo("billing");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, null)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, null)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, ANYTHING, null)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, null)).isEmpty();
 
     }
 
@@ -263,16 +263,16 @@ public class Hl7RelatedGeneralUtilsTest {
         assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "M")).isEqualTo("postal");
         assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
         assertThat(Hl7RelatedGeneralUtils.getAddressType("M", null)).isEqualTo("postal");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEmpty();
         assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
         assertThat(Hl7RelatedGeneralUtils.getAddressType(null, "V")).isEqualTo("physical");
         assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
         assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", null)).isEqualTo("physical");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, null)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, null)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, null)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(null, null)).isEmpty();
 
     }
 
@@ -283,11 +283,11 @@ public class Hl7RelatedGeneralUtilsTest {
         // Inputs are XAD.7 Type, XAD.18 Type 
         assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
         assertThat(Hl7RelatedGeneralUtils.getAddressType("M", "")).isEqualTo("postal");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("M", ANYTHING)).isEmpty();
         assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "V")).isEqualTo("physical");
         assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", "")).isEqualTo("physical");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEqualTo("");
-        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEqualTo("");
+        assertThat(Hl7RelatedGeneralUtils.getAddressType("SH", ANYTHING)).isEmpty();
+        assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, ANYTHING)).isEmpty();
     }
     // Note: Utility  Hl7RelatedGeneralUtils.getAddressDistrict is more effectively tested as part of Patient Address testing
 

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/ResourceExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/ResourceExpressionTest.java
@@ -6,14 +6,18 @@
 package io.github.linuxforhealth.hl7.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableMap;
+
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.model.Segment;
@@ -27,400 +31,386 @@ import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 
 public class ResourceExpressionTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ResourceExpressionTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceExpressionTest.class);
 
-  String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-      + "EVN|A01|20130617154644\r"
-      + "PID|1|465 306 5961|000010016^5^M11^SY1^MR^|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-      + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-      + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
-
-  @Test
-  public void test1_segment() throws IOException {
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
-        .withValueOf("datatype/Identifier").build();
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    Map<String, Object> result = (Map<String, Object>) value.getValue();
-    assertThat(result.get("use")).isEqualTo(null);
-    assertThat(result.get("value")).isEqualTo("000010016");
-
-  }
-
-
-  @Test
-  public void test_component_required_missing() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961||407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
+            + "EVN|A01|20130617154644\r"
+            + "PID|1|465 306 5961|000010016^5^M11^SY1^MR^|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+            + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+            + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
 
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+    @Test
+    public void test1_segment() throws IOException {
 
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
-        .withValueOf("datatype/Identifier").build();
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
 
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
+                .withValueOf("datatype/Identifier").build();
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
 
-    Map<String, EvaluationResult> context = new HashMap<>();
+        Map<String, EvaluationResult> context = new HashMap<>();
 
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
 
-    assertThat(value).isNull();
+        Map<String, Object> result = (Map<String, Object>) value.getValue();
+        assertThat(result.get("use")).isNull();
+        assertThat(result.get("value")).isEqualTo("000010016");
 
-  }
-
-
-  @Test
-  public void test_picks_next_value_from_rep_if_first_fails_condition_or_check()
-      throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961|^^^MR^SSS^^20091020^20200101~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
-        .withValueOf("datatype/Identifier").build();
-
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    assertThat(value).isNotNull();
-    Map<String, Object> result = (Map<String, Object>) value.getValue();
-    assertThat(result.get("use")).isEqualTo(null);
-    assertThat(result.get("value")).isEqualTo("000010017");
-    assertThat(result.get("type")).isNull();
-
-}
-
-
-  @Test
-  public void test1_segment_rep() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961|000010016^^^SY1^MR~000010017^^^SY2^SS~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
-        .withValueOf("datatype/Identifier").withGenerateList(true).build();
-
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-    context.put("code", new SimpleEvaluationResult(hl7DTE.getTypes((Segment) s, 3)));
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    List<Object> results = (List<Object>) value.getValue();
-    assertThat(results).hasSize(3);
-
-    Map<String, Object> result = (Map<String, Object>) results.get(0);
-    assertThat(result.get("use")).isEqualTo(null);
-    assertThat(result.get("value")).isEqualTo("000010016");
-    assertThat(result.get("system")).isNull();
-    assertThat(result.get("type")).isNotNull();
-
-  }
-
-
-  @Test
-  public void test1_segment_identifier_obx() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
-        + "OBX|1|TX|1234||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\r";
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.3")
-        .withValueOf("datatype/Identifier").build();
-
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-    Map<String, Object> result = (Map<String, Object>) value.getValue();
-    assertThat(result.get("use")).isEqualTo(null);
-    assertThat(result.get("value")).isEqualTo("1234");
-    assertThat(result.get("system")).isEqualTo(null);
-
-  }
-
-
-  @Test
-  public void testSegmentIdentifierObxCc() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961|12345678^^^MR|407623|TestPatient^John^^MR||19700101|male||||||||||\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
-        + "OBX|1|TX|1234^some text^SCT||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\r";
-
-    Message hl7message = getMessage(message);
-
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.3")
-        .withValueOf("datatype/Identifier").withGenerateList(true).build();
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-    Map<String, Object> type = (Map<String, Object>) result.get(0).get("type");
-
-    assertThat(type.get("text")).isEqualTo("some text");
-    assertThat(type.get("coding")).isNotNull();
-    List<Object> list = (List) type.get("coding");
-    SimpleCode scs = (SimpleCode)list.get(0);
-    assertThat(scs.getCode()).isEqualTo("1234");
-    assertThat(scs.getSystem()).isEqualTo("http://snomed.info/sct");
-    assertThat(scs.getDisplay()).isEqualTo("some text");
-
-  }
-
-
-  @Test
-  public void testSegmentIdentifierObxCcKnownSystem() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961|123456^^^MR|407623|TestPatient^John^^^MR||19700101|male||||||||||\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
-        + "OBX|1|TX|1234^some text^SCT||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\r";
-
-    Message hl7message = getMessage(message);
-
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.3")
-        .withValueOf("datatype/CodeableConcept").withGenerateList(true).build();
-
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-    assertThat(result.get(0).get("text")).isEqualTo("some text");
-    assertThat(result.get(0).get("coding")).isNotNull();
-    List<Object> list = (List) result.get(0).get("coding");
-    SimpleCode scs = (SimpleCode)list.get(0);
-    assertThat(scs.getCode()).isEqualTo("1234");
-    assertThat(scs.getSystem()).isEqualTo("http://snomed.info/sct");
-    assertThat(scs.getDisplay()).isEqualTo("some text");
-
-  }
-
-  @Test
-  public void testCodeableConceptFromISTtype() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "EVN|A01|20130617154644\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|TestPatient^Jane|19700101|female||||||||||\r"
-        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
-        + "OBX|1|TX|1234^^SCT||First line: ECHOCARDIOGRAPHIC REPORT|||AA|||F||\r";
-
-    Message hl7message = getMessage(message);
-
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.8")
-        .withValueOf("datatype/CodeableConcept").withGenerateList(true).build();
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-    assertThat(result.get(0).get("text")).isNull();
-    assertThat(result.get(0).get("coding")).isNotNull();
-    List<SimpleCode> scs = (List<SimpleCode>) result.get(0).get("coding");
-    SimpleCode sc = scs.get(0);
-    assertThat(sc.getCode()).isEqualTo("AA");
-    assertThat(sc.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0078");
-    assertThat(sc.getDisplay()).isEqualTo("Critically abnormal");
-
-  }
-
-
-  @Test
-  public void test_organization_creation_with_missing_id_value() throws IOException {
-    String message =
-        "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
-            + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
-            + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
-            + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-            + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|^sanofi^MVX|||CP|A\r"
-            + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
-            + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
-            + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
-            + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
-            + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r"
-            + "OBX|5|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
-
-    Message hl7message = getMessage(message);
-
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getAllStructures("ORDER", 0, "RXA").getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("RXA.17")
-        .withValueOf("resource/Organization").withGenerateList(true).build();
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-    assertThat(result.get(0).get("name")).isEqualTo("sanofi");
-    assertThat(result.get(0).get("identifier")).isNull();
-
-    LOGGER.debug("result="+result);
-
-  }
-
-
-  @Test
-  public void test_organization_creation_with_missing_id_and_name_value() throws IOException {
-    String message =
-        "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
-            + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
-            + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
-            + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-            + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|^^MVX|||CP|A\r"
-            + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
-            + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
-            + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
-            + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
-            + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r"
-            + "OBX|5|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
-
-    Message hl7message = getMessage(message);
-
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getAllStructures("ORDER", 0, "RXA").getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("RXA.17")
-        .withValueOf("resource/Organization").withGenerateList(true).build();
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    assertThat(value).isNull();
-
-  }
-
-
-  @Test
-  public void test_organization_creation_with_mo_missing_value() throws IOException {
-    String message =
-        "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
-            + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
-            + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
-            + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-            + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
-            + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
-            + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
-            + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
-            + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
-            + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r"
-            + "OBX|5|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
-
-    Message hl7message = getMessage(message);
-
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-    Structure s = hl7DTE.getAllStructures("ORDER", 0, "RXA").getValue();
-    ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("RXA.17")
-        .withValueOf("resource/Organization").withGenerateList(true).build();
-    ResourceExpression exp = new ResourceExpression(attr);
-    assertThat(exp.getData()).isNotNull();
-
-    Map<String, EvaluationResult> context = new HashMap<>();
-
-    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
-        new SimpleEvaluationResult(s));
-
-    List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-    assertThat(result.get(0).get("name")).isEqualTo("sanofi");
-    List<Map<String, Object>> identifiers =
-        (List<Map<String, Object>>) result.get(0).get("identifier");
-    assertThat(identifiers.get(0).get("value")).isEqualTo("PMC");
-
-    LOGGER.debug("result="+result);
-
-  }
-
-
-  private static Message getMessage(String message) throws IOException {
-    HL7HapiParser hparser = null;
-
-    try {
-      hparser = new HL7HapiParser();
-      return hparser.getParser().parse(message);
-    } catch (HL7Exception e) {
-      throw new IllegalArgumentException(e);
-    } finally {
-      if (hparser != null) {
-        hparser.getContext().close();
-      }
     }
 
-  }
+    @Test
+    public void test_component_required_missing() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961||407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
+                .withValueOf("datatype/Identifier").build();
+
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        assertThat(value).isNull();
+
+    }
+
+    @Test
+    public void test_picks_next_value_from_rep_if_first_fails_condition_or_check()
+            throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961|^^^MR^SSS^^20091020^20200101~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
+                .withValueOf("datatype/Identifier").build();
+
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        assertThat(value).isNotNull();
+        Map<String, Object> result = (Map<String, Object>) value.getValue();
+        assertThat(result.get("use")).isNull();
+        assertThat(result.get("value")).isEqualTo("000010017");
+        assertThat(result.get("type")).isNull();
+
+    }
+
+    @Test
+    public void test1_segment_rep() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961|000010016^^^SY1^MR~000010017^^^SY2^SS~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("PID.3")
+                .withValueOf("datatype/Identifier").withGenerateList(true).build();
+
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+        context.put("code", new SimpleEvaluationResult(hl7DTE.getTypes((Segment) s, 3)));
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        List<Object> results = (List<Object>) value.getValue();
+        assertThat(results).hasSize(3);
+
+        Map<String, Object> result = (Map<String, Object>) results.get(0);
+        assertThat(result.get("use")).isNull();
+        assertThat(result.get("value")).isEqualTo("000010016");
+        assertThat(result.get("system")).isNull();
+        assertThat(result.get("type")).isNotNull();
+
+    }
+
+    @Test
+    public void test1_segment_identifier_obx() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
+                + "OBX|1|TX|1234||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\r";
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.3")
+                .withValueOf("datatype/Identifier").build();
+
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+        Map<String, Object> result = (Map<String, Object>) value.getValue();
+        assertThat(result.get("use")).isNull();
+        assertThat(result.get("value")).isEqualTo("1234");
+        assertThat(result.get("system")).isNull();
+
+    }
+
+    @Test
+    public void testSegmentIdentifierObxCc() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961|12345678^^^MR|407623|TestPatient^John^^MR||19700101|male||||||||||\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
+                + "OBX|1|TX|1234^some text^SCT||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\r";
+
+        Message hl7message = getMessage(message);
+
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.3")
+                .withValueOf("datatype/Identifier").withGenerateList(true).build();
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
+        Map<String, Object> type = (Map<String, Object>) result.get(0).get("type");
+
+        assertThat(type.get("text")).isEqualTo("some text");
+        assertThat(type.get("coding")).isNotNull();
+        List<Object> list = (List) type.get("coding");
+        SimpleCode scs = (SimpleCode) list.get(0);
+        assertThat(scs.getCode()).isEqualTo("1234");
+        assertThat(scs.getSystem()).isEqualTo("http://snomed.info/sct");
+        assertThat(scs.getDisplay()).isEqualTo("some text");
+
+    }
+
+    @Test
+    public void testSegmentIdentifierObxCcKnownSystem() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961|123456^^^MR|407623|TestPatient^John^^^MR||19700101|male||||||||||\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
+                + "OBX|1|TX|1234^some text^SCT||First line: ECHOCARDIOGRAPHIC REPORT||||||F||\r";
+
+        Message hl7message = getMessage(message);
+
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.3")
+                .withValueOf("datatype/CodeableConcept").withGenerateList(true).build();
+
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
+        assertThat(result.get(0).get("text")).isEqualTo("some text");
+        assertThat(result.get(0).get("coding")).isNotNull();
+        List<Object> list = (List) result.get(0).get("coding");
+        SimpleCode scs = (SimpleCode) list.get(0);
+        assertThat(scs.getCode()).isEqualTo("1234");
+        assertThat(scs.getSystem()).isEqualTo("http://snomed.info/sct");
+        assertThat(scs.getDisplay()).isEqualTo("some text");
+
+    }
+
+    @Test
+    public void testCodeableConceptFromISTtype() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "EVN|A01|20130617154644\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|TestPatient^Jane|19700101|female||||||||||\r"
+                + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
+                + "OBX|1|TX|1234^^SCT||First line: ECHOCARDIOGRAPHIC REPORT|||AA|||F||\r";
+
+        Message hl7message = getMessage(message);
+
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("OBX.8")
+                .withValueOf("datatype/CodeableConcept").withGenerateList(true).build();
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
+        assertThat(result.get(0).get("text")).isNull();
+        assertThat(result.get(0).get("coding")).isNotNull();
+        List<SimpleCode> scs = (List<SimpleCode>) result.get(0).get("coding");
+        SimpleCode sc = scs.get(0);
+        assertThat(sc.getCode()).isEqualTo("AA");
+        assertThat(sc.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0078");
+        assertThat(sc.getDisplay()).isEqualTo("Critically abnormal");
+
+    }
+
+    @Test
+    public void test_organization_creation_with_missing_id_value() throws IOException {
+        String message = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
+                + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
+                + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
+                + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
+                + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|^sanofi^MVX|||CP|A\r"
+                + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
+                + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
+                + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
+                + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
+                + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r"
+                + "OBX|5|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
+
+        Message hl7message = getMessage(message);
+
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getAllStructures("ORDER", 0, "RXA").getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("RXA.17")
+                .withValueOf("resource/Organization").withGenerateList(true).build();
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
+        assertThat(result.get(0).get("name")).isEqualTo("sanofi");
+        assertThat(result.get(0).get("identifier")).isNull();
+
+        LOGGER.debug("result=" + result);
+
+    }
+
+    @Test
+    public void test_organization_creation_with_missing_id_and_name_value() throws IOException {
+        String message = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
+                + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
+                + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
+                + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
+                + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|^^MVX|||CP|A\r"
+                + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
+                + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
+                + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
+                + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
+                + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r"
+                + "OBX|5|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
+
+        Message hl7message = getMessage(message);
+
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getAllStructures("ORDER", 0, "RXA").getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("RXA.17")
+                .withValueOf("resource/Organization").withGenerateList(true).build();
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        assertThat(value).isNull();
+
+    }
+
+    @Test
+    public void test_organization_creation_with_mo_missing_value() throws IOException {
+        String message = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
+                + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
+                + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
+                + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
+                + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
+                + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
+                + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
+                + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
+                + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
+                + "OBX|4|TS|59785-6^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r"
+                + "OBX|5|ST|48767-8^Annotation^LN|2|Some text from doctor||||||F|||20130531\r";
+
+        Message hl7message = getMessage(message);
+
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getAllStructures("ORDER", 0, "RXA").getValue();
+        ExpressionAttributes attr = new ExpressionAttributes.Builder().withSpecs("RXA.17")
+                .withValueOf("resource/Organization").withGenerateList(true).build();
+        ResourceExpression exp = new ResourceExpression(attr);
+        assertThat(exp.getData()).isNotNull();
+
+        Map<String, EvaluationResult> context = new HashMap<>();
+
+        EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+                new SimpleEvaluationResult(s));
+
+        List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
+        assertThat(result.get(0).get("name")).isEqualTo("sanofi");
+        List<Map<String, Object>> identifiers = (List<Map<String, Object>>) result.get(0).get("identifier");
+        assertThat(identifiers.get(0).get("value")).isEqualTo("PMC");
+
+        LOGGER.debug("result=" + result);
+
+    }
+
+    private static Message getMessage(String message) throws IOException {
+        HL7HapiParser hparser = null;
+
+        try {
+            hparser = new HL7HapiParser();
+            return hparser.getParser().parse(message);
+        } catch (HL7Exception e) {
+            throw new IllegalArgumentException(e);
+        } finally {
+            if (hparser != null) {
+                hparser.getContext().close();
+            }
+        }
+
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -123,7 +123,7 @@ public class Hl7ORUMessageTest {
 
         // Verify presentedForm from OBX of type TX - In this case no attachments created since there are no OBX with type TX
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments.size(), "Unexpected number of attachments");
 
     }
 
@@ -219,7 +219,7 @@ public class Hl7ORUMessageTest {
 
         // Verify presentedForm from OBX of type TX - In this case no attachments created because the OBX of type TX have ids.
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments.size(), "Unexpected number of attachments");
 
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
@@ -292,7 +292,7 @@ public class Hl7ORUMessageTest {
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
         assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
-        assertThat(diag.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
+        assertThat(diag.getCategory().size()).isZero(); // Verify category from OBR.24
 
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
@@ -326,7 +326,7 @@ public class Hl7ORUMessageTest {
 
         // Verify presentedForm from OBX of type TX - In this case no attachments created because the OBX is not of type TX.
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments.size(), "Unexpected number of attachments");
 
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
@@ -399,7 +399,7 @@ public class Hl7ORUMessageTest {
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
         assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
-        assertThat(diag.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
+        assertThat(diag.getCategory().size()).isZero(); // Verify category from OBR.24
 
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
@@ -432,14 +432,14 @@ public class Hl7ORUMessageTest {
 
         // Verify presentedForm from OBX of type TX - In this case no attachments created because the OBX is not of type TX.
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments.size(), "Unexpected number of attachments");
 
         ///////////////////////////////////////////
         // Now confirm content of the SECOND diagnosticReport because we don't have separate tests for DiagnosticReport
         ///////////////////////////////////////////
         DiagnosticReport diag2 = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
         assertThat(diag2.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
-        assertThat(diag2.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
+        assertThat(diag2.getCategory().size()).isZero(); // Verify category from OBR.24
 
         // Verify code from OBR.4
         assertThat(diag2.hasCode()).isTrue();
@@ -472,7 +472,7 @@ public class Hl7ORUMessageTest {
 
         // Verify presentedForm from OBX of type TX - In this case no attachments created because the OBX is not type TX.
         List<Attachment> attachments2 = diag2.getPresentedForm();
-        Assertions.assertTrue(attachments2.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments2.size(), "Unexpected number of attachments");
 
         ////////////////////////////////////        
         // Check the references that aren't covered in Observation tests
@@ -544,7 +544,7 @@ public class Hl7ORUMessageTest {
         ///////////////////////////////////////////
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticReport.get(0), context);
         assertThat(diag.getStatus().toCode()).isEqualTo("final"); // Verify status from OBR.25
-        assertThat(diag.getCategory().size()).isEqualTo(0); // Verify category from OBR.24
+        assertThat(diag.getCategory().size()).isZero(); // Verify category from OBR.24
 
         // Verify code from OBR.4
         assertThat(diag.hasCode()).isTrue();
@@ -581,7 +581,7 @@ public class Hl7ORUMessageTest {
         assertThat(obsRef.get(0).isEmpty()).isFalse();
         // Verify presentedForm from OBX of type ST - No attachments expected because OBX of type not TX creates an Observation.
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments.size(), "Unexpected number of attachments");
 
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
@@ -615,7 +615,7 @@ public class Hl7ORUMessageTest {
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
-        Assertions.assertTrue(b.getType() == BundleType.COLLECTION, "Bundle type not expected");
+        Assertions.assertSame(BundleType.COLLECTION, b.getType(), "Bundle type not expected");
         List<BundleEntryComponent> e = b.getEntry();
 
         // Verify that the right resources have been created
@@ -697,24 +697,23 @@ public class Hl7ORUMessageTest {
 
         // Verify specimen reference
         List<Reference> spmRef = diag.getSpecimen();
-        assertThat(spmRef.isEmpty());
+        assertThat(spmRef).isEmpty();
 
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
-        assertThat(obsRef.isEmpty()).isTrue();
+        assertThat(obsRef).isEmpty();
 
         //Verify attachment to diagnostic report
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 1, "Unexpected number of attachments");
+        Assertions.assertEquals(1, attachments.size(), "Unexpected number of attachments");
         Attachment a = attachments.get(0);
         Assertions.assertTrue(a.getContentType().equalsIgnoreCase("text/plain"), "Incorrect content type");
         Assertions.assertTrue(a.getLanguage().equalsIgnoreCase("en"), "Incorrect language");
         //Verify data attachment after decoding
         String decoded = new String(Base64.getDecoder().decode(a.getDataElement().getValueAsString()));
         System.out.println("Decoded: '" + decoded + "'");
-        Assertions.assertTrue(
-                decoded.equals("\n[PII] Emergency Department\nED Encounter Arrival Date: [ADDRESS] [PERSONALNAME]:"),
-                "Incorrect data");
+        Assertions.assertEquals("\n[PII] Emergency Department\nED Encounter Arrival Date: [ADDRESS] [PERSONALNAME]:",
+                decoded, "Incorrect data");
         Assertions.assertTrue(a.getTitle().equalsIgnoreCase("ECHO CARDIOGRAM COMPLETE"), "Incorrect title");
         //Verify creation data is persisted correctly - 2020-08-02T12:44:55+08:00
         Calendar c = Calendar.getInstance();
@@ -722,7 +721,7 @@ public class Hl7ORUMessageTest {
         c.set(2020, 7, 2, 12, 44, 55);
         c.setTimeZone(TimeZone.getTimeZone(ZoneId.of("+08:00")));
         Date d = c.getTime();
-        Assertions.assertTrue(a.getCreation().equals(d), "Incorrect creation date");
+        Assertions.assertEquals(d, a.getCreation(), "Incorrect creation date");
 
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests
@@ -756,7 +755,7 @@ public class Hl7ORUMessageTest {
         IBaseResource bundleResource = context.getParser().parseResource(json);
         Bundle b = (Bundle) bundleResource;
         assertThat(bundleResource).isNotNull();
-        Assertions.assertTrue(b.getType() == BundleType.COLLECTION, "Bundle type not expected");
+        Assertions.assertSame(BundleType.COLLECTION, b.getType(), "Bundle type not expected");
         List<BundleEntryComponent> e = b.getEntry();
 
         // Verify that the right resources have been created
@@ -842,16 +841,16 @@ public class Hl7ORUMessageTest {
 
         // Verify specimen reference
         List<Reference> spmRef = diag.getSpecimen();
-        assertThat(spmRef.isEmpty());
+        assertThat(spmRef).isEmpty();
 
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
-        assertThat(obsRef.isEmpty()).isFalse();
+        assertThat(obsRef).isNotEmpty();
         assertThat(obsRef).hasSize(1);
         assertThat(obsRef.get(0).isEmpty()).isFalse();
         // No attachment created since OBX with TX and no id is not first
         List<Attachment> attachments = diag.getPresentedForm();
-        Assertions.assertTrue(attachments.size() == 0, "Unexpected number of attachments");
+        Assertions.assertEquals(0, attachments.size(), "Unexpected number of attachments");
 
         ////////////////////////////////////
         // Verify the references that aren't covered in Observation tests

--- a/src/test/java/io/github/linuxforhealth/hl7/message/SegmentUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/SegmentUtilTest.java
@@ -6,11 +6,15 @@
 package io.github.linuxforhealth.hl7.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
+
 import com.google.common.collect.Lists;
+
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.model.Segment;
@@ -24,504 +28,446 @@ import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 import io.github.linuxforhealth.hl7.parsing.result.ParsingResult;
 
 public class SegmentUtilTest {
-  private static final String NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH =
-      "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH";
-
-  private static final ArrayList<String> ORDER_GROUP_LIST =
-      Lists.newArrayList("PROBLEM", "ORDER", "ORDER_DETAIL", "ORDER_OBSERVATION");
-  private static final ArrayList<String> PROBLEM_GROUP_LIST =
-      Lists.newArrayList("PROBLEM", "PROBLEM_OBSERVATION");
-
-
-  private static final String ECHOCARDIOGRAPHIC_REPORT = "ECHOCARDIOGRAPHIC REPORT";
-
-  private String messageSingleOrderGroup =
-      "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-          + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-          + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-          + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-          + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
-          + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
-          + "OBR|1|CD150920001336|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r";
-
-  private String messageSingleProblemGroup =
-      "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-          + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-          + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-          + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-          + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r";
-
-  private String messageRepeat =
-      "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-          + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-          + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-          + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-          + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
-          + "OBR|1|CD150920001336|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-          + "NTE|1|P|Problem Comments11\r" + "VAR|varid1|200603150610\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r"
-          + "NTE|2|P|Problem Comments22\r" + "VAR|varid1|200603150610\r"
-          + "ORC|NW|1001^OE|9999999^RX|||E|^Q6He^D10^^^R\r"
-          + "OBR|1|CD150920001337|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT2||||||F|||20150930164100|||\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3||||||F|||20150930164100|||";
-
-  private String messageRepeatMultiplePRB =
-      "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-          + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-          + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-          + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
-          + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
-          + "OBR|1|CD150920001336|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-          + "NTE|1|P|Problem Comments11\r" + "VAR|varid1|200603150610\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r"
-          + "NTE|2|P|Problem Comments22\r" + "VAR|varid1|200603150610\r"
-          + "ORC|NW|1001^OE|9999999^RX|||E|^Q6He^D10^^^R\r"
-          + "OBR|1|CD150920001337|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT2||||||F|||20150930164100|||\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3||||||F|||20150930164100|||\r"
-          + "PRB|CE|20060315076|lung  new issue|53693||2||200603150625\r"
-          + "ORC|NW|1009^OE|9999998^RX|||E|^Q6H^D10^^^R\r"
-          + "OBR|1|CD150920001337|CD150920001337|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT new group||||||F|||20150930164100|||\r";
-
-
-
-  String hl7ADTmessage =
-      "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ADT^A08^ADT_A08|1|P^I|2.6||||||ASCII||\r"
-          + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-          + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-          + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
-          + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
-          + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r";
-
-  // Tests for extracting segment from group
-  @Test
-  public void test_single_order_group() throws HL7Exception {
-
-
-    Message hl7message = getMessage(messageSingleOrderGroup);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(2);
-    validateEachGroup(hl7DTE, segmentGroups.get(0), 1, 0, ECHOCARDIOGRAPHIC_REPORT);
-    validateEachGroup(hl7DTE, segmentGroups.get(1), 1, 0,
-        NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
-  }
-
-  @Test
-  public void test_single_problem_group_wrong_group_list_provided() throws HL7Exception {
-
-
-    Message hl7message = getMessage(messageSingleProblemGroup);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
-    assertThat(segmentGroups).isEmpty();
-
-  }
-
-
-  @Test
-  public void test_single_problem_group() throws HL7Exception {
-
-
-    Message hl7message = getMessage(messageSingleProblemGroup);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(PROBLEM_GROUP_LIST,
-        "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(2);
-    validateEachGroup(hl7DTE, segmentGroups.get(0), 1, 0, ECHOCARDIOGRAPHIC_REPORT);
-    validateEachGroup(hl7DTE, segmentGroups.get(1), 1, 0,
-        NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
-  }
-
-
-
-  @Test
-  public void test_parent_repeat() throws HL7Exception {
-    Message hl7message = getMessage(messageRepeat);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(4);
-
-    validateEachGroup(hl7DTE, segmentGroups.get(0), 1, 0, ECHOCARDIOGRAPHIC_REPORT);
-    validateEachGroup(hl7DTE, segmentGroups.get(1), 1, 0,
-        NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
-    validateEachGroup(hl7DTE, segmentGroups.get(2), 1, 0, "ECHOCARDIOGRAPHIC REPORT2");
-    validateEachGroup(hl7DTE, segmentGroups.get(3), 1, 0,
-        "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3");
-  }
-
-
-
-  @Test
-  public void test_parent_repeat_additional_segment_under_parent() throws HL7Exception {
-    Message hl7message = getMessage(messageRepeat);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX", Lists.newArrayList(new HL7Segment("PID")), hl7DTE, Lists.newArrayList());
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(4);
-
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(0), 1, 1, ECHOCARDIOGRAPHIC_REPORT,
-        "PID");
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(1), 1, 1,
-        NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH, "PID");
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(2), 1, 1,
-        "ECHOCARDIOGRAPHIC REPORT2", "PID");
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(3), 1, 1,
-        "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3", "PID");
-
-  }
-
-
-  @Test
-  public void test_parent_repeat_additional_segment_under_group() throws HL7Exception {
-    Message hl7message = getMessage(messageRepeat);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX", Lists.newArrayList(new HL7Segment(ORDER_GROUP_LIST, "NTE", true)), hl7DTE,
-        Lists.newArrayList());
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(4);
-
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(0), 1, 1, ECHOCARDIOGRAPHIC_REPORT,
-        "NTE");
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(1), 1, 1,
-        NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH, "NTE");
-    validateEachGroup(hl7DTE, segmentGroups.get(2), 1, 0, "ECHOCARDIOGRAPHIC REPORT2");
-    validateEachGroup(hl7DTE, segmentGroups.get(3), 1, 0,
-        "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3");
-
-  }
-
-
-  @Test
-  public void test_parent_repeat_additional_segment_under_group_with_group_name()
-      throws HL7Exception {
-    Message hl7message = getMessage(messageRepeatMultiplePRB);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX", Lists.newArrayList(new HL7Segment(ORDER_GROUP_LIST, "NTE", true)), hl7DTE,
-        Lists.newArrayList("PROBLEM"));
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(5);
-
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(0), 1, 1, ECHOCARDIOGRAPHIC_REPORT,
-        "NTE");
-    validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(1), 1, 1,
-        NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH, "NTE");
-    validateEachGroup(hl7DTE, segmentGroups.get(2), 1, 0, "ECHOCARDIOGRAPHIC REPORT2");
-    validateEachGroup(hl7DTE, segmentGroups.get(3), 1, 0,
-        "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3");
-
-    validateEachGroup(hl7DTE, segmentGroups.get(4), 1, 0, "ECHOCARDIOGRAPHIC REPORT new group");
-    List<String> sameGroup =
-        Lists.newArrayList(segmentGroups.get(0).getGroupId(), segmentGroups.get(1).getGroupId(),
-            segmentGroups.get(2).getGroupId(), segmentGroups.get(3).getGroupId());
-    assertThat(sameGroup).containsOnly(segmentGroups.get(0).getGroupId());
-    assertThat(segmentGroups.get(4).getGroupId()).isNotEqualTo(segmentGroups.get(0).getGroupId());
-  }
-
-
-  @Test
-  public void test_repeating_primary_segment_with_repeating_parent_group()
-      throws HL7Exception {
-    String message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
-                  + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
-                  + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|112^Final Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3068^JOHN^Paul^J|\r"
-                  + "OBX|1|ST|TS-F-01-007^Endocrine Disorders 7^L||obs report||||||F\r"
-                  + "OBX|2|ST|TS-F-01-008^Endocrine Disorders 8^L||ECHOCARDIOGRAPHIC REPORT||||||F\r"
-                  + "OBR|1||98^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|113^Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
-                  + "OBX|1|CWE|625-4^Bacteria identified in Stool by Culture^LN^^^^2.33^^result1|1|27268008^Salmonella^SCT^^^^20090731^^Salmonella species|||A^A^HL70078^^^^2.5|||P|||20120301|||^^^^^^^^Bacterial Culture||201203140957||||||\r"
-                  + "OBX|2|ST|TS-F-01-002^Endocrine Disorders^L||ECHOCARDIOGRAPHIC REPORT Group 2||||||F\r";
-  
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<String> orderGroupList = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION");
-    List<String> observationGroupList = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION", "OBSERVATION");
-    List<String> specimenGroupList = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION", "SPECIMEN");
-    List<HL7Segment> additionalSegments = Lists.newArrayList(
-        new HL7Segment(orderGroupList, "OBR", true), 
-        new HL7Segment(observationGroupList, "NTE", true),
-        new HL7Segment(specimenGroupList, "SPM", true) ,
-        new HL7Segment(orderGroupList, "MSH", false));
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(observationGroupList,
-        "OBX", additionalSegments, hl7DTE,
-        Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION"));
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(4);
-
-    List<String> firstGroupIds = Lists.newArrayList(segmentGroups.get(0).getGroupId(), segmentGroups.get(1).getGroupId());
-    List<String> secondGroupIds = Lists.newArrayList(segmentGroups.get(2).getGroupId(), segmentGroups.get(3).getGroupId());
-    // The first two OBX should have the same group ID
-    assertThat(firstGroupIds).containsOnly(firstGroupIds.get(0));
-    // The second two OBX should have the same group ID
-    assertThat(secondGroupIds).containsOnly(secondGroupIds.get(0));
-    // The parent should be the ORDER_OBSERVATION group
-    assertThat(firstGroupIds.get(0)).contains("ORDER_OBSERVATION");
-    assertThat(secondGroupIds.get(0)).contains("ORDER_OBSERVATION");
-    // The first group of OBX should have a different ID than the second group of OBX.
-    assertThat(firstGroupIds.get(0)).isNotEqualTo(secondGroupIds.get(0));
-  }
-
-  // Test for extracting segments outside of group
-
-  @Test
-  public void test_get_segments() throws HL7Exception {
-
-
-    Message hl7message = getMessage(hl7ADTmessage);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups =
-        SegmentExtractorUtil.extractSegmentNonGroups("OBX", new ArrayList<>(), hl7DTE);
-    assertThat(segmentGroups).isNotEmpty();
-    assertThat(segmentGroups).hasSize(1);
-    assertThat(segmentGroups.get(0).getSegments()).hasSize(2);
-
-    Segment s = (Segment) segmentGroups.get(0).getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
-        .isEqualTo(ECHOCARDIOGRAPHIC_REPORT);
-    assertThat(segmentGroups.get(0).getAdditionalSegments()).isEmpty();
-
-
-    s = (Segment) segmentGroups.get(0).getSegments().get(1);
-    type = hl7DTE.getType(s, 5, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
-        .isEqualTo(NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
-
-  }
-
-  @Test
-  public void test_single_segment() throws HL7Exception {
-
-
-    Message hl7message = getMessage(hl7ADTmessage);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    SegmentGroup segmentGroup =
-        SegmentExtractorUtil.extractSegmentNonGroups("OBX", new ArrayList<>(), hl7DTE).get(0);
-    assertThat(segmentGroup).isNotNull();
-    Segment s = (Segment) segmentGroup.getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
-        .isEqualTo(ECHOCARDIOGRAPHIC_REPORT);
-    assertThat(segmentGroup.getAdditionalSegments()).isEmpty();
-
-
-
-  }
-
-
-
-  @Test
-  public void test_single_segment_with_additional_segment() throws HL7Exception {
-
-
-    Message hl7message = getMessage(hl7ADTmessage);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    SegmentGroup segmentGroup = SegmentExtractorUtil
-        .extractSegmentNonGroups("OBX", Lists.newArrayList(new HL7Segment("PV1")), hl7DTE).get(0);
-    assertThat(segmentGroup).isNotNull();
-    Segment s = (Segment) segmentGroup.getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
-        .isEqualTo(ECHOCARDIOGRAPHIC_REPORT);
-    assertThat(segmentGroup.getAdditionalSegments()).hasSize(1);
-
-    Segment pv1 = (Segment) segmentGroup.getAdditionalSegments().get("PV1").get(0);
-    assertThat(pv1.isEmpty()).isFalse();
-    assertThat(pv1.getName()).isEqualTo("PV1");
-
-
-
-  }
-
-
-  @Test
-  public void test_child_segment_with_additional_parent_segment() throws HL7Exception {
-    String message =
-        "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
-            + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
-            + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|112^Final Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
-            + "OBX|1|TX|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
-            + "OBX|2|TX|GA-F-01-024^Galactosemia^L||ECHOCARDIOGRAPHIC REPORT||||||F\r";
-
-    List<String> ORDER_GROUP_LIST =
-        Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION", "OBSERVATION");
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
-        "OBX",
-        Lists.newArrayList(
-            new HL7Segment(Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION"), "OBR", true)),
-        hl7DTE,
-        Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION"));
-
-    assertThat(segmentGroups).isNotNull();
-    assertThat(segmentGroups).hasSize(2);
-
-    Segment obr = (Segment) segmentGroups.get(0).getAdditionalSegments().get("OBR").get(0);
-    assertThat(obr.isEmpty()).isFalse();
-    assertThat(obr.getName()).isEqualTo("OBR");
-
-  }
-
-
-
-  @Test
-  public void test_VUX_no_rep() throws HL7Exception {
-    String hl7VUXmessageNoRep =
-        "MSH|^~\\&|ImmunizationGenerator^1.4|^2|||20121217134645||VXU^V04^VXU_V04|64443|P^|2.5.1^^^^^^^^^^^^|||ER||||\r"
-            + "PID|||1234^^^^PI^||HASBRO^ANDY^JOHN^^^^L^|SLINKY^FUN^^^^^L^|20010606|M|||1564 MONROE^^BROOKLYN^HI^56808^^^^^^|||||||||||||||||||\r"
-            + "PD1|||||||||||01|N||||A\r"
-            + "NK1|1|HASBRO^ANDY^JOHN^^^^L^|SEL^SELF^HL70063^^^|1564 MONROE^^BROOKLYN^HI^13808^^^^^^|||||||||||||||||||||||||||||||||\r"
-            + "IN1|1|G54321^Insurance plan^072|47055^^^NAIC^NIIP|||||||||20120101|20121231|||||||||||||||||||||||POL55555|\r"
-            + "ORC|RE||2^DCS|||||||||||||||||||||||||R\r"
-            + "RXA|0|1|20130124|20130124|10^Polio-Inject^CVX^90713^Polio-Inject^CPT|1.0|||00||||||12345||PMC\r"
-            + "RXR|IM\r"
-            + "OBX|1|CE|30945-0^Contraindication^LN||21^acute illness^NIP^^^|||||||F| \r";
-    ArrayList<String> ORDER_GROUP_VUX = Lists.newArrayList("ORDER");
-    ArrayList<String> OBSERVATION_GROUP_VUX = Lists.newArrayList("ORDER", "OBSERVATION");
-    Message hl7message = getMessage(hl7VUXmessageNoRep);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_VUX,
-        "RXA", Lists.newArrayList(new HL7Segment(OBSERVATION_GROUP_VUX, "OBX", true)), hl7DTE,
-        ORDER_GROUP_VUX);
-    SegmentGroup segmentGroup = segmentGroups.get(0);
-    assertThat(segmentGroup).isNotNull();
-    Segment s = (Segment) segmentGroup.getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 4, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo("20130124");
-    assertThat(segmentGroup.getAdditionalSegments()).hasSize(1);
-    Segment obx = (Segment) segmentGroup.getAdditionalSegments().get("OBX").get(0);
-
-    ParsingResult<Type> obx3 = hl7DTE.getType(obx, 3, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(obx3.getValue())).isEqualTo("30945-0");
-
-
-
-  }
-
-
-
-  @Test
-  public void test_VUX_rep() throws HL7Exception {
-    String hl7VUXmessageRep =
-        "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
-            + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
-            + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
-            + "ORC|RE||197023|||||||^Clerk^Myron|||||||RI2050\r"
-            + "RXA|0|1|20130415|20130415|31^Hep B Peds NOS^CVX|999|||01^historical record^NIP001||||||||\r"
-            + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
-            + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
-            + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
-            + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
-            + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
-            + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
-            + "OBX|4|TS|29769-7^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r";
-    Message hl7message = getMessage(hl7VUXmessageRep);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-    ArrayList<String> ORDER_GROUP_VUX = Lists.newArrayList("ORDER");
-    ArrayList<String> OBSERVATION_GROUP_VUX = Lists.newArrayList("ORDER", "OBSERVATION");
-    List<SegmentGroup> segmentGroups =
-        SegmentExtractorUtil
-            .extractSegmentGroups(ORDER_GROUP_VUX, "RXA",
-                Lists.newArrayList(new HL7Segment(OBSERVATION_GROUP_VUX, "OBX", true),
-                    new HL7Segment(ORDER_GROUP_VUX, "RXR", true)),
-                hl7DTE, Lists.newArrayList("ORDER"));
-    assertThat(segmentGroups).hasSize(2);
-    SegmentGroup segmentGroup1 = segmentGroups.get(0);
-    assertThat(segmentGroup1).isNotNull();
-    Segment s = (Segment) segmentGroup1.getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 4, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo("20130415");
-    assertThat(segmentGroup1.getAdditionalSegments()).isEmpty();
-
-
-
-    SegmentGroup segmentGroup2 = segmentGroups.get(1);
-
-    assertThat(segmentGroup2).isNotNull();
-    Segment s2 = (Segment) segmentGroup2.getSegments().get(0);
-    ParsingResult<Type> type2 = hl7DTE.getType(s2, 4, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type2.getValue())).isEqualTo("20130531");
-    assertThat(segmentGroup2.getAdditionalSegments()).hasSize(2);
-    List<Structure> obxs = segmentGroup2.getAdditionalSegments().get("OBX");
-    assertThat(obxs).hasSize(4);
-
-    ParsingResult<Type> obx3 = hl7DTE.getType((Segment) obxs.get(0), 3, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(obx3.getValue())).isEqualTo("64994-7");
-
-    Segment rxr = (Segment) segmentGroup2.getAdditionalSegments().get("RXR").get(0);
-
-    ParsingResult<Type> rxr1 = hl7DTE.getType(rxr, 1, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(rxr1.getValue())).isEqualTo("C28161");
-
-
-
-  }
-
-
-
-  private static void validateEachGroupAdditionalSegment(HL7DataExtractor hl7DTE,
-      SegmentGroup segmentGroup, int noOfSegments, int noOfAddSegments, String matchValue,
-      String additionalSegmentName) throws HL7Exception {
-    assertThat(segmentGroup.getSegments()).hasSize(noOfSegments);
-    assertThat(segmentGroup.getSegments().get(0).isEmpty()).isFalse();
-    Segment s = (Segment) segmentGroup.getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo(matchValue);
-    assertThat(segmentGroup.getAdditionalSegments()).hasSize(noOfAddSegments);
-
-    Segment pv1 = (Segment) segmentGroup.getAdditionalSegments().get(additionalSegmentName).get(0);
-    assertThat(pv1.isEmpty()).isFalse();
-    assertThat(pv1.getName()).isEqualTo(additionalSegmentName);
-  }
-
-
-
-  private static void validateEachGroup(HL7DataExtractor hl7DTE, SegmentGroup segmentGroup,
-      int noOfSegments, int noOfAddSegments, String matchValue) throws HL7Exception {
-    assertThat(segmentGroup.getSegments()).hasSize(noOfSegments);
-    assertThat(segmentGroup.getSegments().get(0).isEmpty()).isFalse();
-    Segment s = (Segment) segmentGroup.getSegments().get(0);
-    ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
-    assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo(matchValue);
-    assertThat(segmentGroup.getAdditionalSegments()).hasSize(noOfAddSegments);
-  }
-
-
-  private static Message getMessage(String message) {
-    HL7HapiParser hparser = null;
-
-    try {
-      hparser = new HL7HapiParser();
-      return hparser.getParser().parse(message);
-    } catch (HL7Exception e) {
-      throw new IllegalArgumentException(e);
-    } finally {
-      if (hparser != null) {
-        try {
-          hparser.getContext().close();
-        } catch (IOException e) {
-          throw new IllegalStateException(e);
-        }
-      }
+    private static final String NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH = "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH";
+
+    private static final ArrayList<String> ORDER_GROUP_LIST = Lists.newArrayList("PROBLEM", "ORDER", "ORDER_DETAIL",
+            "ORDER_OBSERVATION");
+    private static final ArrayList<String> PROBLEM_GROUP_LIST = Lists.newArrayList("PROBLEM", "PROBLEM_OBSERVATION");
+
+    private static final String ECHOCARDIOGRAPHIC_REPORT = "ECHOCARDIOGRAPHIC REPORT";
+
+    private String messageSingleOrderGroup = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+            + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
+            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
+            + "OBR|1|CD150920001336|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r";
+
+    private String messageSingleProblemGroup = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+            + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r";
+
+    private String messageRepeat = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
+            + "OBR|1|CD150920001336|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+            + "NTE|1|P|Problem Comments11\r" + "VAR|varid1|200603150610\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r"
+            + "NTE|2|P|Problem Comments22\r" + "VAR|varid1|200603150610\r"
+            + "ORC|NW|1001^OE|9999999^RX|||E|^Q6He^D10^^^R\r"
+            + "OBR|1|CD150920001337|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT2||||||F|||20150930164100|||\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3||||||F|||20150930164100|||";
+
+    private String messageRepeatMultiplePRB = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r"
+            + "ORC|NW|1000^OE|9999999^RX|||E|^Q6H^D10^^^R\r"
+            + "OBR|1|CD150920001336|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+            + "NTE|1|P|Problem Comments11\r" + "VAR|varid1|200603150610\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r"
+            + "NTE|2|P|Problem Comments22\r" + "VAR|varid1|200603150610\r"
+            + "ORC|NW|1001^OE|9999999^RX|||E|^Q6He^D10^^^R\r"
+            + "OBR|1|CD150920001337|CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT2||||||F|||20150930164100|||\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3||||||F|||20150930164100|||\r"
+            + "PRB|CE|20060315076|lung  new issue|53693||2||200603150625\r"
+            + "ORC|NW|1009^OE|9999998^RX|||E|^Q6H^D10^^^R\r"
+            + "OBR|1|CD150920001337|CD150920001337|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT new group||||||F|||20150930164100|||\r";
+
+    String hl7ADTmessage = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ADT^A08^ADT_A08|1|P^I|2.6||||||ASCII||\r"
+            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+            + "NTE|1|P|Problem Comments\r" + "VAR|varid1|200603150610\r"
+            + "OBX|1|TX|||ECHOCARDIOGRAPHIC REPORT||||||F|||20150930164100|||\r"
+            + "OBX|2|TX|||NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH||||||F|||20150930164100|||\r";
+
+    // Tests for extracting segment from group
+    @Test
+    public void test_single_order_group() throws HL7Exception {
+
+        Message hl7message = getMessage(messageSingleOrderGroup);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
+        assertThat(segmentGroups).isNotEmpty().hasSize(2);
+        validateEachGroup(hl7DTE, segmentGroups.get(0), 1, 0, ECHOCARDIOGRAPHIC_REPORT);
+        validateEachGroup(hl7DTE, segmentGroups.get(1), 1, 0,
+                NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
     }
 
-  }
+    @Test
+    public void test_single_problem_group_wrong_group_list_provided() throws HL7Exception {
+
+        Message hl7message = getMessage(messageSingleProblemGroup);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
+        assertThat(segmentGroups).isEmpty();
+
+    }
+
+    @Test
+    public void test_single_problem_group() throws HL7Exception {
+
+        Message hl7message = getMessage(messageSingleProblemGroup);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(PROBLEM_GROUP_LIST,
+                "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
+        assertThat(segmentGroups).isNotEmpty().hasSize(2);
+        validateEachGroup(hl7DTE, segmentGroups.get(0), 1, 0, ECHOCARDIOGRAPHIC_REPORT);
+        validateEachGroup(hl7DTE, segmentGroups.get(1), 1, 0,
+                NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
+    }
+
+    @Test
+    public void test_parent_repeat() throws HL7Exception {
+        Message hl7message = getMessage(messageRepeat);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX", Lists.newArrayList(), hl7DTE, Lists.newArrayList());
+        assertThat(segmentGroups).isNotEmpty().hasSize(4);
+
+        validateEachGroup(hl7DTE, segmentGroups.get(0), 1, 0, ECHOCARDIOGRAPHIC_REPORT);
+        validateEachGroup(hl7DTE, segmentGroups.get(1), 1, 0,
+                NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
+        validateEachGroup(hl7DTE, segmentGroups.get(2), 1, 0, "ECHOCARDIOGRAPHIC REPORT2");
+        validateEachGroup(hl7DTE, segmentGroups.get(3), 1, 0,
+                "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3");
+    }
+
+    @Test
+    public void test_parent_repeat_additional_segment_under_parent() throws HL7Exception {
+        Message hl7message = getMessage(messageRepeat);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX", Lists.newArrayList(new HL7Segment("PID")), hl7DTE, Lists.newArrayList());
+        assertThat(segmentGroups).isNotEmpty().hasSize(4);
+
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(0), 1, 1, ECHOCARDIOGRAPHIC_REPORT,
+                "PID");
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(1), 1, 1,
+                NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH, "PID");
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(2), 1, 1,
+                "ECHOCARDIOGRAPHIC REPORT2", "PID");
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(3), 1, 1,
+                "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3", "PID");
+
+    }
+
+    @Test
+    public void test_parent_repeat_additional_segment_under_group() throws HL7Exception {
+        Message hl7message = getMessage(messageRepeat);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX", Lists.newArrayList(new HL7Segment(ORDER_GROUP_LIST, "NTE", true)), hl7DTE,
+                Lists.newArrayList());
+        assertThat(segmentGroups).isNotEmpty().hasSize(4);
+
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(0), 1, 1, ECHOCARDIOGRAPHIC_REPORT,
+                "NTE");
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(1), 1, 1,
+                NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH, "NTE");
+        validateEachGroup(hl7DTE, segmentGroups.get(2), 1, 0, "ECHOCARDIOGRAPHIC REPORT2");
+        validateEachGroup(hl7DTE, segmentGroups.get(3), 1, 0,
+                "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3");
+
+    }
+
+    @Test
+    public void test_parent_repeat_additional_segment_under_group_with_group_name()
+            throws HL7Exception {
+        Message hl7message = getMessage(messageRepeatMultiplePRB);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX", Lists.newArrayList(new HL7Segment(ORDER_GROUP_LIST, "NTE", true)), hl7DTE,
+                Lists.newArrayList("PROBLEM"));
+        assertThat(segmentGroups).isNotEmpty().hasSize(5);
+
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(0), 1, 1, ECHOCARDIOGRAPHIC_REPORT,
+                "NTE");
+        validateEachGroupAdditionalSegment(hl7DTE, segmentGroups.get(1), 1, 1,
+                NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH, "NTE");
+        validateEachGroup(hl7DTE, segmentGroups.get(2), 1, 0, "ECHOCARDIOGRAPHIC REPORT2");
+        validateEachGroup(hl7DTE, segmentGroups.get(3), 1, 0,
+                "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH 3");
+
+        validateEachGroup(hl7DTE, segmentGroups.get(4), 1, 0, "ECHOCARDIOGRAPHIC REPORT new group");
+        List<String> sameGroup = Lists.newArrayList(segmentGroups.get(0).getGroupId(),
+                segmentGroups.get(1).getGroupId(),
+                segmentGroups.get(2).getGroupId(), segmentGroups.get(3).getGroupId());
+        assertThat(sameGroup).containsOnly(segmentGroups.get(0).getGroupId());
+        assertThat(segmentGroups.get(4).getGroupId()).isNotEqualTo(segmentGroups.get(0).getGroupId());
+    }
+
+    @Test
+    public void test_repeating_primary_segment_with_repeating_parent_group()
+            throws HL7Exception {
+        String message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
+                + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
+                + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|112^Final Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3068^JOHN^Paul^J|\r"
+                + "OBX|1|ST|TS-F-01-007^Endocrine Disorders 7^L||obs report||||||F\r"
+                + "OBX|2|ST|TS-F-01-008^Endocrine Disorders 8^L||ECHOCARDIOGRAPHIC REPORT||||||F\r"
+                + "OBR|1||98^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|113^Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
+                + "OBX|1|CWE|625-4^Bacteria identified in Stool by Culture^LN^^^^2.33^^result1|1|27268008^Salmonella^SCT^^^^20090731^^Salmonella species|||A^A^HL70078^^^^2.5|||P|||20120301|||^^^^^^^^Bacterial Culture||201203140957||||||\r"
+                + "OBX|2|ST|TS-F-01-002^Endocrine Disorders^L||ECHOCARDIOGRAPHIC REPORT Group 2||||||F\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<String> orderGroupList = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION");
+        List<String> observationGroupList = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION", "OBSERVATION");
+        List<String> specimenGroupList = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION", "SPECIMEN");
+        List<HL7Segment> additionalSegments = Lists.newArrayList(
+                new HL7Segment(orderGroupList, "OBR", true),
+                new HL7Segment(observationGroupList, "NTE", true),
+                new HL7Segment(specimenGroupList, "SPM", true),
+                new HL7Segment(orderGroupList, "MSH", false));
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(observationGroupList,
+                "OBX", additionalSegments, hl7DTE,
+                Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION"));
+        assertThat(segmentGroups).isNotEmpty().hasSize(4);
+
+        List<String> firstGroupIds = Lists.newArrayList(segmentGroups.get(0).getGroupId(),
+                segmentGroups.get(1).getGroupId());
+        List<String> secondGroupIds = Lists.newArrayList(segmentGroups.get(2).getGroupId(),
+                segmentGroups.get(3).getGroupId());
+        // The first two OBX should have the same group ID
+        assertThat(firstGroupIds).containsOnly(firstGroupIds.get(0));
+        // The second two OBX should have the same group ID
+        assertThat(secondGroupIds).containsOnly(secondGroupIds.get(0));
+        // The parent should be the ORDER_OBSERVATION group
+        assertThat(firstGroupIds.get(0)).contains("ORDER_OBSERVATION");
+        assertThat(secondGroupIds.get(0)).contains("ORDER_OBSERVATION");
+        // The first group of OBX should have a different ID than the second group of OBX.
+        assertThat(firstGroupIds.get(0)).isNotEqualTo(secondGroupIds.get(0));
+    }
+
+    // Test for extracting segments outside of group
+
+    @Test
+    public void test_get_segments() throws HL7Exception {
+
+        Message hl7message = getMessage(hl7ADTmessage);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentNonGroups("OBX", new ArrayList<>(),
+                hl7DTE);
+        assertThat(segmentGroups).isNotEmpty().hasSize(1);
+        assertThat(segmentGroups.get(0).getSegments()).hasSize(2);
+
+        Segment s = (Segment) segmentGroups.get(0).getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
+                .isEqualTo(ECHOCARDIOGRAPHIC_REPORT);
+        assertThat(segmentGroups.get(0).getAdditionalSegments()).isEmpty();
+
+        s = (Segment) segmentGroups.get(0).getSegments().get(1);
+        type = hl7DTE.getType(s, 5, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
+                .isEqualTo(NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH);
+
+    }
+
+    @Test
+    public void test_single_segment() throws HL7Exception {
+
+        Message hl7message = getMessage(hl7ADTmessage);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        SegmentGroup segmentGroup = SegmentExtractorUtil.extractSegmentNonGroups("OBX", new ArrayList<>(), hl7DTE)
+                .get(0);
+        assertThat(segmentGroup).isNotNull();
+        Segment s = (Segment) segmentGroup.getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
+                .isEqualTo(ECHOCARDIOGRAPHIC_REPORT);
+        assertThat(segmentGroup.getAdditionalSegments()).isEmpty();
+
+    }
+
+    @Test
+    public void test_single_segment_with_additional_segment() throws HL7Exception {
+
+        Message hl7message = getMessage(hl7ADTmessage);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        SegmentGroup segmentGroup = SegmentExtractorUtil
+                .extractSegmentNonGroups("OBX", Lists.newArrayList(new HL7Segment("PV1")), hl7DTE).get(0);
+        assertThat(segmentGroup).isNotNull();
+        Segment s = (Segment) segmentGroup.getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue()))
+                .isEqualTo(ECHOCARDIOGRAPHIC_REPORT);
+        assertThat(segmentGroup.getAdditionalSegments()).hasSize(1);
+
+        Segment pv1 = (Segment) segmentGroup.getAdditionalSegments().get("PV1").get(0);
+        assertThat(pv1.isEmpty()).isFalse();
+        assertThat(pv1.getName()).isEqualTo("PV1");
+
+    }
+
+    @Test
+    public void test_child_segment_with_additional_parent_segment() throws HL7Exception {
+        String message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
+                + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
+                + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|112^Final Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
+                + "OBX|1|TX|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
+                + "OBX|2|TX|GA-F-01-024^Galactosemia^L||ECHOCARDIOGRAPHIC REPORT||||||F\r";
+
+        List<String> ORDER_GROUP_LIST = Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION", "OBSERVATION");
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
+                "OBX",
+                Lists.newArrayList(
+                        new HL7Segment(Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION"), "OBR", true)),
+                hl7DTE,
+                Lists.newArrayList("PATIENT_RESULT", "ORDER_OBSERVATION"));
+
+        assertThat(segmentGroups).isNotNull();
+        assertThat(segmentGroups).hasSize(2);
+
+        Segment obr = (Segment) segmentGroups.get(0).getAdditionalSegments().get("OBR").get(0);
+        assertThat(obr.isEmpty()).isFalse();
+        assertThat(obr.getName()).isEqualTo("OBR");
+
+    }
+
+    @Test
+    public void test_VUX_no_rep() throws HL7Exception {
+        String hl7VUXmessageNoRep = "MSH|^~\\&|ImmunizationGenerator^1.4|^2|||20121217134645||VXU^V04^VXU_V04|64443|P^|2.5.1^^^^^^^^^^^^|||ER||||\r"
+                + "PID|||1234^^^^PI^||HASBRO^ANDY^JOHN^^^^L^|SLINKY^FUN^^^^^L^|20010606|M|||1564 MONROE^^BROOKLYN^HI^56808^^^^^^|||||||||||||||||||\r"
+                + "PD1|||||||||||01|N||||A\r"
+                + "NK1|1|HASBRO^ANDY^JOHN^^^^L^|SEL^SELF^HL70063^^^|1564 MONROE^^BROOKLYN^HI^13808^^^^^^|||||||||||||||||||||||||||||||||\r"
+                + "IN1|1|G54321^Insurance plan^072|47055^^^NAIC^NIIP|||||||||20120101|20121231|||||||||||||||||||||||POL55555|\r"
+                + "ORC|RE||2^DCS|||||||||||||||||||||||||R\r"
+                + "RXA|0|1|20130124|20130124|10^Polio-Inject^CVX^90713^Polio-Inject^CPT|1.0|||00||||||12345||PMC\r"
+                + "RXR|IM\r"
+                + "OBX|1|CE|30945-0^Contraindication^LN||21^acute illness^NIP^^^|||||||F| \r";
+        ArrayList<String> ORDER_GROUP_VUX = Lists.newArrayList("ORDER");
+        ArrayList<String> OBSERVATION_GROUP_VUX = Lists.newArrayList("ORDER", "OBSERVATION");
+        Message hl7message = getMessage(hl7VUXmessageNoRep);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_VUX,
+                "RXA", Lists.newArrayList(new HL7Segment(OBSERVATION_GROUP_VUX, "OBX", true)), hl7DTE,
+                ORDER_GROUP_VUX);
+        SegmentGroup segmentGroup = segmentGroups.get(0);
+        assertThat(segmentGroup).isNotNull();
+        Segment s = (Segment) segmentGroup.getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 4, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo("20130124");
+        assertThat(segmentGroup.getAdditionalSegments()).hasSize(1);
+        Segment obx = (Segment) segmentGroup.getAdditionalSegments().get("OBX").get(0);
+
+        ParsingResult<Type> obx3 = hl7DTE.getType(obx, 3, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(obx3.getValue())).isEqualTo("30945-0");
+
+    }
+
+    @Test
+    public void test_VUX_rep() throws HL7Exception {
+        String hl7VUXmessageRep = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
+                + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
+                + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
+                + "ORC|RE||197023|||||||^Clerk^Myron|||||||RI2050\r"
+                + "RXA|0|1|20130415|20130415|31^Hep B Peds NOS^CVX|999|||01^historical record^NIP001||||||||\r"
+                + "ORC|RE||197027|||||||^Clerk^Myron||MD67895^Pediatric^MARY^^^^MD^^RIA|||||RI2050\r"
+                + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|||CP|A\r"
+                + "RXR|C28161^IM^NCIT^IM^INTRAMUSCULAR^HL70162|RT^right thigh^HL70163\r"
+                + "OBX|1|CE|64994-7^vaccine fund pgm elig cat^LN|1|V02^VFC eligible Medicaid/MedicaidManaged Care^HL70064||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r"
+                + "OBX|2|CE|30956-7^Vaccine Type^LN|2|48^HIB PRP-T^CVX||||||F|||20130531\r"
+                + "OBX|3|TS|29768-9^VIS Publication Date^LN|2|19981216||||||F|||20130531\r"
+                + "OBX|4|TS|29769-7^VIS Presentation Date^LN|2|20130531||||||F|||20130531\r";
+        Message hl7message = getMessage(hl7VUXmessageRep);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+        ArrayList<String> ORDER_GROUP_VUX = Lists.newArrayList("ORDER");
+        ArrayList<String> OBSERVATION_GROUP_VUX = Lists.newArrayList("ORDER", "OBSERVATION");
+        List<SegmentGroup> segmentGroups = SegmentExtractorUtil
+                .extractSegmentGroups(ORDER_GROUP_VUX, "RXA",
+                        Lists.newArrayList(new HL7Segment(OBSERVATION_GROUP_VUX, "OBX", true),
+                                new HL7Segment(ORDER_GROUP_VUX, "RXR", true)),
+                        hl7DTE, Lists.newArrayList("ORDER"));
+        assertThat(segmentGroups).hasSize(2);
+        SegmentGroup segmentGroup1 = segmentGroups.get(0);
+        assertThat(segmentGroup1).isNotNull();
+        Segment s = (Segment) segmentGroup1.getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 4, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo("20130415");
+        assertThat(segmentGroup1.getAdditionalSegments()).isEmpty();
+
+        SegmentGroup segmentGroup2 = segmentGroups.get(1);
+
+        assertThat(segmentGroup2).isNotNull();
+        Segment s2 = (Segment) segmentGroup2.getSegments().get(0);
+        ParsingResult<Type> type2 = hl7DTE.getType(s2, 4, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type2.getValue())).isEqualTo("20130531");
+        assertThat(segmentGroup2.getAdditionalSegments()).hasSize(2);
+        List<Structure> obxs = segmentGroup2.getAdditionalSegments().get("OBX");
+        assertThat(obxs).hasSize(4);
+
+        ParsingResult<Type> obx3 = hl7DTE.getType((Segment) obxs.get(0), 3, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(obx3.getValue())).isEqualTo("64994-7");
+
+        Segment rxr = (Segment) segmentGroup2.getAdditionalSegments().get("RXR").get(0);
+
+        ParsingResult<Type> rxr1 = hl7DTE.getType(rxr, 1, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(rxr1.getValue())).isEqualTo("C28161");
+
+    }
+
+    private static void validateEachGroupAdditionalSegment(HL7DataExtractor hl7DTE,
+            SegmentGroup segmentGroup, int noOfSegments, int noOfAddSegments, String matchValue,
+            String additionalSegmentName) throws HL7Exception {
+        assertThat(segmentGroup.getSegments()).hasSize(noOfSegments);
+        assertThat(segmentGroup.getSegments().get(0).isEmpty()).isFalse();
+        Segment s = (Segment) segmentGroup.getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo(matchValue);
+        assertThat(segmentGroup.getAdditionalSegments()).hasSize(noOfAddSegments);
+
+        Segment pv1 = (Segment) segmentGroup.getAdditionalSegments().get(additionalSegmentName).get(0);
+        assertThat(pv1.isEmpty()).isFalse();
+        assertThat(pv1.getName()).isEqualTo(additionalSegmentName);
+    }
+
+    private static void validateEachGroup(HL7DataExtractor hl7DTE, SegmentGroup segmentGroup,
+            int noOfSegments, int noOfAddSegments, String matchValue) throws HL7Exception {
+        assertThat(segmentGroup.getSegments()).hasSize(noOfSegments);
+        assertThat(segmentGroup.getSegments().get(0).isEmpty()).isFalse();
+        Segment s = (Segment) segmentGroup.getSegments().get(0);
+        ParsingResult<Type> type = hl7DTE.getType(s, 5, 0);
+        assertThat(Hl7DataHandlerUtil.getStringValue(type.getValue())).isEqualTo(matchValue);
+        assertThat(segmentGroup.getAdditionalSegments()).hasSize(noOfAddSegments);
+    }
+
+    private static Message getMessage(String message) {
+        HL7HapiParser hparser = null;
+
+        try {
+            hparser = new HL7HapiParser();
+            return hparser.getParser().parse(message);
+        } catch (HL7Exception e) {
+            throw new IllegalArgumentException(e);
+        } finally {
+            if (hparser != null) {
+                try {
+                    hparser.getContext().close();
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
@@ -351,8 +351,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    @Disabled
-    // TODO: TXA-13 is not yet mapped in DocumentReference.yml
+    @Disabled("TODO: TXA-13 is not yet mapped in DocumentReference.yml")
     public void doc_ref_relates_to_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
@@ -490,7 +489,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
         DocumentReference documentReference = (DocumentReference) context.getParser().parseResource(klass, s);
 
         assertThat(documentReference.hasSubject()).isTrue();
-        assertThat(documentReference.getSubject().getReference().startsWith("Patient"));
+        assertThat(documentReference.getSubject().getReference()).startsWith("Patient");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
1. Change to javadoc not to create index (which in some instances was bringing jszip)
2. Fixes for variety of sonarqube code smells