### PR TITLE
Clinical status "resolved" if prb.9 but no prb.14

### DIFF
--- a/src/main/resources/hl7/resource/Condition.yml
+++ b/src/main/resources/hl7/resource/Condition.yml
@@ -188,7 +188,7 @@ clinicalStatus_1:
 
 # If PRB 14 is empty or invalid, AND PRB.9 has data, set to "resolved"
 # CONDITION_CLINICAL_STATUS_FHIR returns null if the value is invalid or null.
-clinicalStatus:
+clinicalStatus_2:
   condition: $prb9 NOT_NULL && $validCoding NULL
   valueOf: datatype/CodeableConcept_var
   expressionType: resource

--- a/src/main/resources/hl7/resource/Condition.yml
+++ b/src/main/resources/hl7/resource/Condition.yml
@@ -167,6 +167,7 @@ extension_1:
       urlValue: condition-assertedDate
 
 # We don't populate this optional field if the value is invalid.
+# CONDITION_VERIFICATION_STATUS_FHIR filters only valid values.
 verificationStatus:
   condition: $coding NOT_NULL
   valueOf: datatype/CodeableConcept
@@ -176,13 +177,28 @@ verificationStatus:
     text: String, PRB.13.2
 
 # We don't populate this optional field if the value is invalid.
-clinicalStatus:
+# Use CONDITION_CLINICAL_STATUS_FHIR to filter out invalid values.
+clinicalStatus_1:
   condition: $coding NOT_NULL
   valueOf: datatype/CodeableConcept
   expressionType: resource
   vars:
     coding: CONDITION_CLINICAL_STATUS_FHIR, PRB.14
     text: String, PRB.14.2
+
+# If PRB 14 is empty or invalid, AND PRB.9 has data, set to "resolved"
+# CONDITION_CLINICAL_STATUS_FHIR returns null if the value is invalid or null.
+clinicalStatus:
+  condition: $prb9 NOT_NULL && $validCoding NULL
+  valueOf: datatype/CodeableConcept_var
+  expressionType: resource
+  vars:
+    validCoding: CONDITION_CLINICAL_STATUS_FHIR, PRB.14.1
+    prb9: PRB.9
+  constants: 
+    code: 'resolved' 
+    display: 'Resolved'
+    system: 'http://terminology.hl7.org/CodeSystem/condition-clinical'
 
 note:
    valueOf: datatype/Annotation

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
@@ -9,14 +9,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
-import org.hl7.fhir.r4.model.Property;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Test;
@@ -48,123 +45,102 @@ class HL7ConditionFHIRConversionTest {
 
         String hl7message = msh + "PID||||||||||||||||||||||||||||||\r"
                 + "PV1||I|||||||||||||||||1400|||||||||||||||||||||||||\r"
-                + "DG1|1|ICD10|C56.9^Ovarian Cancer^I10|Test|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|V45|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
+                // DG1.3 to Code
+                // DG1.5 to Onset (DateTime)
+                // DG1.6 type required 
+                // DG1.15 to Rank
+                // DG1.16 to Practitioner  
+                // DG1.19 to RecordedDate
+                // DG1.20 to Identifier
+                + "DG1|1||C56.9^Ovarian Cancer^I10||20210322154449|A|||||||||1|123^DOE^JOHN^A^|||20210322154326|V45|||||\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+        // Verfify no extraneous resources
+        // Expect encounter, patient, practitioner, condition
+        assertThat(e).hasSize(4);
 
         // --- CONDITION TESTS ---
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionResource).hasSize(1);
-
-        // Get condition Resource
-        Resource condition = conditionResource.get(0);
-
-        // Get condition identifiers
-        Property identifierProperty = condition.getNamedProperty("identifier");
-        List<Base> identifierList = identifierProperty.getValues();
+        Condition condition = (Condition) conditionResource.get(0);
 
         // Verify we have 3 identifiers
-        // NOTE: The other identifiers, not related to condition, are tested in the
+        // NOTE: The other identifiers, not related to condition, are tested deeply in the
         // identifier suite of unit tests.
-        assertThat(identifierList).hasSize(3);
-
+        assertThat(condition.getIdentifier()).hasSize(3);
+        // First identifier is the Visit Number, and is a codeable concept
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getIdentifier().get(0).getType(), "VN",
+                "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        // Second identifier  
+        assertThat(condition.getIdentifier().get(1).getSystem()).isEqualTo("urn:id:extID");
+        assertThat(condition.getIdentifier().get(1).getValue()).isEqualTo("C56.9-I10");
         // The 3rd identifier value should be from DG1.20
-        String thirdIdentiferValue = ResourceUtils.getValueAsString(identifierList.get(2), "value");
-        assertThat(thirdIdentiferValue).isEqualTo("V45");
+        assertThat(condition.getIdentifier().get(2).getValue()).isEqualTo("V45"); // DG1.20
 
         // Verify asserter reference to Practitioner exists
