### PR TITLE
#366 Initial seed for IN1 to Coverage

### DIFF
--- a/src/main/resources/fhir/resourcemapping.yml
+++ b/src/main/resources/fhir/resourcemapping.yml
@@ -21,3 +21,4 @@ DocumentReference: org.hl7.fhir.r4.model.DocumentReference
 ServiceRequest: org.hl7.fhir.r4.model.ServiceRequest
 MedicationRequest: org.hl7.fhir.r4.model.MedicationRequest
 Device: org.hl7.fhir.r4.model.Device
+Coverage: org.hl7.fhir.r4.model.Coverage

--- a/src/main/resources/hl7/message/ADT_A01.yml
+++ b/src/main/resources/hl7/message/ADT_A01.yml
@@ -69,3 +69,13 @@ resources:
         - MSH
         - PID
         - PV1
+
+    - resourceName: Coverage
+      segment: .IN1
+      group: INSURANCE
+      resourcePath: resource/Coverage
+      repeats: true
+      additionalSegments:
+        - MSH
+        - PID
+        - PV1

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -1,0 +1,54 @@
+#
+# (C) Copyright IBM Corp. 2021, 2022
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+# Coverage required fields
+#  Status
+#  Beneficiary (Patient)
+#  Payor
+
+resourceType: Coverage
+id:
+  type: STRING
+  valueOf: 'UUID.randomUUID()'
+  expressionType: JEXL
+
+# Status is required, but it comes from a non-table 2 char ST 
+# It MUST be one of: active | cancelled | draft | entered-in-error; default to activew
+# For now, until we get a good mapping, assume all records are active
+status:
+   type: STRING
+   default: active
+   valueOf: $active
+   #   valueOf: IN1.45 value will come from IN1.45, but we don't yet have a mapping.
+   expressionType: HL7Spec
+   constants:
+     active: 'active'
+
+payor:
+   valueOf: resource/Organization
+   expressionType: reference
+   vars: 
+       orgName: String, IN1.4.1
+       orgIdentifier: String, IN1.3.1
+
+beneficiary:
+    valueOf: datatype/Reference
+    expressionType: resource
+    specs: $Patient
+
+class:
+   valueOf: secondary/Class
+   condition: $className NOT_NULL
+   generateList: true
+   expressionType: resource
+   vars: 
+      classValue: String, IN1.8
+      className: String, IN1.9.1
+   constants: 
+      typeSystem: 'http://terminology.hl7.org/CodeSystem/coverage-class'
+      typeCode: 'group'
+      typeDisplay: 'Group'
+

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -16,7 +16,7 @@ id:
   expressionType: JEXL
 
 # Status is required, but it comes from a non-table 2 char ST 
-# It MUST be one of: active | cancelled | draft | entered-in-error; default to activew
+# It MUST be one of: active | cancelled | draft | entered-in-error
 # For now, until we get a good mapping, assume all records are active
 status:
    type: STRING
@@ -41,7 +41,7 @@ beneficiary:
 
 class:
    valueOf: secondary/Class
-   condition: $className NOT_NULL
+   condition: $classValue NOT_NULL
    generateList: true
    expressionType: resource
    vars: 

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -13,16 +13,16 @@ identifier:
    generateList: true  
    expressionType: resource
    vars:
-      id: CWE.1 | XON.10 | XON.3
+      id: CWE.1 | XON.10 | XON.3 | $orgIdentifier
       system: CWE.3
 name_v1:
    type: STRING
    condition: $idValue NULL
-   valueOf: CWE.2 | XON.1
+   valueOf: CWE.2 | XON.1 | $orgName
    required: true
    expressionType: HL7Spec
    vars:
-      idValue: CWE.1 | XON.10 | XON.3
+      idValue: CWE.1 | XON.10 | XON.3 
 name_v2:
    type: STRING
    condition: $idValue NOT_NULL

--- a/src/main/resources/hl7/secondary/Class.yml
+++ b/src/main/resources/hl7/secondary/Class.yml
@@ -12,8 +12,9 @@ value:
 
 type: 
    valueOf: datatype/CodeableConcept_var
-   generateList: true
+   # generateList: true
    expressionType: resource
+   required: true
    vars: 
       system: $typeSystem
       code: $typeCode

