### PR TITLE
#366 Additional IN1 fields

### DIFF
--- a/src/main/resources/hl7/datatype/ContactPoint.yml
+++ b/src/main/resources/hl7/datatype/ContactPoint.yml
@@ -59,6 +59,13 @@ use_2:
      constants:
          mobile: "mobile"      
 
+period:
+    valueOf: datatype/Period
+    expressionType: resource
+    vars:
+       start: XTN.13
+       end: XTN.14
+
 rank: 
      type: STRING
      valueOf: XTN.18

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -23,3 +23,16 @@ system_2:
    valueOf: $join
    vars:
       join: $systemCX, GeneralUtils.noWhiteSpace(join)
+
+use:
+   condition: $use NOT_NULL 
+   type: STRING
+   valueOf: $use
+
+period:
+    condition: $start NOT_NULL || $end NOT_NULL 
+    valueOf: datatype/Period
+    expressionType: resource
+    vars: 
+       start: $start
+       end: $end   

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -15,6 +15,59 @@ id:
   valueOf: 'UUID.randomUUID()'
   expressionType: JEXL
 
+identifier_1:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN1.2.1
+    systemCX: IN1.2.3
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "XV"
+    display: "Health Plan Identifier"
+
+identifier_2:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN1.2.4
+    systemCX: IN1.2.6
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "XV"
+    display: "Health Plan Identifier" 
+
+identifier_3:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN1.46
+    # No system set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "XV"
+    display: "Health Plan Identifier" 
+    use: "old"    
+
+identifier_4:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN1.36
+    # No system set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MB"
+    display: "Member Number"         
+
 # Status is required, but it comes from a non-table 2 char ST 
 # It MUST be one of: active | cancelled | draft | entered-in-error
 # For now, until we get a good mapping, assume all records are active
@@ -32,7 +85,14 @@ payor:
    expressionType: reference
    vars: 
        orgName: String, IN1.4.1
-       orgIdentifier: String, IN1.3.1
+       orgIdValue: String, IN1.3.1
+       orgIdSystem: String, IN1.3.4
+       orgIdTypeCode: String, IN1.3.5
+       orgIdStart: IN1.3.7
+       orgIdEnd: IN1.3.8
+       orgAddressXAD: IN1.5
+       orgContactXCN: IN1.6
+       orgContactPointXTN: IN1.7
 
 beneficiary:
     valueOf: datatype/Reference
@@ -52,3 +112,9 @@ class:
       typeCode: 'group'
       typeDisplay: 'Group'
 
+period:
+    valueOf: datatype/Period
+    expressionType: resource
+    vars:
+       start: IN1.12
+       end: IN1.13

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -240,6 +240,12 @@ performer_2:
      performerValue2: OBX.23
      orgAddressXAD: OBX.24
      orgContactXCN: OBX.25
+   constants:  
+     # Observation Organization needs an ADMIN purpose
+     orgContactPurposeCode: 'ADMIN'
+     orgContactPurposeSystemCode: 'contactentity-type'
+     orgContactPurposeDisplay: 'Administrative'
+     orgContactPurposeText: 'Organization Medical Director'
 
 device:
    condition: $deviceValue NOT_NULL

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -8,13 +8,27 @@ id:
    type: STRING
    valueOf: UUID.randomUUID()
    expressionType: JEXL
-identifier:
+# Used by most organizations   
+identifier_1:
+   condition: $orgIdValue NULL
    valueOf: datatype/Identifier_Gen
    generateList: true  
    expressionType: resource
    vars:
-      id: CWE.1 | XON.10 | XON.3 | $orgIdentifier
-      system: CWE.3
+      id: CWE.1 | XON.10 | XON.3
+      system: CWE.3 
+# Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier    
+identifier_2:
+   condition: $orgIdValue NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true  
+   expressionType: resource
+   vars:
+      valueIn: $orgIdValue
+      systemCX: $orgIdSystem
+      start: $orgIdStart
+      end: $orgIdEnd
+      code: $orgIdTypeCode      
 name_v1:
    type: STRING
    condition: $idValue NULL
@@ -47,8 +61,10 @@ contact:
    generateList: true
    expressionType: resource
    specs: $orgContactXCN