-        Base asserter = ResourceUtils.getValue(condition, "asserter");
-        assertThat(ResourceUtils.getValueAsString(asserter, "reference").substring(0, 13)).isEqualTo("Practitioner/");
+        assertThat(condition.getAsserter().getReference().substring(0, 13)).isEqualTo("Practitioner/");
 
         // Verify recorded date is set correctly.
-        assertThat(ResourceUtils.getValueAsString(condition, "recordedDate"))
-                .isEqualTo("DateTimeType[2021-03-22T15:43:26+08:00]");
+        assertThat(condition.getRecordedDateElement().toString()).containsPattern("2021-03-22T15:43:26"); // DG1.19
 
         // Verify onset date time is set correctly.
-        assertThat(ResourceUtils.getValueAsString(condition, "onsetDateTime"))
-                .isEqualTo("DateTimeType[2021-03-22T15:44:49+08:00]");
+        assertThat(condition.getOnset().toString()).containsPattern("2021-03-22T15:44:49"); // DG1.5
 
-        // Verify code text is set correctly.
-        Base code = ResourceUtils.getValue(condition, "code");
-        assertThat(ResourceUtils.getValueAsString(code, "text")).isEqualTo("Ovarian Cancer");
-
-        // Verify code coding is set correctly.
-        Base coding = ResourceUtils.getValue(code, "coding");
-        assertThat(ResourceUtils.getValueAsString(coding, "system"))
-                .isEqualTo("UriType[http://hl7.org/fhir/sid/icd-10-cm]");
-        assertThat(ResourceUtils.getValueAsString(coding, "code")).isEqualTo("C56.9");
-        assertThat(ResourceUtils.getValueAsString(coding, "display")).isEqualTo("Ovarian Cancer");
+        // Verify code text and coding are set correctly.
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCode(), "C56.9", "Ovarian Cancer",
+                "http://hl7.org/fhir/sid/icd-10-cm", "Ovarian Cancer"); // DG1.3
 
         // Verify encounter reference exists
-        Base encounterProp = ResourceUtils.getValue(condition, "encounter");
-        assertThat(ResourceUtils.getValueAsString(encounterProp, "reference").substring(0, 10)).isEqualTo("Encounter/");
+        assertThat(condition.getEncounter().getReference().substring(0, 10)).isEqualTo("Encounter/");
 
         // Verify subject reference to Patient exists
-        Base subject = ResourceUtils.getValue(condition, "subject");
-        assertThat(ResourceUtils.getValueAsString(subject, "reference").substring(0, 8)).isEqualTo("Patient/");
+        assertThat(condition.getSubject().getReference().substring(0, 8)).isEqualTo("Patient/");
 
-        // Verify category text is set correctly.
-        Base category = ResourceUtils.getValue(condition, "category");
-        assertThat(ResourceUtils.getValueAsString(category, "text")).isEqualTo("Encounter Diagnosis");
-
-        // Verify category coding fields are set correctly.
-        Base catCoding = ResourceUtils.getValue(category, "coding");
-        assertThat(ResourceUtils.getValueAsString(catCoding, "system"))
-                .isEqualTo("UriType[http://terminology.hl7.org/CodeSystem/condition-category]");
-        assertThat(ResourceUtils.getValueAsString(catCoding, "code")).isEqualTo("encounter-diagnosis");
-        assertThat(ResourceUtils.getValueAsString(catCoding, "display")).isEqualTo("Encounter Diagnosis");
+        // Verify category text and coding are set correctly.
+        assertThat(condition.getCategory()).hasSize(1);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCategoryFirstRep(), "encounter-diagnosis",
+                "Encounter Diagnosis",
+                "http://terminology.hl7.org/CodeSystem/condition-category", "Encounter Diagnosis"); // DG1.3
 
         // --- ENCOUNTER TESTS ---
 
         List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
-
-        // Get the encounter resource
-        Base encounter = encounterResource.get(0);
-
-        // Verify reasonReference to condition exists
-        Base reasonReference = ResourceUtils.getValue(encounter, "reasonReference");
-        assertThat(ResourceUtils.getValueAsString(reasonReference, "reference").substring(0, 10))
-                .isEqualTo("Condition/");
-
-        // Verify encounter diagnosis use is set correctly
-        Base diagnosis = ResourceUtils.getValue(encounter, "diagnosis");
-        Base use = ResourceUtils.getValue(diagnosis, "use");
-        Base diagCoding = ResourceUtils.getValue(use, "coding");
-        assertThat(ResourceUtils.getValueAsString(diagCoding, "system"))
-                .isEqualTo("UriType[http://terminology.hl7.org/CodeSystem/diagnosis-role]");
-        assertThat(ResourceUtils.getValueAsString(diagCoding, "code")).isEqualTo("AD");
-        assertThat(ResourceUtils.getValueAsString(diagCoding, "display")).isEqualTo("Admission diagnosis");
-
-        // Verify encounter diagnosis rank is set correctly.
-        assertThat(ResourceUtils.getValueAsString(diagnosis, "rank")).isEqualTo("PositiveIntType[1]");
+        Encounter encounter = (Encounter) encounterResource.get(0);
 
         // Encounter should have a reference to the conditions (only 1 in this unit test)