--- a/src/main/resources/hl7/secondary/Class.yml
+++ b/src/main/resources/hl7/secondary/Class.yml
@@ -1,0 +1,26 @@
+#
+# (C) Copyright IBM Corp. 2021, 2022
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+value: 
+     type: STRING
+     valueOf: $classValue
+     expressionType: HL7Spec
+     required: true
+
+type: 
+   valueOf: datatype/CodeableConcept_var
+   generateList: true
+   expressionType: resource
+   vars: 
+      system: $typeSystem
+      code: $typeCode
+      display: $typeDisplay
+
+name:
+     type: STRING
+     valueOf: $className
+     expressionType: HL7Spec
+

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -1,0 +1,83 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.segments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Coverage;
+import org.hl7.fhir.r4.model.Organization;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.junit.jupiter.api.Test;
+
+import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
+/**
+ * Tests for IN1, Coverage, and related segments
+ */
+class Hl7FinancialInsuranceTest {
+
+    @Test
+    void testBasicInsuranceCoverageFields() throws IOException {
+        // Currently only tests limited items, other fields to be added
+
+        String hl7message = "MSH|^~\\&|||||20151008111200||ADT^A01^ADT_A01|MSGID000001|T|2.6|||||||||\n"
+                + "EVN||20210407191342||||||\n"
+                + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                // Keep temporarily for reference
+                // + "PID|0|1001|adt-a01-a08-patient-6^^^MRN|1008|DEMPSY^PAT^L|BEILY^MIRANDA^M|19251008|F|PAT|Caucasian|1221 CALIFORNIA CIRCLE^^MILPITAS^CA^95127|CA|6471112222|6473334444|ENGLISH|C|BTH|5451235|988775|D-12445889-Z|56877|N|Winnipeg, MB|N|16|CANADIAN|VET|CANADIAN|20170815080000|Y|N|AL|20170816060000|UMD|SPECIESCODE1|BREEDCODE1|STRAIN|NA|NNK1|1|Stanley^Jane^S^Jr^Mrs^BS^P|SPO^Text^CodeSystem|19 Raymond St^Route 3^Albany^NY^56321^USA^H|(002)912-8668^WPN^CP|(555)777-8888^WPN^PH|C^Text^SNM3|19980708||Nurse|C34|D345678|Ward|M|F|19790612153405|S|A0|USA|EN|F|F|N|N|COC|Flick|GERMAN|N|EMERGANCY|Jane Flick|1-888-777-9999|20 Golden Drive^Rochester^NY|Flick|O|2131-1|NO|111224444|Denver^CO\n"
+                + "PV1||I||||||||||||||||||||||||||||||||||||||||||\n"
+                // More than needed for now, but will use as more fields are implemented
+                // Values in use:  
+                // IN1.3 to Organization Identifier Value
+                // IN1.4 to Organization Name
+                // IN1.8 to Coverage.class.value
+                // IN1.9.1 to Coverage.class.name
+                + "IN1|1|GLOBAL|7776664|Blue Cross Blue Shield|456 Blue Cross Lane|Maria Kirk|1-222-555-6666|UA34567|Blue|987123|IBM|20210101145034|20211231145045|Verbal|DELUXE|Jim Stanley|NON|19780429145224|19 Raymond St|M|CO|3|Y|20210101145300|N|20210102145320|N|Certificate here|20210322145350|Dr Disney|S|GOOD|200|12|B6543|H789456|1000.00|5000.00|17|210.00|520.00|1|M|123 IBM way|True|NONE|B|NO|J321456|M|20210322145605|London|YES\n";
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).hasSize(1); // From PV1
+
+        List<Resource> patients = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patients).hasSize(1); // From PID
+        Patient patient = (Patient) patients.get(0);
+        String patientId = patient.getId();
+
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(1); // From Payor created by IN1
+        Organization organization = (Organization) organizations.get(0);
+        String organizationId = organization.getId();
+        assertThat(organization.getName()).isEqualTo("Blue Cross Blue Shield"); // IN1.4
+        assertThat(organization.getIdentifier()).hasSize(1);
+        assertThat(organization.getIdentifierFirstRep().getValue()).isEqualTo("7776664"); // IN1.3
+
+        List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
+        assertThat(coverages).hasSize(1); // From IN1 segment
+        Coverage coverage = (Coverage) coverages.get(0);
+        // Confirm Beneficiary references to Patient, and Payor references to Organization
+        assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
+        assertThat(coverage.getPayorFirstRep().getReference()).isEqualTo(organizationId);
+
+        // Only one class expected.  (getClass_ is correct name for method)
+        assertThat(coverage.getClass_()).hasSize(1);
+        assertThat(coverage.getClass_FirstRep().getName()).isEqualTo("Blue"); // IN1.9.1
+        assertThat(coverage.getClass_FirstRep().getValue()).isEqualTo("UA34567"); // IN1.8
+        DatatypeUtils.checkCommonCodeableConceptVersionedAssertions(coverage.getClass_FirstRep().getType(), "group",
+                "Group", "http://terminology.hl7.org/CodeSystem/coverage-class", null, null);
+
+        // Confirm there are no unaccounted for resources
+        assertThat(e).hasSize(4);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This is an initial seed for IN1.  It creates a small but FHIR valid Coverage object from key fields in IN1.
Also includes Class template.

@LisaWellman tag  