-   constants:
-      code: 'ADMIN'
-      system_code: 'contactentity-type'
-      display: 'Administrative'
-      text: 'Organization Medical Director'
+   vars:
+      # May be provided to create a purpose in the Contact element
+      code: $orgContactPurposeCode
+      system_code: $orgContactPurposeSystemCode
+      display: $orgContactPurposeDisplay
+      text: $orgContactPurposeText
+      contactPointXTN: $orgContactPointXTN

--- a/src/main/resources/hl7/secondary/Contact.yml
+++ b/src/main/resources/hl7/secondary/Contact.yml
@@ -6,7 +6,7 @@
 ---
 purpose:
    valueOf: datatype/CodeableConcept_var
-   condition: $code NOT_NULL || $display NOT_NULL || $system_code NOT_NULL || text NOT_NULL
+   condition: $code NOT_NULL || $display NOT_NULL || $system_code NOT_NULL || $text NOT_NULL
    generateList: true
    expressionType: resource
    vars: 
@@ -17,3 +17,11 @@ name:
   expressionType: resource
   specs: XCN | $contactNameXCN
 
+telecom:
+   condition: $contactPointXTN NOT_NULL
+   valueOf: datatype/ContactPoint
+   generateList: true
+   expressionType: resource
+   specs: $contactPointXTN
+   constants:
+      use: work

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -91,7 +91,7 @@ class ConverterConfigurationTest {
         prop.put("additional.resources.location", "src/test/resources/additional_resources");
         prop.store(new FileOutputStream(configFile), null);
     }