-        Base conditionRef = ResourceUtils.getValue(encounter, "reasonReference");
-        assertThat(ResourceUtils.getValueAsString(conditionRef, "reference").substring(0, 10)).isEqualTo("Condition/");
+        assertThat(encounter.getReasonReference()).hasSize(1);
+        assertThat(encounter.getReasonReference().get(0).getReference().substring(0, 10))
+                .isEqualTo("Condition/");
+
+        // Verify encounter diagnosis condition, use, and rank are set correctly
+        assertThat(encounter.getDiagnosis()).hasSize(1);
+        assertThat(encounter.getDiagnosisFirstRep().getCondition().getReference().substring(0, 10))
+                .isEqualTo("Condition/");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(encounter.getDiagnosisFirstRep().getUse(), "AD",
+                "Admission diagnosis",
+                "http://terminology.hl7.org/CodeSystem/diagnosis-role", null);
+        assertThat(encounter.getDiagnosisFirstRep().getRank()).isEqualTo(1); // DG1.15
 
         // --- PRACTIONER TESTS ---
 
-        // Find the practitioner resource from the FHIR bundle.
-        List<Resource> practitionerResource = e.stream()
-                .filter(v -> ResourceType.Practitioner == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        // Find the asserter (practitioner)  resource from the FHIR bundle.
+        List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(1);
-
-        // Get practitioner Resource
-        Resource practitioner = practitionerResource.get(0);
+        Practitioner practitioner = (Practitioner) practitionerResource.get(0);
 
         // Verify name text, family, and given are set correctly.
-        Base name = ResourceUtils.getValue(practitioner, "name");
-        assertThat(ResourceUtils.getValueAsString(name, "text")).isEqualTo("JOHN A DOE");
-        assertThat(ResourceUtils.getValueAsString(name, "family")).isEqualTo("DOE");
-        assertThat(ResourceUtils.getValueAsString(name, "given")).isEqualTo("JOHN");
+        assertThat(practitioner.getName()).hasSize(1);
+        assertThat(practitioner.getNameFirstRep().getText()).isEqualTo("JOHN A DOE"); // DG1.17
+        assertThat(practitioner.getNameFirstRep().getFamily()).isEqualTo("DOE"); // DG1.17.2
+        assertThat(practitioner.getNameFirstRep().getGivenAsSingleString()).isEqualTo("JOHN A"); // DG1.17.3
 
-        // Verify asserter identifier is set correctly.
-        Base identifier = ResourceUtils.getValue(practitioner, "identifier");
-        assertThat(ResourceUtils.getValueAsString(identifier, "value")).isEqualTo("123");
+        // Verify asserter (practitioner) identifier is set correctly.
+        assertThat(practitioner.getIdentifier()).hasSize(1);
+        assertThat(practitioner.getIdentifierFirstRep().getValue()).isEqualTo("123"); // DG1.17.1
 
     }
 
