### PR TITLE
#363 validate current behavior of mult CWEs

### DIFF
--- a/src/test/java/io/github/linuxforhealth/hl7/segments/CodeableConceptTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/CodeableConceptTest.java
@@ -20,20 +20,14 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.github.linuxforhealth.core.terminology.UrlLookup;
-import io.github.linuxforhealth.hl7.ConverterOptions;
-import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 class CodeableConceptTest {
     private static final String V3_RACE_SYSTEM = "http://terminology.hl7.org/CodeSystem/v3-Race";
-    private static final ConverterOptions OPTIONS = new Builder().withPrettyPrint().build();
-    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PatientFHIRConversionTest.class);
 
     // These test cover all the paths to create codeableConcepts from CWEs.
     // 
@@ -448,7 +442,6 @@ class CodeableConceptTest {
 
         String hl7message = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                //   + "PV1|1|E|||||||||||||||||||||||||||||||||||||||||||\n"
                 //  ORC.16 key for this test.  It sets a reason code: two codes with two codings each.  See other comments.
                 + "ORC|RE|248648498^|248648498^|ML18267-C00001^Beaker|SC||||||||||20170917151717|042^Human immunodeficiency virus [HIV] disease [42]^I9CDX^HIV^HIV/Aids^L~012^Other respiratory tuberculosis^I9CDX^017^Tuberculosis of other organs^I9CDX|||||||||||||||\n"
                 //  NOTE: OBR.31 is omitted purposely so the ORC.16 is used for the reason code

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
@@ -106,10 +106,10 @@ public class Hl7OrderRequestFHIRConversionTest {
     // ORC.16 should create a ServiceRequest.reasonCode CWE
     assertThat(serviceRequest.hasReasonCode()).isTrue();
     assertThat(serviceRequest.getReasonCode()).hasSize(1);
-    DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getReasonCodeFirstRep(), "042",
+    DatatypeUtils.checkCommonCodeableConceptVersionedAssertions(serviceRequest.getReasonCodeFirstRep(), "042",
         "Human immunodeficiency virus [HIV] disease [42]",
         "http://terminology.hl7.org/CodeSystem/ICD-9CM-diagnosiscodes",
-        "Human immunodeficiency virus [HIV] disease [42]");
+        "Human immunodeficiency virus [HIV] disease [42]", "29");
 
     // ORC.12 should create an ServiceRequest.requester reference & display
     assertThat(serviceRequest.hasRequester()).isTrue();
@@ -214,8 +214,8 @@ public class Hl7OrderRequestFHIRConversionTest {
     // OBR.31 should create the ServiceRequest.reasonCode CWE
     assertThat(serviceRequest.hasReasonCode()).isTrue();
     assertThat(serviceRequest.getReasonCode()).hasSize(1);
-    DatatypeUtils.checkCommonCodeableConceptAssertions(serviceRequest.getReasonCodeFirstRep(), "HIV", "HIV/Aids",
-        "urn:id:L", "HIV/Aids");
+    DatatypeUtils.checkCommonCodeableConceptVersionedAssertions(serviceRequest.getReasonCodeFirstRep(), "HIV", "HIV/Aids",
+        "urn:id:L", "HIV/Aids", "V1");
 
     // OBR.16 should create an ServiceRequest.requester reference & display
     assertThat(serviceRequest.hasRequester()).isTrue();

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/DatatypeUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/DatatypeUtils.java
@@ -29,24 +29,40 @@ public class DatatypeUtils {
             assertThat(cc.hasCoding()).isTrue();
             assertThat(cc.getCoding().size()).isEqualTo(1);
             Coding coding = cc.getCoding().get(0);
-            if (code == null) {
-                assertThat(coding.hasCode()).isFalse();
-            } else {
-                assertThat(coding.hasCode()).isTrue();
-                assertThat(coding.getCode()).isEqualTo(code);
-            }
-            if (display == null) {
-                assertThat(coding.hasDisplay()).isFalse();
-            } else {
-                assertThat(coding.hasDisplay()).isTrue();
-                assertThat(coding.getDisplay()).isEqualTo(display);
-            }
-            if (system == null) {
-                assertThat(coding.hasSystem()).isFalse();
-            } else {
-                assertThat(coding.hasSystem()).isTrue();
-                assertThat(coding.getSystem()).isEqualTo(system);
-            }
+            checkCommonCodingAssertions(coding, code, display, system, null);
         }
+    }
+
+    // Checks a single coding element. Null in any input indicates it should check False
+    public static void checkCommonCodingAssertions(Coding coding, String code, String display,
+            String system, String version) {
+        assertThat(coding).isNotNull();
+        // assertThat(c).isGreaterThan(index-1);
+
+        if (code == null) {
+            assertThat(coding.hasCode()).isFalse();
+        } else {
+            assertThat(coding.hasCode()).isTrue();
+            assertThat(coding.getCode()).isEqualTo(code);
+        }
+        if (display == null) {
+            assertThat(coding.hasDisplay()).isFalse();
+        } else {
+            assertThat(coding.hasDisplay()).isTrue();
+            assertThat(coding.getDisplay()).isEqualTo(display);
+        }
+        if (system == null) {
+            assertThat(coding.hasSystem()).isFalse();
+        } else {
+            assertThat(coding.hasSystem()).isTrue();
+            assertThat(coding.getSystem()).isEqualTo(system);
+        }
+        if (version == null) {
+            assertThat(coding.hasVersion()).isFalse();
+        } else {
+            assertThat(coding.hasVersion()).isTrue();
+            assertThat(coding.getVersion()).isEqualTo(version);
+        }
+        
     }
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/DatatypeUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/DatatypeUtils.java
@@ -13,9 +13,17 @@ import org.hl7.fhir.r4.model.Coding;
 public class DatatypeUtils {
 
     // Common check for values of a codeable concept.  Null in any input indicates it should check False
-    // Assumes 1 coding and only checks the first one.
+    // Assumes 1 coding and only checks the first one. Kept for backwards compatability. 
+    // Now, use checkCommonCodeableConceptVersionedAssertions.
     public static void checkCommonCodeableConceptAssertions(CodeableConcept cc, String code, String display,
             String system, String text) {
+        checkCommonCodeableConceptVersionedAssertions(cc, code, display, system, text, null);        
+    }
+
+    // Common check for values of a codeable concept, including version.  Null in any input indicates it should check False
+    // Assumes 1 coding and only checks the first one.
+    public static void checkCommonCodeableConceptVersionedAssertions(CodeableConcept cc, String code, String display,
+            String system, String text, String version) {
         if (text == null) {
             assertThat(cc.hasText()).isFalse();
         } else {
@@ -23,13 +31,13 @@ public class DatatypeUtils {
             assertThat(cc.getText()).isEqualTo(text);
         }
 
-        if (code == null && display == null && system == null) {
+        if (code == null && display == null && system == null && version == null) {
             assertThat(cc.hasCoding()).isFalse();
         } else {
             assertThat(cc.hasCoding()).isTrue();
             assertThat(cc.getCoding().size()).isEqualTo(1);
             Coding coding = cc.getCoding().get(0);
-            checkCommonCodingAssertions(coding, code, display, system, null);
+            checkCommonCodingAssertions(coding, code, display, system, version);
         }
     }
 
@@ -37,7 +45,6 @@ public class DatatypeUtils {
     public static void checkCommonCodingAssertions(Coding coding, String code, String display,
             String system, String version) {
         assertThat(coding).isNotNull();
-        // assertThat(c).isGreaterThan(index-1);
 
         if (code == null) {
             assertThat(coding.hasCode()).isFalse();


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This test demonstrates the current expected behavior of multiple CWEs with primary and secondary codes.
Careful documentation of why this is expected.
This protects against inadvertent unexpected changes.