-
+ 
     @Test
     void testConfigurationDefaultsAreUsed() throws IOException {
         File configFile = new File(folder, "config.properties");

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -740,7 +740,7 @@ class Hl7ORUMessageTest {
 
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
-        assertThat(obsRef).hasSize(1);
+        assertThat(obsRef).isNotEmpty().hasSize(1);
         assertThat(obsRef.get(0).isEmpty()).isFalse();
         // No attachment created since OBX with TX and no id is not first
         List<Attachment> attachments = diag.getPresentedForm();

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -15,7 +15,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
-import java.util.stream.Collectors;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Attachment;
@@ -41,7 +40,7 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7ORUMessageTest {
+class Hl7ORUMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7ORUMessageTest.class);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
@@ -52,37 +51,25 @@ public class Hl7ORUMessageTest {
             .build();
 
     // DiagnosticReports are only created from ORU messages so the test of DiagnosticReport content is included in this test module.
-
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
     // Test the minimum scenario where the least possible segments and resource info are provided in the message
-    public void test_oru_patient_diagReport() throws IOException {
+    void test_oru_patient_diagReport() throws IOException {
         String hl7message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
                 + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
                 + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|1051-2^New Born Screening^LN|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^|||||\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Verify correct resources created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> diagnosticReport = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticReport = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticReport).hasSize(1);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -127,10 +114,12 @@ public class Hl7ORUMessageTest {
 
     }
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
     // Test multiple OBX (non TX) put into Observation resources. 
     // Observation resources are created instead of attachments in the diagReport because they are not type TX.
-    public void test_oru_with_multiple_observations() throws IOException {
+    void test_oru_with_multiple_observations() throws IOException {
         String hl7message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
                 + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
                 // OBR.24 creates a DiagnosticReport.category
@@ -138,39 +127,22 @@ public class Hl7ORUMessageTest {
                 + "OBX|1|ST|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
                 + "OBX|2|ST|GA-F-01-024^Galactosemia^L||ECHOCARDIOGRAPHIC REPORT||||||F\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Verify correct resources created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(2);
 
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(1);
 
-        List<Resource> diagnosticReport = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticReport = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticReport).hasSize(1);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(1);
 
         // Expecting only the above resources, no extras!
@@ -236,52 +208,35 @@ public class Hl7ORUMessageTest {
 
     }
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
-    public void test_orur01_with_encounter_present() throws IOException {
+    void test_orur01_with_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20180520230000||ORU^R01|MSGID006552|T|2.6\r"
                 + "PID|1||000065432^^^MRN^MR||ROSTENKOWSKI^BERNADETTE^||19840823|Female||1002-5|382 OTHERSTREET AVE^^PASADENA^LA^223343||4582143248||^French|S||53811||||U|||||||\r"
                 + "PV1|1|O|||||9905^Adams^John|9906^Yellow^William^F|9907^Blue^Oren^J||||||||9908^Green^Mircea^||2462201|||||||||||||||||||||||||20180520230000\r"
                 + "OBR|1||bbf1993ab|1122^Final Echocardiogram Report|||20180520230000|||||||||||||002|||||F|||550469^Tsadok550469^Janetary~660469^Merrit660469^Darren^F~770469^Das770469^Surjya^P~880469^Winter880469^Oscar^||||770469&Das770469&Surjya&P^^^6N^1234^A|\r"
                 + "OBX|1|NM|2552^HRTRTMON|1|115||||||F|||20180520230000|||\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Verify that the right resources are created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
 
-        List<Resource> diagnosticReport = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticReport = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticReport).hasSize(1);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(1);
 
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(5);
 
         // Expecting only the above resources, no extras!
@@ -344,8 +299,10 @@ public class Hl7ORUMessageTest {
 
     }
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
-    public void test_oru_with_multiple_reports() throws IOException {
+    void test_oru_with_multiple_reports() throws IOException {
         String hl7message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
                 + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
                 + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|112^Final Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3068^JOHN^Paul^J|\r"
@@ -355,40 +312,22 @@ public class Hl7ORUMessageTest {
                 + "OBX|1|CWE|625-4^Bacteria identified in Stool by Culture^LN^^^^2.33^^result1|1|27268008^Salmonella^SCT^^^^20090731^^Salmonella species|||A^A^HL70078^^^^2.5|||P|||20120301|||^^^^^^^^Bacterial Culture||201203140957||||||\r"
                 + "OBX|2|ST|TS-F-01-002^Endocrine Disorders^L||ECHOCARDIOGRAPHIC REPORT Group 2||||||F\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Verify that the right resources are being created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(4);
 
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(2);
 
-        List<Resource> diagnosticReport = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticReport = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticReport).hasSize(2);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(2);
 
         // Expecting only the above resources, no extras!
@@ -488,52 +427,35 @@ public class Hl7ORUMessageTest {
         }
     }
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
-    public void test_oru_with_specimen() throws IOException {
+    void test_oru_with_specimen() throws IOException {
         String hl7message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
                 + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
                 + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|1051-2^New Born Screening^LN|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
                 + "OBX|1|ST|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r"
                 + "SPM|1|SpecimenID||BLD|||||||P||||||201410060535|201410060821||Y||||||1\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Verify that the right resources are created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> diagnosticReport = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticReport = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticReport).hasSize(1);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(1);
 
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1);
 
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(1);
 
-        List<Resource> specimenResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> specimenResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(specimenResource).hasSize(1);
 
         // Expecting only the above resources, no extras! 
@@ -603,8 +525,10 @@ public class Hl7ORUMessageTest {
      * The OBX type TX are added to the presentedForm as an attachment for the diagnostic
      * @throws IOException
      */
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
-    public void test_oru_multipleOBXofDifferentTypes() throws IOException {
+    void test_oru_multipleOBXofDifferentTypes() throws IOException {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(new File("src/test/resources/ORU-multiline-short.hl7"), OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
@@ -619,50 +543,34 @@ public class Hl7ORUMessageTest {
         List<BundleEntryComponent> e = b.getEntry();
 
         // Verify that the right resources have been created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> organizationResource = e.stream()
-                .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> organizationResource = ResourceUtils.getResourceList(e, ResourceType.Organization);
         // We expect an organization created from an Encounter.serviceProvider reference 
         assertThat(organizationResource).hasSize(1);
 
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(4);
 
-        List<Resource> messageHeader = e.stream()
-                .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> messageHeader = ResourceUtils.getResourceList(e, ResourceType.MessageHeader);
         assertThat(messageHeader).hasSize(1);
 
         //Verify Diagnostic Report is created as expected
-        List<Resource> reportResource = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> reportResource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(reportResource).hasSize(1);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(1);
 
         // Verify there are no extra resources created
         assertThat(e.size()).isEqualTo(10);
 
         //Verify no observations are created
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(0); // TODO: When NTE is implemented, then update this to one.
 
         ///////////////////////////////////////////
@@ -745,7 +653,10 @@ public class Hl7ORUMessageTest {
      * @throws IOException
      */
     @Test
-    public void test_oru_multipleOBXWithMixedType() throws IOException {
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
+    void test_oru_multipleOBXWithMixedType() throws IOException {
+        
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(new File("src/test/resources/ORU-multiline-short-mixed.hl7"), OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
@@ -759,47 +670,31 @@ public class Hl7ORUMessageTest {
         List<BundleEntryComponent> e = b.getEntry();
 
         // Verify that the right resources have been created
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> organizationResource = e.stream()
-                .filter(v -> ResourceType.Organization == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> organizationResource = ResourceUtils.getResourceList(e, ResourceType.Organization);
         // We expect an organization created from an Encounter.serviceProvider reference 
         assertThat(organizationResource).hasSize(1);
 
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(4);
 
-        List<Resource> messageHeader = e.stream()
-                .filter(v -> ResourceType.MessageHeader == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> messageHeader = ResourceUtils.getResourceList(e, ResourceType.MessageHeader);
         assertThat(messageHeader).hasSize(1);
 
         // Verify one Observation is created (from the ST, not the TX)
-        List<Resource> obsResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(obsResource).hasSize(1); // TODO: When NTE is implemented, then update this.
 
         // Verify Diagnostic Report is created as expected
-        List<Resource> reportResource = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> reportResource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(reportResource).hasSize(1);
 
-        List<Resource> servReqResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> servReqResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(servReqResource).hasSize(1);
 
         // Verify there are no extra resources created
@@ -845,7 +740,6 @@ public class Hl7ORUMessageTest {
 
         // Verify result reference
         List<Reference> obsRef = diag.getResult();
-        assertThat(obsRef).isNotEmpty();
         assertThat(obsRef).hasSize(1);
         assertThat(obsRef.get(0).isEmpty()).isFalse();
         // No attachment created since OBX with TX and no id is not first
@@ -868,7 +762,7 @@ public class Hl7ORUMessageTest {
     }
 
     @Test
-    public void test_ORU_r01_without_status() throws IOException {
+    void test_ORU_r01_without_status() throws IOException {
         String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
                 + "PID|1||PATID5421^^^NISTMPI^MR||Wilson^Patrice^Natasha^^^^L||19820304|F||2106-3^White^HL70005|144 East 12th Street^^Los Angeles^CA^90012^^H||^PRN^PH^^^203^2290210|||||||||N^Not Hispanic or Latino^HL70189\r"
                 + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
@@ -885,9 +779,7 @@ public class Hl7ORUMessageTest {
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
-        List<Resource> diagnosticReport = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticReport = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticReport).hasSize(1);
 
         String s = context.getParser().encodeResourceToString(diagnosticReport.get(0));

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -28,7 +28,7 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
  * Tests for IN1, Coverage, and related segments
  */
 class Hl7FinancialInsuranceTest {
-    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    // Suppress warnings about too many assertions in a test. Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
     @java.lang.SuppressWarnings("squid:S5961")
     @Test
     void testBasicInsuranceCoverageFields() throws IOException {

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -98,6 +98,8 @@ class Hl7FinancialInsuranceTest {
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
         assertThat(organizations).hasSize(1); // From Payor created by IN1
         Organization org = (Organization) organizations.get(0);
+
+        // Check organization Id's
         String organizationId = org.getId();
         assertThat(org.getName()).isEqualTo("Large Blue Organization"); // IN1.4
         assertThat(org.getIdentifier()).hasSize(1);
@@ -108,7 +110,7 @@ class Hl7FinancialInsuranceTest {
         assertThat(orgId1.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.3.8
         DatatypeUtils.checkCommonCodeableConceptAssertions(orgId1.getType(), "IdType5", null, null, null); // IN1.3.5
 
-        // Basic check the Organization address. IN1.4 is a standard XAD address, which is tested exhaustively in other tests.  
+        // Check the Organization address. IN1.4 is a standard XAD address, which is tested exhaustively in other tests.  
         assertThat(org.getAddress()).hasSize(1);
         assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString())
                 .isEqualTo("456 Ultramarine Lane"); // IN1.4.1
@@ -116,7 +118,7 @@ class Hl7FinancialInsuranceTest {
         assertThat(org.getAddress().get(0).getState()).isEqualTo("CA"); // IN1.4.4
         assertThat(org.getAddress().get(0).getPostalCode()).isEqualTo("ZIP5"); // IN1.4.5
 
-        // Basic check Organization contact name.  IN1.6 name is standard XPN, tested exhaustively in other tests.
+        // Check Organization contact name.  IN1.6 name is standard XPN, tested exhaustively in other tests.
         HumanName contactName = org.getContact().get(0).getName();
         assertThat(org.getContact()).hasSize(1);
         assertThat(contactName.getFamily()).isEqualTo("LastFake"); // IN1.6.1
@@ -130,7 +132,7 @@ class Hl7FinancialInsuranceTest {
         assertThat(contactName.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.6.13
         assertThat(org.getContact().get(0).hasPurpose()).isFalse(); // Check there is no purpose. Don't need one, here.
 
-        // Basic Organization contact telecom.  IN1.7 is standard XTN, tested exhaustively in other tests.
+        // Check Organization contact telecom.  IN1.7 is standard XTN, tested exhaustively in other tests.
         assertThat(org.getContact().get(0).getTelecom()).hasSize(1);
         ContactPoint contactPoint = org.getContact().get(0).getTelecomFirstRep(); // telecom is type ContactPoint
         assertThat(contactPoint.getSystemElement().getCode()).hasToString("phone"); // default type hardcoded.

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -11,7 +11,10 @@ import java.io.IOException;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Coverage;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
@@ -25,7 +28,8 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
  * Tests for IN1, Coverage, and related segments
  */
 class Hl7FinancialInsuranceTest {
-
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
     void testBasicInsuranceCoverageFields() throws IOException {
         // Currently only tests limited items, other fields to be added
@@ -33,16 +37,53 @@ class Hl7FinancialInsuranceTest {
         String hl7message = "MSH|^~\\&|||||20151008111200||ADT^A01^ADT_A01|MSGID000001|T|2.6|||||||||\n"
                 + "EVN||20210407191342||||||\n"
                 + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                // Keep temporarily for reference
-                // + "PID|0|1001|adt-a01-a08-patient-6^^^MRN|1008|DEMPSY^PAT^L|BEILY^MIRANDA^M|19251008|F|PAT|Caucasian|1221 CALIFORNIA CIRCLE^^MILPITAS^CA^95127|CA|6471112222|6473334444|ENGLISH|C|BTH|5451235|988775|D-12445889-Z|56877|N|Winnipeg, MB|N|16|CANADIAN|VET|CANADIAN|20170815080000|Y|N|AL|20170816060000|UMD|SPECIESCODE1|BREEDCODE1|STRAIN|NA|NNK1|1|Stanley^Jane^S^Jr^Mrs^BS^P|SPO^Text^CodeSystem|19 Raymond St^Route 3^Albany^NY^56321^USA^H|(002)912-8668^WPN^CP|(555)777-8888^WPN^PH|C^Text^SNM3|19980708||Nurse|C34|D345678|Ward|M|F|19790612153405|S|A0|USA|EN|F|F|N|N|COC|Flick|GERMAN|N|EMERGANCY|Jane Flick|1-888-777-9999|20 Golden Drive^Rochester^NY|Flick|O|2131-1|NO|111224444|Denver^CO\n"
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\n"
-                // More than needed for now, but will use as more fields are implemented
-                // Values in use:  
-                // IN1.3 to Organization Identifier Value
+                // IN1 Segment is split and concatenated for easier understanding. (| precedes numbered field.)
+                // IN1.2.1, IN1.2.3 to Identifier 1
+                // IN1.2.4, IN1.2.6 to Identifier 2
+                + "IN1|1|Value1^^System3^Value4^^System6"
+                // IN1.3 to Organization Identifier 
+                //    IN1.3.1 to Organization Identifier.value
+                //    IN1.3.4 to Organization Identifier.system
+                //    IN1.3.5 to Organization Identifier.type.code
+                //    IN1.3.7 to Organization Identifier.period.start
+                //    IN1.3.8 to Organization Identifier.period.end
+                + "|IdValue1^^^IdSystem4^IdType5^^20201231145045^20211231145045"
                 // IN1.4 to Organization Name
+                + "|Large Blue Organization"
+                // IN1.5 to Organization Address (All XAD standard fields)
+                + "|456 Ultramarine Lane^^Faketown^CA^ZIP5"
+                // IN1.6 to Organization Contact Name 
+                //    IN1.6.1 to Organization Contact Name .family
+                //    IN1.6.2 to Organization Contact Name .given (first)
+                //    IN1.6.3 to Organization Contact Name .given (middle)
+                //    IN1.6.4 to Organization Contact Name .suffix
+                //    IN1.6.5 to Organization Contact Name .prefix
+                //    IN1.6.7 to Organization Contact Name .use
+                //    IN1.6.12 to Organization Contact Name .period.start
+                //    IN1.6.13 to Organization Contact Name .period.end
+                + "|LastFake^FirstFake^MiddleFake^III^Dr.^^L^^^^^20201231145045^20211231145045"
+                // IN1.7 to Organization Contact telecom  
+                //    IN1.7.1 to Organization Contact telecom .value (ONLY when 7.5-7.7 are empty.  See rules in getFormattedTelecomNumberValue.)
+                //    IN1.7.2 to Organization Contact telecom .use is "work" 
+                //    IN1.7.5 (Country) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
+                //    IN1.7.6 (Area) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
+                //    IN1.7.7 (Local) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
+                //    IN1.7.8 (Extension) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
+                //    IN1.7.13 to Organization Contact Name .period.start
+                //    IN1.7.14 to Organization Contact Name .period.end
+                //    IN1.7.18 to Organization Contact telecom .rank 
+                + "|^^^^^333^4444444^^^^^^20201231145045^20211231145045^^^^1"
                 // IN1.8 to Coverage.class.value
                 // IN1.9.1 to Coverage.class.name
-                + "IN1|1|GLOBAL|7776664|Blue Cross Blue Shield|456 Blue Cross Lane|Maria Kirk|1-222-555-6666|UA34567|Blue|987123|IBM|20210101145034|20211231145045|Verbal|DELUXE|Jim Stanley|NON|19780429145224|19 Raymond St|M|CO|3|Y|20210101145300|N|20210102145320|N|Certificate here|20210322145350|Dr Disney|S|GOOD|200|12|B6543|H789456|1000.00|5000.00|17|210.00|520.00|1|M|123 IBM way|True|NONE|B|NO|J321456|M|20210322145605|London|YES\n";
+                // IN1.12 to Coverage.period.start
+                // IN1.13 to Coverage.period.end
+                // IN1.14 to IN1.35 NOT REFERENCED
+                + "|UA34567|Blue|||20201231145045|20211231145045||||||||||||||||||||||"
+                // IN1.36 to Identifier 4
+                // IN1.46 to Identifier 3
+                // IN1.47 to IN1.45 NOT REFERENCED
+                + "|MEMBER36||||||||||Value46|||||||\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -56,25 +97,94 @@ class Hl7FinancialInsuranceTest {
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
         assertThat(organizations).hasSize(1); // From Payor created by IN1
-        Organization organization = (Organization) organizations.get(0);
-        String organizationId = organization.getId();
-        assertThat(organization.getName()).isEqualTo("Blue Cross Blue Shield"); // IN1.4
-        assertThat(organization.getIdentifier()).hasSize(1);
-        assertThat(organization.getIdentifierFirstRep().getValue()).isEqualTo("7776664"); // IN1.3
+        Organization org = (Organization) organizations.get(0);
+        String organizationId = org.getId();
+        assertThat(org.getName()).isEqualTo("Large Blue Organization"); // IN1.4
+        assertThat(org.getIdentifier()).hasSize(1);
+        Identifier orgId1 = org.getIdentifierFirstRep();
+        assertThat(orgId1.getValue()).isEqualTo("IdValue1"); // IN1.3.1
+        assertThat(orgId1.getSystem()).isEqualTo("urn:id:IdSystem4"); // IN1.3.4
+        assertThat(orgId1.getPeriod().getStartElement().toString()).containsPattern("2020-12-31T14:50:45"); // IN1.3.7
+        assertThat(orgId1.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.3.8
+        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId1.getType(), "IdType5", null, null, null); // IN1.3.5
+
+        // Basic check the Organization address. IN1.4 is a standard XAD address, which is tested exhaustively in other tests.  
+        assertThat(org.getAddress()).hasSize(1);
+        assertThat(org.getAddress().get(0).getLine().get(0).getValueAsString())
+                .isEqualTo("456 Ultramarine Lane"); // IN1.4.1
+        assertThat(org.getAddress().get(0).getCity()).isEqualTo("Faketown"); // IN1.4.3
+        assertThat(org.getAddress().get(0).getState()).isEqualTo("CA"); // IN1.4.4
+        assertThat(org.getAddress().get(0).getPostalCode()).isEqualTo("ZIP5"); // IN1.4.5
+
+        // Basic check Organization contact name.  IN1.6 name is standard XPN, tested exhaustively in other tests.
+        HumanName contactName = org.getContact().get(0).getName();
+        assertThat(org.getContact()).hasSize(1);
+        assertThat(contactName.getFamily()).isEqualTo("LastFake"); // IN1.6.1
+        assertThat(contactName.getGiven().get(0).getValueAsString()).isEqualTo("FirstFake"); // IN1.6.2
+        assertThat(contactName.getGiven().get(1).getValueAsString()).isEqualTo("MiddleFake"); // IN1.6.3
+        assertThat(contactName.getPrefixAsSingleString()).hasToString("Dr."); // IN1.6.6
+        assertThat(contactName.getSuffixAsSingleString()).hasToString("III"); // IN1.6.5
+        assertThat(contactName.getText()).isEqualTo("Dr. FirstFake MiddleFake LastFake III"); // from IN1.6 aggregate
+        assertThat(contactName.getUseElement().getCode()).hasToString("official"); // IN1.6.7
+        assertThat(contactName.getPeriod().getStartElement().toString()).containsPattern("2020-12-31T14:50:45"); // IN1.6.12
+        assertThat(contactName.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.6.13
+        assertThat(org.getContact().get(0).hasPurpose()).isFalse(); // Check there is no purpose. Don't need one, here.
+
+        // Basic Organization contact telecom.  IN1.7 is standard XTN, tested exhaustively in other tests.
+        assertThat(org.getContact().get(0).getTelecom()).hasSize(1);
+        ContactPoint contactPoint = org.getContact().get(0).getTelecomFirstRep(); // telecom is type ContactPoint
+        assertThat(contactPoint.getSystemElement().getCode()).hasToString("phone"); // default type hardcoded.
+        assertThat(contactPoint.getUseElement().getCode()).hasToString("work"); // IN1.7.2
+        assertThat(contactPoint.getValue()).hasToString("(333) 444 4444"); // IN1.7.6, IN1.7.7 via getFormattedTelecomNumberValue
+        assertThat(contactPoint.getPeriod().getStartElement().toString()).containsPattern("2020-12-31T14:50:45"); // IN1.7.13
+        assertThat(contactPoint.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.7.14
+        assertThat(contactPoint.getRank()).isEqualTo(1); // IN1.7.18
 
         List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
         assertThat(coverages).hasSize(1); // From IN1 segment
         Coverage coverage = (Coverage) coverages.get(0);
-        // Confirm Beneficiary references to Patient, and Payor references to Organization
+
+        // Confirm Coverage Identifiers
+        assertThat(coverage.getIdentifier()).hasSize(4);
+        assertThat(coverage.getIdentifier().get(0).getValue()).isEqualTo("Value1"); // IN1.2.1
+        assertThat(coverage.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:System3"); // IN1.2.3
+        assertThat(coverage.getIdentifier().get(0).getUse()).isNull(); // No use, here
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(0).getType(), "XV",
+                "Health Plan Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        assertThat(coverage.getIdentifier().get(1).getValue()).isEqualTo("Value4"); // IN1.2.4
+        assertThat(coverage.getIdentifier().get(1).getSystem()).isEqualTo("urn:id:System6"); // IN1.2.6
+        assertThat(coverage.getIdentifier().get(1).getUse()).isNull(); // No use, here
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(1).getType(), "XV",
+                "Health Plan Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        assertThat(coverage.getIdentifier().get(2).getValue()).isEqualTo("Value46"); // IN1.46
+        assertThat(coverage.getIdentifier().get(2).getSystem()).isNull(); // No system, here
+        assertThat(coverage.getIdentifier().get(2).getUseElement().getCode()).hasToString("old"); // Use is enumeration "old"
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(2).getType(), "XV",
+                "Health Plan Identifier",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        assertThat(coverage.getIdentifier().get(3).getValue()).isEqualTo("MEMBER36"); // IN1.36
+        assertThat(coverage.getIdentifier().get(3).getSystem()).isNull(); // No system, here
+        assertThat(coverage.getIdentifier().get(3).getUse()).isNull(); // No use, here
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(3).getType(), "MB",
+                "Member Number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+
+        // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
         assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
         assertThat(coverage.getPayorFirstRep().getReference()).isEqualTo(organizationId);
 
-        // Only one class expected.  (getClass_ is correct name for method)
+        // Only one Coverage Class expected.  (getClass_ is correct name for method)
         assertThat(coverage.getClass_()).hasSize(1);
         assertThat(coverage.getClass_FirstRep().getName()).isEqualTo("Blue"); // IN1.9.1
         assertThat(coverage.getClass_FirstRep().getValue()).isEqualTo("UA34567"); // IN1.8
         DatatypeUtils.checkCommonCodeableConceptVersionedAssertions(coverage.getClass_FirstRep().getType(), "group",
                 "Group", "http://terminology.hl7.org/CodeSystem/coverage-class", null, null);
+
+        // Confirm Coverage period
+        assertThat(coverage.getPeriod().getStartElement().toString()).containsPattern("2020-12-31T14:50:45"); // IN1.12
+        assertThat(coverage.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.13
 
         // Confirm there are no unaccounted for resources
         assertThat(e).hasSize(4);

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -82,7 +82,7 @@ class Hl7FinancialInsuranceTest {
                 + "|UA34567|Blue|||20201231145045|20211231145045||||||||||||||||||||||"
                 // IN1.36 to Identifier 4
                 // IN1.46 to Identifier 3
-                // IN1.47 to IN1.45 NOT REFERENCED
+                // IN1.47 to IN1.53 NOT REFERENCED
                 + "|MEMBER36||||||||||Value46|||||||\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This adds support for many IN1 fields:
* IN1.2.1, IN1.2.3 to Identifier 1
* IN1.2.4, IN1.2.6 to Identifier 2
* IN1.3 to Organization Identifier 
  * IN1.3.1 to Organization Identifier.value
  * IN1.3.4 to Organization Identifier.system
  * IN1.3.5 to Organization Identifier.type.code
  * IN1.3.7 to Organization Identifier.period.start
  * IN1.3.8 to Organization Identifier.period.end
* IN1.4 to Organization Name
* IN1.5 to Organization Address (All XAD standard fields)
* IN1.6 to Organization Contact Name 
  * IN1.6.1 to Organization Contact Name .family
  * IN1.6.2 to Organization Contact Name .given (first)
  * IN1.6.3 to Organization Contact Name .given (middle)
  * IN1.6.4 to Organization Contact Name .suffix
  * IN1.6.5 to Organization Contact Name .prefix
  * IN1.6.7 to Organization Contact Name .use
  * IN1.6.12 to Organization Contact Name .period.start
  * IN1.6.13 to Organization Contact Name .period.end
* IN1.7 to Organization Contact telecom  
  * IN1.7.1 to Organization Contact telecom .value (ONLY when 7.5-7.7 are empty.  See rules in getFormattedTelecomNumberValue.)
  * IN1.7.2 to Organization Contact telecom .use is "work" 
  * IN1.7.5 (Country) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
  * IN1.7.6 (Area) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
  * IN1.7.7 (Local) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
  * IN1.7.8 (Extension) to Organization Contact telecom .value (as input to getFormattedTelecomNumberValue)
  * IN1.7.13 to Organization Contact Name .period.start
  * IN1.7.14 to Organization Contact Name .period.end
  * IN1.7.18 to Organization Contact telecom .rank 
* IN1.12 to Coverage.period.start
* IN1.13 to Coverage.period.end
* IN1.36 to Identifier 4
* IN1.46 to Identifier 3

Adds tests.
Backwards compatible.

tag @LisaWellman  @klwhaley 