@@ -175,42 +151,33 @@ class HL7ConditionFHIRConversionTest {
 
         String hl7message = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 + "PID||||||||||||||||||||||||||||||\r"
-                + "DG1|1|ICD10|B45678|Broken Arm|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|one^https://terminology.hl7.org/CodeSystem/two^three^https://terminology.hl7.org/CodeSystem/four|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
+                // DG1.3 to identifiers (required)
+                // DG1.6 type required
+                // DG1.20 to identifers
+                + "DG1|1||B45678|||A||||||||||||||one^https://terminology.hl7.org/CodeSystem/two^three^https://terminology.hl7.org/CodeSystem/four||||||\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionResource).hasSize(1);
-
-        // Get condition Resource
-        Resource condition = conditionResource.get(0);
-
-        // Get condition identifiers
-        Property identifierProperty = condition.getNamedProperty("identifier");
-        List<Base> identifierList = identifierProperty.getValues();
+        Condition condition = (Condition) conditionResource.get(0);
 
         // Verify we have 3 identifiers
         // NOTE: The first identifier which is not related to condition is tested in the
         // identifier suite of unit tests.
-        assertThat(identifierList).hasSize(3);
-
+        assertThat(condition.getIdentifier()).hasSize(3);
+        // First identifier 
+        assertThat(condition.getIdentifier().get(0).getValue()).isEqualTo("B45678"); //DG1.3
+        assertThat(condition.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:extID"); // DG1.3 (assumed)
         // Test 2nd identifier
-        Base identifierTwo = identifierList.get(1);
-        // value = DG1.20.1
-        assertThat(ResourceUtils.getValueAsString(identifierTwo, "value")).isEqualTo("one");
-        // system = DG1.20.2
-        assertThat(ResourceUtils.getValueAsString(identifierTwo, "system"))
-                .isEqualTo("UriType[https://terminology.hl7.org/CodeSystem/two]");
-
+        assertThat(condition.getIdentifier().get(1).getValue()).isEqualTo("one"); //DG1.20.1
+        assertThat(condition.getIdentifier().get(1).getSystem())
+                .isEqualTo("https://terminology.hl7.org/CodeSystem/two"); // DG1.20.2
         // Test 3rd identifier.
-        Base identifierThree = identifierList.get(2);
-        // value = DG1.20.3
-        assertThat(ResourceUtils.getValueAsString(identifierThree, "value")).isEqualTo("three");
-        // system = DG1.20.4
-        assertThat(ResourceUtils.getValueAsString(identifierThree, "system"))
-                .isEqualTo("UriType[https://terminology.hl7.org/CodeSystem/four]");
-
+        assertThat(condition.getIdentifier().get(2).getValue()).isEqualTo("three"); //DG1.20.3
+        assertThat(condition.getIdentifier().get(2).getSystem())
+                .isEqualTo("https://terminology.hl7.org/CodeSystem/four"); // DG1.20.4
     }
 
     // Tests multiple DG1 segments to verify we get multiple conditions with
@@ -236,40 +203,34 @@ class HL7ConditionFHIRConversionTest {
 
         // Check the Code of each condition
         Condition condition = (Condition) conditionResource.get(0);
-        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCode(), "V72.83", "Other specified pre-operative examination",
-        "http://terminology.hl7.org/CodeSystem/icd9", "Other specified pre-operative examination");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCode(), "V72.83",
+                "Other specified pre-operative examination",
+                "http://terminology.hl7.org/CodeSystem/icd9", "Other specified pre-operative examination");
 
         condition = (Condition) conditionResource.get(1);
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCode(), "R00.0", "Tachycardia, unspecified",
-        "http://hl7.org/fhir/sid/icd-10-cm", "Tachycardia, unspecified");
+                "http://hl7.org/fhir/sid/icd-10-cm", "Tachycardia, unspecified");
 
         condition = (Condition) conditionResource.get(2);
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCode(), "R06.02", "Shortness of breath",
-        "http://hl7.org/fhir/sid/icd-10-cm", "Shortness of breath");
+                "http://hl7.org/fhir/sid/icd-10-cm", "Shortness of breath");
 
         // Verify encounter reference exists
-        Base encounterProp = ResourceUtils.getValue(condition, "encounter");
-        assertThat(ResourceUtils.getValueAsString(encounterProp, "reference").substring(0, 10)).isEqualTo("Encounter/");
+        assertThat(condition.getEncounter().getReference().substring(0, 10)).isEqualTo("Encounter/");
 
-        //------------------------------------------------------//
+        // --- ENCOUNTER TESTS ---
 
         // Find the encounter from the FHIR bundle.
         List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); //Verify we only have 1 encounter
+        Encounter encounter = (Encounter) encounterResource.get(0);
 
-        //Verify we only have 1 encounter
-        assertThat(encounterResource).hasSize(1);
+        // Verify encounter.reasonReference has a reference for each of the 3 conditions.
+        assertThat(encounter.getReasonReference()).hasSize(3);
 
-        // Get the encounter resource
-        Base encounter = encounterResource.get(0);
-
-        // Verify encounter.reasonReference has a reference for each condition.
-        List<Base> reasonReferences = encounter.getNamedProperty("reasonReference").getValues();
-        // Therefore there should be 3.
-        assertThat(reasonReferences).hasSize(3);
-
-        // And the references should be referencing conditions
-        for (Base reasonReference : reasonReferences) {
-            assertThat(ResourceUtils.getValueAsString(reasonReference, "reference").substring(0, 10))
+        // Check the references are referencing conditions
+        for (int i = 0; i < 3; i++) {
+            assertThat(encounter.getReasonReference().get(i).getReference().substring(0, 10))
                     .isEqualTo("Condition/");
         }
 
@@ -302,49 +263,32 @@ class HL7ConditionFHIRConversionTest {
         assertThat(conditionResource).hasSize(8);
 
         // Find the encounter from the FHIR bundle.
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); //Verify we only have 1 encounter
+        Encounter encounter = (Encounter) encounterResource.get(0);
 
-        //Verify we only have 1 encounter
-        assertThat(encounterResource).hasSize(1);
-
-        // Get the encounter resource
-        Base encounter = encounterResource.get(0);
-
-        // Verify reasonReference has a reference for each condition.
-        List<Base> reasonReferences = encounter.getNamedProperty("reasonReference").getValues();
-        // Therefore there should be 8.
-        assertThat(reasonReferences).hasSize(8);
-
-        // And the references should be referencing conditions
-        for (Base reasonReference : reasonReferences) {
-            assertThat(ResourceUtils.getValueAsString(reasonReference, "reference").substring(0, 10))
+        // Verify reasonReference has a reference for each condition. Therefore there should be 8.
+        assertThat(encounter.getReasonReference()).hasSize(8);
+        // Check the references are referencing conditions
+        for (int i = 0; i < 8; i++) {
+            assertThat(encounter.getReasonReference().get(i).getReference().substring(0, 10))
                     .isEqualTo("Condition/");
         }
 
-        // Verify there is encounter.diagnosis for every diagnosis
-        List<Base> diagnosises = encounter.getNamedProperty("diagnosis").getValues();
-        // Therefore there should be 8.
-        assertThat(diagnosises).hasSize(8);
+        // Verify there is encounter.diagnosis for every diagnosis. Therefore there should be 8.
+        assertThat(encounter.getDiagnosis()).hasSize(8);
 
         // Verify each diagnosis is set correctly.
-        for (Base diagnosis : diagnosises) {
-
-            Base use = ResourceUtils.getValue(diagnosis, "use");
-            Base diagCoding = ResourceUtils.getValue(use, "coding");
-            assertThat(ResourceUtils.getValueAsString(diagCoding, "system"))
-                    .isEqualTo("UriType[http://terminology.hl7.org/CodeSystem/diagnosis-role]");
-            assertThat(ResourceUtils.getValueAsString(diagCoding, "code")).isEqualTo("AD");
-            assertThat(ResourceUtils.getValueAsString(diagCoding, "display")).isEqualTo("Admission diagnosis");
-
-            // Verify encounter diagnosis rank is set correctly.
-            assertThat(ResourceUtils.getValueAsString(diagnosis, "rank")).isEqualTo("PositiveIntType[8]");
-
+        for (int i = 0; i < 8; i++) {
             // Diagnosis requires a reference to condition.
-            Base conditionRef = ResourceUtils.getValue(encounter, "reasonReference");
-            assertThat(ResourceUtils.getValueAsString(conditionRef, "reference").substring(0, 10))
+            assertThat(encounter.getDiagnosis().get(i).getCondition().getReference().substring(0, 10))
                     .isEqualTo("Condition/");
+            // Verify Use coding of each diagnosis
+            DatatypeUtils.checkCommonCodeableConceptAssertions(encounter.getDiagnosis().get(i).getUse(), "AD",
+                    "Admission diagnosis",
+                    "http://terminology.hl7.org/CodeSystem/diagnosis-role", null);
+            // Verify encounter diagnosis rank is set correctly.
+            assertThat(encounter.getDiagnosis().get(i).getRank()).isEqualTo(8); // DG1.15
         }
 
     }
@@ -388,71 +332,62 @@ class HL7ConditionFHIRConversionTest {
 
         String hl7message = msh + "PID||||||||||||||||||||||||||||||\r"
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|20180310074000||||confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status|remission^Remission^http://terminology.hl7.org/CodeSystem/condition-clinical|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
+                // PRB broken into multiple lines for readability
+                // PRB.1 to PRB.4 required
+                // PRB.2 to Recorded DateTime
+                // PRB.7 for extension assertionDate
+                // PRB.9 to Abatement DateTime
+                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|||20100907175347||20180310074000|||"
+                // PRB.13 for verificationStatus
+                + "|confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status||"
+                // PRB.16 prereq for PRB.17
+                // PRB.17 for Onset detail
+                // PRB.26 for severity
+                + "|20170102074000|textual representation of the time when the problem began|||||||||some prb detail|\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.
         List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionResource).hasSize(1);
-
-        // Get the condition Resource
-        Resource condition = conditionResource.get(0);
+        Condition condition = (Condition) conditionResource.get(0);
 
         // Verify recorded date is set correctly.
-        assertThat(ResourceUtils.getValueAsString(condition, "recordedDate"))
-                .isEqualTo("DateTimeType[2017-01-10T07:40:00+08:00]");
+        assertThat(condition.getRecordedDateElement().toString()).containsPattern("2017-01-10T07:40:00"); // PRB.2
 
         // Verify abatement date is set correctly.
-        assertThat(ResourceUtils.getValueAsString(condition, "abatementDateTime"))
-                .isEqualTo("DateTimeType[2018-03-10T07:40:00+08:00]");
+        assertThat(condition.getAbatement().toString()).containsPattern("2018-03-10T07:40:00"); // PRB.9
 
-        // Verify verification status text is set correctly.
-        Base verificationStatus = ResourceUtils.getValue(condition, "verificationStatus");
-        assertThat(ResourceUtils.getValueAsString(verificationStatus, "text")).isEqualTo("Confirmed");
-
-        // Verify verification status coding is set correctly
-        Base coding = ResourceUtils.getValue(verificationStatus, "coding");
-        assertThat(ResourceUtils.getValueAsString(coding, "system"))
-                .isEqualTo("UriType[http://terminology.hl7.org/CodeSystem/condition-ver-status]");
-        assertThat(ResourceUtils.getValueAsString(coding, "display")).isEqualTo("Confirmed");
-        assertThat(ResourceUtils.getValueAsString(coding, "code")).isEqualTo("confirmed");
+        // Verify verificationStatus text and coding
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getVerificationStatus(), "confirmed", "Confirmed",
+                "http://terminology.hl7.org/CodeSystem/condition-ver-status", "Confirmed"); // PRB.13
 
         // Verify onset string is set correctly (PRB.17). Only present if PRB.16 is
         // present. In this test case it is.
-        assertThat(ResourceUtils.getValueAsString(condition, "onset"))
-                .isEqualTo("DateTimeType[2017-01-02T07:40:00+08:00]");
+        assertThat(condition.getOnset().toString()).containsPattern("2017-01-02T07:40:00"); // PRB.17
 
         // Verify encounter reference exists
-        Base encounter = ResourceUtils.getValue(condition, "encounter");
-        assertThat(ResourceUtils.getValueAsString(encounter, "reference").substring(0, 10)).isEqualTo("Encounter/");
+        assertThat(condition.getEncounter().getReference().substring(0, 10)).isEqualTo("Encounter/");
 
         // Verify subject reference to Patient exists
-        Base subject = ResourceUtils.getValue(condition, "subject");
-        assertThat(ResourceUtils.getValueAsString(subject, "reference").substring(0, 8)).isEqualTo("Patient/");
+        assertThat(condition.getSubject().getReference().substring(0, 8)).isEqualTo("Patient/");
 
-        // Verify category text is set correctly.
-        Base category = ResourceUtils.getValue(condition, "category");
-        assertThat(ResourceUtils.getValueAsString(category, "text")).isEqualTo("Problem List Item");
-
-        // Verify category coding fields are set correctly.
-        Base catCoding = ResourceUtils.getValue(category, "coding");
-        assertThat(ResourceUtils.getValueAsString(catCoding, "system"))
-                .isEqualTo("UriType[http://terminology.hl7.org/CodeSystem/condition-category]");
-        assertThat(ResourceUtils.getValueAsString(catCoding, "display")).isEqualTo("Problem List Item");
-        assertThat(ResourceUtils.getValueAsString(catCoding, "code")).isEqualTo("problem-list-item");
+        // Verify category text and coding are set correctly.
+        assertThat(condition.getCategory()).hasSize(1);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCategoryFirstRep(), "problem-list-item",
+                "Problem List Item",
+                "http://terminology.hl7.org/CodeSystem/condition-category", "Problem List Item"); // PRB.3
 
         // Verify extension is set correctly.
-        Base extension = ResourceUtils.getValue(condition, "extension");
-        assertThat(ResourceUtils.getValueAsString(extension, "url"))
-                .isEqualTo("UriType[http://hl7.org/fhir/StructureDefinition/condition-assertedDate]");
-        assertThat(ResourceUtils.getValueAsString(extension, "valueDateTime"))
-                .isEqualTo("DateTimeType[2010-09-07T17:53:47+08:00]");
+
+        assertThat(condition.getExtension()).hasSize(1);
+        assertThat(condition.getExtension().get(0).getUrl())
+                .isEqualTo("http://hl7.org/fhir/StructureDefinition/condition-assertedDate");
+        assertThat(condition.getExtension().get(0).getValue().toString()).containsPattern("2010-09-07T17:53:47"); // PRB.7
 
         // Verify severity code is set correctly.
-        Base severity = ResourceUtils.getValue(condition, "severity");
-        Base sevCoding = ResourceUtils.getValue(severity, "coding");
-        assertThat(ResourceUtils.getValueAsString(sevCoding, "code")).isEqualTo("some prb detail");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getSeverity(), "some prb detail", null, null,
+                null); // PRB.26
 
     }
 
@@ -467,7 +402,10 @@ class HL7ConditionFHIRConversionTest {
 
         String hl7message = msh + "PID||||||||||||||||||||||||||||||\r"
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|20180310074000||||confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status|remission^Remission^http://terminology.hl7.org/CodeSystem/condition-clinical|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
+                // // PRB broken into multiple lines for readability
+                // // PRB.1 to PRB.4 required
+                // // PRB.14 for clinical Status
+                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||remission^Remission^http://terminology.hl7.org/CodeSystem/condition-clinical|||||||||||||\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -478,11 +416,11 @@ class HL7ConditionFHIRConversionTest {
 
         // Verify code is set correctly.
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getCode(), "K80.00", "Cholelithiasis",
-                "http://hl7.org/fhir/sid/icd-10-cm", "Cholelithiasis");
+                "http://hl7.org/fhir/sid/icd-10-cm", "Cholelithiasis"); // PRB.3
 
         // Verify clinicalStatus is set correctly
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getClinicalStatus(), "remission", "Remission",
-                "http://terminology.hl7.org/CodeSystem/condition-clinical", "Remission");
+                "http://terminology.hl7.org/CodeSystem/condition-clinical", "Remission"); //PRB.14
 
     }
 
@@ -492,7 +430,7 @@ class HL7ConditionFHIRConversionTest {
     @ValueSource(strings = {
             // CASE 1:
             // PRB.1 to PRB.4 required
-            // PRB.9 is EMPTY so B.14 does not activate a Resolved clinicalStatus
+            // PRB.9 is EMPTY so PRB.14 does not activate a Resolved clinicalStatus
             // PRB.14 is INVALID with 'BAD' so clinicalStatus is omitted
             // PRB.13 is EMPTY so verificationStatus is omitted
             "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||BAD^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status|||||||||||||\r",
@@ -500,7 +438,7 @@ class HL7ConditionFHIRConversionTest {
             // For verificationStatus 'C^Confirmed^Confirmation Status List':
             // because 'C' is not a valid code we should be omitting this optional field.
             // PRB.1 to PRB.4 required
-            // PRB.9 is EMPTY so B.14 does not activate a Resolved clinicalStatus
+            // PRB.9 is EMPTY soPRB.14 does not activate a Resolved clinicalStatus
             // PRB.14 is INVALID with 'C' so clinicalStatus is omitted
             // PRB.13 is EMPTY so verificationStatus is omitted
             "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||C^Confirmed^Confirmation Status List|||||||||||||\r",
@@ -544,7 +482,11 @@ class HL7ConditionFHIRConversionTest {
 
         String hl7message = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\r"
                 + "PID||||||||||||||||||||||||||||||\r" + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||confirmed|remission|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
+                // PRB.1 to PRB.4 required
+                // PRB.9 is EMPTY so PRB.14 does not activate a Resolved clinicalStatus
+                // PRB.13 to verificationStatus
+                // PRB.14 to clinicalStatus
+                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|||||||||confirmed|remission|\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -555,11 +497,11 @@ class HL7ConditionFHIRConversionTest {
 
         // Verify verificationStatus has a coding but no text
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getVerificationStatus(), "confirmed", "Confirmed",
-                "http://terminology.hl7.org/CodeSystem/condition-ver-status", null);
+                "http://terminology.hl7.org/CodeSystem/condition-ver-status", null); // PRB.13
 
         // Verify clinicalStatus has a coding but no text
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getClinicalStatus(), "remission", "Remission",
-                "http://terminology.hl7.org/CodeSystem/condition-clinical", null);
+                "http://terminology.hl7.org/CodeSystem/condition-clinical", null); // PRB.14
 
     }
 
@@ -572,7 +514,10 @@ class HL7ConditionFHIRConversionTest {
         String hl7message = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\r"
                 + "PID||||||||||||||||||||||||||||||\r"
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||confirmed^Confirmed^Confirmation Status List||textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
+                // PRB.1 to PRB.4 required
+                // PRB.9 is EMPTY so PRB.14 does not activate a Resolved clinicalStatus
+                // PRB.13 to verificationStatus
+                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|||||||||confirmed^Confirmed^Confirmation Status List||\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -583,7 +528,7 @@ class HL7ConditionFHIRConversionTest {
 
         // Verify verificationStatus has a coding and text
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getVerificationStatus(), "confirmed", "Confirmed",
-                "http://terminology.hl7.org/CodeSystem/condition-ver-status", "Confirmed");
+                "http://terminology.hl7.org/CodeSystem/condition-ver-status", "Confirmed"); // PRB.13
 
     }
 
@@ -595,7 +540,11 @@ class HL7ConditionFHIRConversionTest {
         String hl7message = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\r"
                 + "PID||||||||||||||||||||||||||||||\r"
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|20180310074000||||confirmed^Confirmed^BADCLINCALSTATUSSYSTEM|remission^Remission^BADVERIFICATIONSTATUSSYSTEM|20180310074000|20170102074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
+                // PRB.1 to PRB.4 required
+                // PRB.9 is EMPTY so PRB.14 does not activate a Resolved clinicalStatus
+                // PRB.13 to verificationStatus
+                // PRB.14 to clinicalStatus
+                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|||||||||confirmed^Confirmed^BADCLINCALSTATUSSYSTEM|remission^Remission^BADVERIFICATIONSTATUSSYSTEM|\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -606,11 +555,11 @@ class HL7ConditionFHIRConversionTest {
 
         // Verify verificationStatus has a coding with correct system and text
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getVerificationStatus(), "confirmed", "Confirmed",
-                "http://terminology.hl7.org/CodeSystem/condition-ver-status", "Confirmed");
+                "http://terminology.hl7.org/CodeSystem/condition-ver-status", "Confirmed"); // PRB.13
 
         // Verify clinicalStatus has a coding with correct system  and text
         DatatypeUtils.checkCommonCodeableConceptAssertions(condition.getClinicalStatus(), "remission", "Remission",
-                "http://terminology.hl7.org/CodeSystem/condition-clinical", "Remission");
+                "http://terminology.hl7.org/CodeSystem/condition-clinical", "Remission"); // PRB.14
 
     }
 
@@ -636,7 +585,8 @@ class HL7ConditionFHIRConversionTest {
 
         String hl7message = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\r"
                 + "PID||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20210101000000|G47.31^Primary central sleep apnea^ICD-10-CM|28827016|||20210101000000|20210101000000|||||confirmed^Confirmed^http://terminology.hl7.org/CodeSystem/condition-ver-status||20210101000000|20210101000000\r";
+                // PRB.1 to PRB.4 required
+                + "PRB|AD|20210101000000|G47.31^Primary central sleep apnea^ICD-10-CM|28827016|\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -673,14 +623,19 @@ class HL7ConditionFHIRConversionTest {
     // Tests that onset[x] is set to PRB.16 if it is present and PRB.17 is present.
     @ParameterizedTest
     @ValueSource(strings = {
-            "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||||20180310074000|20180310074000||1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r",
-            "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||||20180310074000|20180310074000|textual representation of the time when the problem began|1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r" })
-    void validateProblemWithOnsetDateTimeWithNoOnsetString() {
+            // PRB.1 to PRB.4 required
+            // PRB.16 to onset date
+            // PRB.17 purposely empty 
+            "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||||20180310074000||\r",
+            // PRB.1 to PRB.4 required
+            // PRB.16 to onset date
+            // PRB.17 purposely empty 
+            "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||||20180310074000|textual representation of the time when the problem began|\r" })
+    void validateProblemWithOnsetDateTimeWithNoOnsetString(String segmentPRB) {
 
         String hl7message = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\r"
                 + "PID||||||||||||||||||||||||||||||\r"
-                + "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956|E1|1|20100907175347|20150907175347|||||||20180310074000|20180310074000||1^primary|ME^Medium|0.4|marginal|good|marginal|marginal|highly sensitive|some prb detail|\r";
-
+                + segmentPRB;
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the condition from the FHIR bundle.

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
@@ -438,7 +438,7 @@ class HL7ConditionFHIRConversionTest {
             // For verificationStatus 'C^Confirmed^Confirmation Status List':
             // because 'C' is not a valid code we should be omitting this optional field.
             // PRB.1 to PRB.4 required
-            // PRB.9 is EMPTY soPRB.14 does not activate a Resolved clinicalStatus
+            // PRB.9 is EMPTY so PRB.14 does not activate a Resolved clinicalStatus
             // PRB.14 is INVALID with 'C' so clinicalStatus is omitted
             // PRB.13 is EMPTY so verificationStatus is omitted
             "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||C^Confirmed^Confirmation Status List|||||||||||||\r",
@@ -629,7 +629,7 @@ class HL7ConditionFHIRConversionTest {
             "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||||20180310074000||\r",
             // PRB.1 to PRB.4 required
             // PRB.16 to onset date
-            // PRB.17 purposely empty 
+            // PRB.17 present
             "PRB|AD|20170110074000|K80.00^Cholelithiasis^I10|53956||||||||||||20180310074000|textual representation of the time when the problem began|\r" })
     void validateProblemWithOnsetDateTimeWithNoOnsetString(String segmentPRB) {
 
@@ -643,11 +643,10 @@ class HL7ConditionFHIRConversionTest {
         assertThat(conditionResource).hasSize(1);
 
         // Get the condition Resource
-        Resource condition = conditionResource.get(0);
+        Condition condition = (Condition) conditionResource.get(0);
 
         // Verify onset is set correctly to PRB.16
-        assertThat(ResourceUtils.getValueAsString(condition, "onset"))
-                .isEqualTo("DateTimeType[2018-03-10T07:40:00+08:00]");
+        assertThat(condition.getOnset().toString()).containsPattern("2018-03-10T07:40:00"); // PRB.16
 
     }
 


### PR DESCRIPTION
This handles that if PRB.9 is set and PRB.14 is EMPTY or INVALID, default Condition.clinicalStatus to "resolved"

The tests were added.  The test file needed updates to best practices.  Pretty big overhaul.
To find the new tests, look at the last two.

@LisaWellman  tag