### PR TITLE
Remove pervasive SonarQube "public" method smell

### DIFF
--- a/src/test/java/io/github/linuxforhealth/core/terminology/TerminologyLookupTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/terminology/TerminologyLookupTest.java
@@ -9,10 +9,10 @@ package io.github.linuxforhealth.core.terminology;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
-public class TerminologyLookupTest {
+class TerminologyLookupTest {
 
   @Test
-  public void test() {
+  void test() {
     SimpleCode code =
         TerminologyLookup.lookup("v2-0396", "ICD10GM2012");
     assertThat(code).isNotNull();

--- a/src/test/java/io/github/linuxforhealth/hl7/data/DateUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/DateUtilTest.java
@@ -11,76 +11,76 @@ import org.junit.jupiter.api.Test;
 
 import io.github.linuxforhealth.hl7.data.date.DateUtil;
 
-public class DateUtilTest {
+class DateUtilTest {
 
     @Test
-    public void simple_date() {
+    void simple_date() {
         String ld = DateUtil.formatToDate("2008");
         assertThat(ld).isEqualTo("2008");
     }
 
     @Test
-    public void simple_date_month() {
+    void simple_date_month() {
         String ld = DateUtil.formatToDate("200809");
         assertThat(ld).isEqualTo("2008-09");
     }
 
     @Test
-    public void simple_date_month_day() {
+    void simple_date_month_day() {
         String ld = DateUtil.formatToDate("20080926");
         assertThat(ld).isEqualTo("2008-09-26");
     }
 
     @Test
-    public void simple_date_month_day_hour() {
+    void simple_date_month_day_hour() {
         String ld = DateUtil.formatToDate("2008092609");
         assertThat(ld).isEqualTo("2008-09-26");
     }
 
     @Test
-    public void simple_date_month_day_zone() {
+    void simple_date_month_day_zone() {
         String ld = DateUtil.formatToDate("200711040132-0400");
         assertThat(ld).isEqualTo("2007-11-04");
     }
 
     @Test
-    public void simple_date_month_day_milliseconds_zone() {
+    void simple_date_month_day_milliseconds_zone() {
         String ld = DateUtil.formatToDate("20071104013206.345-0400");
         assertThat(ld).isEqualTo("2007-11-04");
     }
 
     @Test
-    public void simple_datetime() {
+    void simple_datetime() {
         String ld = DateUtil.formatToDateTimeWithZone("2008");
         assertThat(ld).isEqualTo("2008");
     }
 
     @Test
-    public void simple_datetime_month() {
+    void simple_datetime_month() {
         String ld = DateUtil.formatToDateTimeWithZone("200809");
         assertThat(ld).isEqualTo("2008-09");
     }
 
     @Test
-    public void simple_dateime_month_day() {
+    void simple_dateime_month_day() {
         String ld = DateUtil.formatToDateTimeWithZone("20080926");
         assertThat(ld).isEqualTo("2008-09-26");
     }
 
     @Test
-    public void simple_datetime_month_day_hour() {
+    void simple_datetime_month_day_hour() {
         String ld = DateUtil.formatToDateTimeWithZone("2008092609");
         assertThat(ld).isEqualTo("2008-09-26T09:00:00+08:00");
     }
 
     @Test
-    public void simple_datetime_month_day_zone() {
+    void simple_datetime_month_day_zone() {
         String ld = DateUtil.formatToDateTimeWithZone("200711040132-0400");
         assertThat(ld).isEqualTo("2007-11-04T01:32:00-04:00");
     }
 
     @Test
-    public void simple_datetime_month_day_milliseconds_zone() {
+    void simple_datetime_month_day_milliseconds_zone() {
         String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3+0900");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+09:00");
 
@@ -95,7 +95,7 @@ public class DateUtilTest {
     }
 
     @Test
-    public void simple_datetime_month_day_milliseconds_no_zone() {
+    void simple_datetime_month_day_milliseconds_no_zone() {
         String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+08:00");
 

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7DataHandlerUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7DataHandlerUtilTest.java
@@ -20,24 +20,24 @@ import ca.uhn.hl7v2.model.v26.group.ORU_R01_ORDER_OBSERVATION;
 import ca.uhn.hl7v2.model.v26.message.ORU_R01;
 import ca.uhn.hl7v2.model.v26.segment.OBX;
 
-public class Hl7DataHandlerUtilTest {
+class Hl7DataHandlerUtilTest {
 
     private static final String SOME_TEXT_VALUE = "SOME TEXT VALUE";
     private static final String SOME_OTHER_TEXT_VALUE = "SOME OTHER TEXT VALUE";
 
     @Test
-    public void test_getStringValue_returns_value() {
+    void test_getStringValue_returns_value() {
         String value = "any string value";
         assertThat(Hl7DataHandlerUtil.getStringValue(value)).isEqualTo(value);
     }
 
     @Test
-    public void test_getStringValue_returns_null_for_null_input() {
+    void test_getStringValue_returns_null_for_null_input() {
         assertThat(Hl7DataHandlerUtil.getStringValue(null)).isNull();
     }
 
     @Test
-    public void test_getStringValue_returns_value_for_hl7_primitive() throws DataTypeException {
+    void test_getStringValue_returns_value_for_hl7_primitive() throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         TX tx = new TX(message);
         tx.setValue(SOME_TEXT_VALUE);
@@ -45,7 +45,7 @@ public class Hl7DataHandlerUtilTest {
     }
 
     @Test
-    public void test_getStringValue_returns_value_for_hl7_compositive() throws DataTypeException {
+    void test_getStringValue_returns_value_for_hl7_compositive() throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         CWE ce = new CWE(message);
         ce.getIdentifier().setValue(SOME_TEXT_VALUE);
@@ -55,7 +55,7 @@ public class Hl7DataHandlerUtilTest {
     }
 
     @Test
-    public void test_getStringValue_returns_value_for_hl7_compositive_all_components()
+    void test_getStringValue_returns_value_for_hl7_compositive_all_components()
             throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         CWE ce = new CWE(message);
@@ -67,7 +67,7 @@ public class Hl7DataHandlerUtilTest {
     }
 
     @Test
-    public void test_getStringValue_returns_value_for_hl7_varies() throws DataTypeException {
+    void test_getStringValue_returns_value_for_hl7_varies() throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         ORU_R01_ORDER_OBSERVATION orderObservation = message.getPATIENT_RESULT().getORDER_OBSERVATION();
         ORU_R01_OBSERVATION observation = orderObservation.getOBSERVATION(0);
@@ -80,7 +80,7 @@ public class Hl7DataHandlerUtilTest {
     }
 
     @Test
-    public void test_getStringValue_returns_value_for_list_of_hl7_compositive()
+    void test_getStringValue_returns_value_for_list_of_hl7_compositive()
             throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         CWE ce = new CWE(message);
@@ -97,7 +97,7 @@ public class Hl7DataHandlerUtilTest {
     }
 
     @Test
-    public void test_getStringValue_returns_value_for_list_of_hl7_compositive_all_components()
+    void test_getStringValue_returns_value_for_list_of_hl7_compositive_all_components()
             throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         CWE ce = new CWE(message);

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -15,12 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Hl7RelatedGeneralUtilsTest {
+class Hl7RelatedGeneralUtilsTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7RelatedGeneralUtilsTest.class);
 
     @Test
-    public void testConcatenateWithChar() {
+    void testConcatenateWithChar() {
 
         ArrayList<Object> objects = new ArrayList<Object>();
         String st = "AA";
@@ -51,48 +51,48 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_generate_name() {
+    void test_generate_name() {
         String name = Hl7RelatedGeneralUtils.generateName("prefix", "first", "M", "family", "suffix");
         assertThat(name).isEqualTo("prefix first M family suffix");
         LOGGER.debug("name=" + name);
     }
 
     @Test
-    public void test_generate_name_prefix_suffix_missing() {
+    void test_generate_name_prefix_suffix_missing() {
         String name = Hl7RelatedGeneralUtils.generateName(null, "first", "M", "family", null);
         assertThat(name).isEqualTo("first M family");
     }
 
     @Test
-    public void test_get_encounter_var1() {
+    void test_get_encounter_var1() {
         // if var1 is not null then EncounterStatus.FINISHED
         String name = Hl7RelatedGeneralUtils.getEncounterStatus("var1", "var2", "var3");
         assertThat(name).isEqualTo(EncounterStatus.FINISHED.toCode());
     }
 
     @Test
-    public void test_get_encounter_var2() {
+    void test_get_encounter_var2() {
 
         String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, "var2", "var3");
         assertThat(name).isEqualTo(EncounterStatus.ARRIVED.toCode());
     }
 
     @Test
-    public void test_get_encounter_var3() {
+    void test_get_encounter_var3() {
 
         String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, null, "var3");
         assertThat(name).isEqualTo(EncounterStatus.CANCELLED.toCode());
     }
 
     @Test
-    public void test_get_encounter_all_vars_null() {
+    void test_get_encounter_all_vars_null() {
 
         String name = Hl7RelatedGeneralUtils.getEncounterStatus(null, null, null);
         assertThat(name).isEqualTo(EncounterStatus.UNKNOWN.toCode());
     }
 
     @Test
-    public void test_date_diff_valid_values_same_dates() {
+    void test_date_diff_valid_values_same_dates() {
 
         long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
                 "2007-11-04T01:32:06.345+09:00");
@@ -100,7 +100,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_date_diff_valid_values_1min_ahead() {
+    void test_date_diff_valid_values_1min_ahead() {
 
         long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:32:06.345+09:00",
                 "2007-11-04T01:33:06.345+09:00");
@@ -108,7 +108,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_date_diff_valid_values_no_min() {
+    void test_date_diff_valid_values_no_min() {
 
         Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-05",
                 "2007-11-04T01:33:06.345+20:00");
@@ -116,14 +116,14 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_date_diff_null_values() {
+    void test_date_diff_null_values() {
 
         Long diff = Hl7RelatedGeneralUtils.diffDateMin(null, "2007-11-04T01:33:06.345+09:00");
         assertThat(diff).isNull();
     }
 
     @Test
-    public void test_date_diff_incorrect_date_format() {
+    void test_date_diff_incorrect_date_format() {
 
         Long diff = Hl7RelatedGeneralUtils.diffDateMin("2007-11-04T01:33:06890",
                 "2007-11-04T01:33:06.345+09:00");
@@ -131,7 +131,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_splitting_values() {
+    void test_splitting_values() {
 
         String val = Hl7RelatedGeneralUtils.split("5.9-8.4", "-", 0);
         assertThat(val).isEqualTo("5.9");
@@ -140,7 +140,7 @@ public class Hl7RelatedGeneralUtilsTest {
     // ExtractHigh and ExtractLow assumes if there are two or more values, the first is low, the second is high,
     // but if there is only one value, it is the high
     @Test
-    public void testExtractHigh() {
+    void testExtractHigh() {
 
         String aString = "27.0-55.2";
         String resultValue = Hl7RelatedGeneralUtils.extractHigh(aString);
@@ -168,7 +168,7 @@ public class Hl7RelatedGeneralUtilsTest {
     // the first is low, the second is high, but if there is only one value, it is the high
     // See extensive notes near the methods. 
     @Test
-    public void testExtractLow() {
+    void testExtractLow() {
 
         String aString = "27.0-55.2";
         String resultValue = Hl7RelatedGeneralUtils.extractLow(aString);
@@ -193,7 +193,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_makeStringArray() {
+    void test_makeStringArray() {
         // Test for 2
         List<String> stringArray = Hl7RelatedGeneralUtils.makeStringArray("banana", "peach");
         assertThat(stringArray.size()).isEqualTo(2);
@@ -208,7 +208,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_getAddressUse() {
+    void test_getAddressUse() {
         String ANYTHING = "anything";
         // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", ANYTHING)).isEqualTo("temp");
@@ -256,7 +256,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_getAddressType() {
+    void test_getAddressType() {
         String ANYTHING = "anything";
         // Inputs are XAD.7 Type, XAD.18 Type 
         assertThat(Hl7RelatedGeneralUtils.getAddressType(ANYTHING, "M")).isEqualTo("postal");
@@ -277,7 +277,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void test_getAddressDistrict() {
+    void test_getAddressDistrict() {
         String ANYTHING = "anything";
 
         // Inputs are XAD.7 Type, XAD.18 Type 
@@ -292,7 +292,7 @@ public class Hl7RelatedGeneralUtilsTest {
     // Note: Utility  Hl7RelatedGeneralUtils.getAddressDistrict is more effectively tested as part of Patient Address testing
 
     @Test
-    public void getFormattedTelecomNumberValue() {
+    void getFormattedTelecomNumberValue() {
         // Empty values return nothing
         assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("", "", "", "", "", "")).isEmpty();
         // Everything empty except XTN1 returns XTN1.
@@ -351,7 +351,7 @@ public class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    public void testGetFormatAsId() {
+    void testGetFormatAsId() {
 
         // Inputs are any string
         assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -31,12 +31,12 @@ import ca.uhn.hl7v2.model.v26.segment.PV1;
 import io.github.linuxforhealth.core.terminology.SimpleCode;
 import io.github.linuxforhealth.hl7.data.date.DateUtil;
 
-public class SimpleDataValueResolverTest {
+class SimpleDataValueResolverTest {
 
     private static final String VALID_UUID = "48ed55de-36be-4358-8ab6-4332c4a611ed";
 
     @Test
-    public void get_string_value() throws DataTypeException {
+    void get_string_value() throws DataTypeException {
         ORU_R01 message = new ORU_R01();
         TX tx = new TX(message);
         tx.setValue("some value");
@@ -44,44 +44,44 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void get_adm_gender_value() {
+    void get_adm_gender_value() {
         String gen = "F";
         assertThat(SimpleDataValueResolver.ADMINISTRATIVE_GENDER_CODE_FHIR.apply(gen)).isEqualTo("female");
     }
 
     @Test
-    public void get_adm_gender_value_unknow() {
+    void get_adm_gender_value_unknow() {
         String gen = "ABC";
         assertThat(SimpleDataValueResolver.ADMINISTRATIVE_GENDER_CODE_FHIR.apply(gen)).isEqualTo("unknown");
     }
 
     @Test
-    public void get_boolean_value_non_boolean() {
+    void get_boolean_value_non_boolean() {
         String gen = "ABC";
         assertThat(SimpleDataValueResolver.BOOLEAN.apply(gen)).isFalse();
     }
 
     @Test
-    public void get_boolean_value_true() {
+    void get_boolean_value_true() {
         String gen = "True";
         assertThat(SimpleDataValueResolver.BOOLEAN.apply(gen)).isTrue();
     }
 
     @Test
-    public void get_date_value_valid() {
+    void get_date_value_valid() {
         String gen = "20091130";
         assertThat(SimpleDataValueResolver.DATE.apply(gen)).isNotNull();
         assertThat(SimpleDataValueResolver.DATE.apply(gen)).isEqualTo(DateUtil.formatToDate(gen));
     }
 
     @Test
-    public void get_date_value_null() {
+    void get_date_value_null() {
 
         assertThat(SimpleDataValueResolver.DATE.apply(null)).isNull();
     }
 
     @Test
-    public void get_datetime_value_valid() {
+    void get_datetime_value_valid() {
         String gen = "20110613122406";
         assertThat(SimpleDataValueResolver.DATE_TIME.apply(gen)).isNotNull();
         assertThat(SimpleDataValueResolver.DATE_TIME.apply(gen)).isEqualTo(DateUtil.formatToDateTimeWithZone(gen));
@@ -93,65 +93,65 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void get_instant_value_null() {
+    void get_instant_value_null() {
         assertThat(SimpleDataValueResolver.INSTANT.apply(null)).isNull();
     }
 
     @Test
-    public void get_instant_value_valid() {
+    void get_instant_value_valid() {
         String gen = "20091130112038";
         assertThat(SimpleDataValueResolver.INSTANT.apply(gen)).isNotNull();
         assertThat(SimpleDataValueResolver.INSTANT.apply(gen)).isEqualTo(DateUtil.formatToZonedDateTime(gen));
     }
 
     @Test
-    public void get_datetime_value_null() {
+    void get_datetime_value_null() {
         assertThat(SimpleDataValueResolver.DATE_TIME.apply(null)).isNull();
     }
 
     @Test
-    public void get_float_value_valid() {
+    void get_float_value_valid() {
         String gen = "123";
         assertThat(SimpleDataValueResolver.FLOAT.apply(gen)).isEqualTo(123.0F);
     }
 
     @Test
-    public void get_float_value_null() {
+    void get_float_value_null() {
         assertThat(SimpleDataValueResolver.FLOAT.apply(null)).isNull();
     }
 
     @Test
-    public void get_float_value_invalid() {
+    void get_float_value_invalid() {
         String gen = "abc";
         assertThat(SimpleDataValueResolver.FLOAT.apply(gen)).isNull();
     }
 
     @Test
-    public void get_integer_value_invalid() {
+    void get_integer_value_invalid() {
         String gen = "abc";
         assertThat(SimpleDataValueResolver.INTEGER.apply(gen)).isNull();
     }
 
     @Test
-    public void get_integer_value_valid() {
+    void get_integer_value_valid() {
         String gen = "123";
         assertThat(SimpleDataValueResolver.INTEGER.apply(gen)).isEqualTo(123);
     }
 
     @Test
-    public void get_integer_value_null() {
+    void get_integer_value_null() {
         assertThat(SimpleDataValueResolver.INTEGER.apply(null)).isNull();
     }
 
     @Test
-    public void get_observation_status_value_valid() {
+    void get_observation_status_value_valid() {
         String gen = "d";
         assertThat(SimpleDataValueResolver.OBSERVATION_STATUS_CODE_FHIR.apply(gen))
                 .isEqualTo(ObservationStatus.CANCELLED.toCode());
     }
 
     @Test
-    public void testObservationStatusValueNotValid() {
+    void testObservationStatusValueNotValid() {
         String gen = "ZZZ";
         SimpleCode code = SimpleDataValueResolver.OBSERVATION_STATUS_FHIR.apply(gen);
         assertThat(code).isNotNull();
@@ -162,20 +162,20 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void get_service_request_status_value_valid() {
+    void get_service_request_status_value_valid() {
         String gen = "SC";
         assertThat(SimpleDataValueResolver.SERVICE_REQUEST_STATUS.apply(gen))
                 .isEqualTo(ServiceRequestStatus.ACTIVE.toCode());
     }
 
     @Test
-    public void get_service_request_status_value_invalid() {
+    void get_service_request_status_value_invalid() {
         String gen = "z";
         assertThat(SimpleDataValueResolver.SERVICE_REQUEST_STATUS.apply(gen)).isNull();
     }
 
     @Test
-    public void testReligiousAffiliationValueValid() {
+    void testReligiousAffiliationValueValid() {
         String gen = "LUT";
         SimpleCode code = SimpleDataValueResolver.RELIGIOUS_AFFILIATION_FHIR_CC.apply(gen);
         assertThat(code.getDisplay()).isEqualTo(V3ReligiousAffiliation._1028.getDisplay());
@@ -184,7 +184,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void testReligiousAffiliationValueNonvalid() {
+    void testReligiousAffiliationValueNonvalid() {
         String gen = "ZZZ";
         SimpleCode code = SimpleDataValueResolver.RELIGIOUS_AFFILIATION_FHIR_CC.apply(gen);
         assertThat(code).isNotNull();
@@ -196,7 +196,7 @@ public class SimpleDataValueResolverTest {
 
     @Test
     // Tests one leg of CODING_SYSTEM_V2_IS_USER_DEFINED_TABLE that is not covered in other tests
-    public void testCodingSystemV2ISUserDefinedTable() {
+    void testCodingSystemV2ISUserDefinedTable() {
         String code = "ZZZ";
         SimpleCode coding = SimpleDataValueResolver.CODING_SYSTEM_V2_IS_USER_DEFINED_TABLE.apply(code);
         assertThat(coding).isNotNull();
@@ -206,7 +206,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void get_race_value_valid() throws DataTypeException {
+    void get_race_value_valid() throws DataTypeException {
         CWE cwe = new CWE(null);
         cwe.getCwe3_NameOfCodingSystem().setValue("HL70005");
         cwe.getCwe1_Identifier().setValue("2028-9");
@@ -219,7 +219,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void testMaritalStatusValueValid() {
+    void testMaritalStatusValueValid() {
         String gen = "A";
         SimpleCode coding = (SimpleCode) SimpleDataValueResolver.MARITAL_STATUS.apply(gen);
         assertThat(coding.getDisplay()).isEqualTo(V3MaritalStatus.A.getDisplay());
@@ -227,7 +227,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void testMaritalStatusValueNonValid() {
+    void testMaritalStatusValueNonValid() {
         String gen = "ZZZ";
         SimpleCode code = SimpleDataValueResolver.MARITAL_STATUS.apply(gen);
         assertThat(code).isNotNull();
@@ -238,52 +238,52 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void get_observation_status_value_invalid() {
+    void get_observation_status_value_invalid() {
         String gen = "ddx";
         assertThat(SimpleDataValueResolver.OBSERVATION_STATUS_CODE_FHIR.apply(gen)).isNull();
     }
 
     @Test
-    public void get_specimen_status_value_valid() {
+    void get_specimen_status_value_valid() {
         String gen = "Y";
         assertThat(SimpleDataValueResolver.SPECIMEN_STATUS_CODE_FHIR.apply(gen))
                 .isEqualTo(SpecimenStatus.AVAILABLE.toCode());
     }
 
     @Test
-    public void get_specimen_status_value_invalid() {
+    void get_specimen_status_value_invalid() {
         String gen = "x";
         assertThat(SimpleDataValueResolver.SPECIMEN_STATUS_CODE_FHIR.apply(gen)).isNull();
     }
 
     @Test
-    public void get_URI_value_valid() throws URISyntaxException {
+    void get_URI_value_valid() throws URISyntaxException {
         String gen = VALID_UUID;
         assertThat(SimpleDataValueResolver.URI_VAL.apply(gen)).isEqualTo(new URI("urn", "uuid", VALID_UUID));
     }
 
     @Test
-    public void get_URI_value_invalid() {
+    void get_URI_value_invalid() {
         String gen = "ddx";
         assertThat(SimpleDataValueResolver.URI_VAL.apply(gen)).isNull();
 
     }
 
     @Test
-    public void get_UUID_value_invalid() {
+    void get_UUID_value_invalid() {
         String gen = "ddx";
         assertThat(SimpleDataValueResolver.UUID_VAL.apply(gen)).isNull();
 
     }
 
     @Test
-    public void get_UUID_value_valid() {
+    void get_UUID_value_valid() {
         String gen = VALID_UUID;
         assertThat(SimpleDataValueResolver.UUID_VAL.apply(gen)).isEqualTo(UUID.fromString(VALID_UUID));
     }
 
     @Test
-    public void get_system_id_value_valid() {
+    void get_system_id_value_valid() {
         assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("ABC")).isEqualTo("urn:id:ABC");
         assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("A B C")).isEqualTo("urn:id:A_B_C");
         assertThat(SimpleDataValueResolver.SYSTEM_ID.apply("")).isNull();
@@ -291,7 +291,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void getDisplayNameValid() throws DataTypeException {
+    void getDisplayNameValid() throws DataTypeException {
         XCN xcn = new XCN(null);
         xcn.getPrefixEgDR().setValue("Dr");
         xcn.getGivenName().setValue("Joe");
@@ -303,7 +303,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void getDisplayNameNotValid() throws DataTypeException {
+    void getDisplayNameNotValid() throws DataTypeException {
         CWE cwe = new CWE(null);
         cwe.getCwe3_NameOfCodingSystem().setValue("HL70005");
         cwe.getCwe1_Identifier().setValue("2028-9");
@@ -316,7 +316,7 @@ public class SimpleDataValueResolverTest {
     }
 
     @Test
-    public void getPV1DurationLength() throws DataTypeException {
+    void getPV1DurationLength() throws DataTypeException {
         // Get a PV1
         ORU_R01 message = new ORU_R01();
         ORU_R01_PATIENT_RESULT patientResult = message.getPATIENT_RESULT();

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/Hl7ExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/Hl7ExpressionTest.java
@@ -23,10 +23,10 @@ import io.github.linuxforhealth.hl7.message.HL7MessageData;
 import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
 import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 
-public class Hl7ExpressionTest {
+class Hl7ExpressionTest {
 
   @Test
-  public void test1_segment() throws IOException {
+  void test1_segment() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -56,7 +56,7 @@ public class Hl7ExpressionTest {
 
 
   @Test
-  public void test1_segment_using_valueof() throws IOException {
+  void test1_segment_using_valueof() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -87,7 +87,7 @@ public class Hl7ExpressionTest {
 
 
   @Test
-  public void test3_field() throws IOException {
+  void test3_field() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -124,7 +124,7 @@ public class Hl7ExpressionTest {
   }
 
   @Test
-  public void test3_field_subcomponent() throws IOException {
+  void test3_field_subcomponent() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -161,7 +161,7 @@ public class Hl7ExpressionTest {
 
 
   @Test
-  public void test3_field_options() throws IOException {
+  void test3_field_options() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -193,7 +193,7 @@ public class Hl7ExpressionTest {
 
 
   @Test
-  public void test3_CODING_SYSTEM_V2_field() throws IOException {
+  void test3_CODING_SYSTEM_V2_field() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/JELXExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/JELXExpressionTest.java
@@ -22,7 +22,7 @@ import io.github.linuxforhealth.hl7.message.HL7MessageData;
 import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
 import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 
-public class JELXExpressionTest {
+class JELXExpressionTest {
 
   private static final String SOME_VALUE = "SOME_VALUE";
   private static final String SOME_VALUE_1 = "SOME_VALUE_1";
@@ -30,7 +30,7 @@ public class JELXExpressionTest {
   private static final String SOME_VALUE_3 = "SOME_VALUE_3";
 
   @Test
-  public void test_simple() throws IOException {
+  void test_simple() throws IOException {
 
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
@@ -64,7 +64,7 @@ public class JELXExpressionTest {
 
 
   @Test
-  public void test_with_variables() throws IOException, DataTypeException {
+  void test_with_variables() throws IOException, DataTypeException {
 
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/JexlEngineUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/JexlEngineUtilTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.Test;
 import io.github.linuxforhealth.core.data.JexlEngineUtil;
 
 
-public class JexlEngineUtilTest {
+class JexlEngineUtilTest {
 
   @Test
-  public void test() {
+  void test() {
     JexlEngineUtil engine= new JexlEngineUtil();
     Map<String, Object> context = new HashMap<>();
     context.put("var1", "s");
@@ -31,7 +31,7 @@ public class JexlEngineUtilTest {
 
 
   @Test
-  public void blank_expression_throws_exception() {
+  void blank_expression_throws_exception() {
     JexlEngineUtil wex = new JexlEngineUtil();
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
         wex.evaluate("", new HashMap<>());
@@ -41,7 +41,7 @@ public class JexlEngineUtilTest {
 
 
   @Test
-  public void non_supported_expression_throws_exception() {
+  void non_supported_expression_throws_exception() {
     JexlEngineUtil wex = new JexlEngineUtil();
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
         wex.evaluate("System.currentTimeMillis()", new HashMap<>());
@@ -51,7 +51,7 @@ public class JexlEngineUtilTest {
 
 
   @Test
-  public void non_supported_expression_combining_lines_throws_exception() {
+  void non_supported_expression_combining_lines_throws_exception() {
     JexlEngineUtil wex = new JexlEngineUtil();
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
     	wex.evaluate("String.toString();System.exit(1); ", new HashMap<>());
@@ -59,7 +59,7 @@ public class JexlEngineUtilTest {
   }
 
   @Test
-  public void non_supported_expression_throws_exception_2() {
+  void non_supported_expression_throws_exception_2() {
     JexlEngineUtil wex = new JexlEngineUtil();
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
     	wex.evaluate("String", new HashMap<>());
@@ -68,7 +68,7 @@ public class JexlEngineUtilTest {
 
 
   @Test
-  public void valid_expression_returns_value() {
+  void valid_expression_returns_value() {
     JexlEngineUtil wex = new JexlEngineUtil();
     Object b = wex.evaluate("String.toString() ", new HashMap<>());
     assertThat(b).isEqualTo(String.class.toString());
@@ -76,7 +76,7 @@ public class JexlEngineUtilTest {
 
 
   @Test
-  public void valid_NumUtils_expression_returns_value() {
+  void valid_NumUtils_expression_returns_value() {
     JexlEngineUtil wex = new JexlEngineUtil();
     Object b = wex.evaluate("NumberUtils.createFloat(\"1.2\")", new HashMap<>());
     assertThat(b).isEqualTo(NumberUtils.createFloat("1.2"));

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/ResourceExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/ResourceExpressionTest.java
@@ -29,7 +29,7 @@ import io.github.linuxforhealth.hl7.message.HL7MessageData;
 import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
 import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 
-public class ResourceExpressionTest {
+class ResourceExpressionTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceExpressionTest.class);
 
@@ -40,7 +40,7 @@ public class ResourceExpressionTest {
             + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
 
     @Test
-    public void test1_segment() throws IOException {
+    void test1_segment() throws IOException {
 
         Message hl7message = getMessage(message);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -63,7 +63,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test_component_required_missing() throws IOException {
+    void test_component_required_missing() throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961||407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -90,7 +90,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test_picks_next_value_from_rep_if_first_fails_condition_or_check()
+    void test_picks_next_value_from_rep_if_first_fails_condition_or_check()
             throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
@@ -122,7 +122,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test1_segment_rep() throws IOException {
+    void test1_segment_rep() throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961|000010016^^^SY1^MR~000010017^^^SY2^SS~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -156,7 +156,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test1_segment_identifier_obx() throws IOException {
+    void test1_segment_identifier_obx() throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -185,7 +185,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void testSegmentIdentifierObxCc() throws IOException {
+    void testSegmentIdentifierObxCc() throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961|12345678^^^MR|407623|TestPatient^John^^MR||19700101|male||||||||||\r"
@@ -221,7 +221,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void testSegmentIdentifierObxCcKnownSystem() throws IOException {
+    void testSegmentIdentifierObxCcKnownSystem() throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961|123456^^^MR|407623|TestPatient^John^^^MR||19700101|male||||||||||\r"
@@ -256,7 +256,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void testCodeableConceptFromISTtype() throws IOException {
+    void testCodeableConceptFromISTtype() throws IOException {
         String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|TestPatient^Jane|19700101|female||||||||||\r"
@@ -290,7 +290,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test_organization_creation_with_missing_id_value() throws IOException {
+    void test_organization_creation_with_missing_id_value() throws IOException {
         String message = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
                 + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
                 + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
@@ -327,7 +327,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test_organization_creation_with_missing_id_and_name_value() throws IOException {
+    void test_organization_creation_with_missing_id_and_name_value() throws IOException {
         String message = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
                 + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
                 + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"
@@ -360,7 +360,7 @@ public class ResourceExpressionTest {
     }
 
     @Test
-    public void test_organization_creation_with_mo_missing_value() throws IOException {
+    void test_organization_creation_with_mo_missing_value() throws IOException {
         String message = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
                 + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
                 + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/SimpleExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/SimpleExpressionTest.java
@@ -16,13 +16,13 @@ import io.github.linuxforhealth.core.expression.EmptyEvaluationResult;
 import io.github.linuxforhealth.core.expression.SimpleEvaluationResult;
 import io.github.linuxforhealth.hl7.expression.util.TestBlankInputData;
 
-public class SimpleExpressionTest {
+class SimpleExpressionTest {
 
   private static final String SOME_VALUE = "SOME_VALUE";
   private static final InputDataExtractor data = new TestBlankInputData();
 
   @Test
-  public void test_constant() {
+  void test_constant() {
     ExpressionAttributes attr = new ExpressionAttributes.Builder().withValue(SOME_VALUE).build();
     SimpleExpression exp = new SimpleExpression(attr);
     Map<String, EvaluationResult> context = new HashMap<>();
@@ -34,7 +34,7 @@ public class SimpleExpressionTest {
 
 
   @Test
-  public void test_variable() {
+  void test_variable() {
     ExpressionAttributes attr = new ExpressionAttributes.Builder().withValue(SOME_VALUE).build();
     SimpleExpression exp = new SimpleExpression(attr);
     Map<String, EvaluationResult> context = new HashMap<>();
@@ -48,7 +48,7 @@ public class SimpleExpressionTest {
 
 
   @Test
-  public void test_variable_invalid_var() {
+  void test_variable_invalid_var() {
     ExpressionAttributes attr = new ExpressionAttributes.Builder().withValue("$").build();
     SimpleExpression exp = new SimpleExpression(attr);
 
@@ -63,7 +63,7 @@ public class SimpleExpressionTest {
 
 
   @Test
-  public void test_variable_no_context() {
+  void test_variable_no_context() {
     ExpressionAttributes attr = new ExpressionAttributes.Builder().withValueOf("$var1").build();
     SimpleExpression exp = new SimpleExpression(attr);
 
@@ -75,7 +75,7 @@ public class SimpleExpressionTest {
   }
 
   @Test
-  public void test_blank() {
+  void test_blank() {
     ExpressionAttributes attr = new ExpressionAttributes.Builder().withValue("").build();
     SimpleExpression exp = new SimpleExpression(attr);
     Map<String, EvaluationResult> context = new HashMap<>();

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/varable/VariableGeneratorTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/varable/VariableGeneratorTest.java
@@ -13,7 +13,7 @@ import io.github.linuxforhealth.hl7.expression.variable.DataTypeVariable;
 import io.github.linuxforhealth.hl7.expression.variable.ExpressionVariable;
 import io.github.linuxforhealth.hl7.expression.variable.VariableGenerator;
 
-public class VariableGeneratorTest {
+class VariableGeneratorTest {
 
   /**
    *
@@ -24,7 +24,7 @@ public class VariableGeneratorTest {
    * @throws IOException
    */
   @Test
-  public void parseDataTypeVariableWithAsterixAtEnd() throws IOException {
+  void parseDataTypeVariableWithAsterixAtEnd() throws IOException {
 	  String varName = "var1";
 	  String variableExpression = "STRING, OBX-5 *";
 	  DataTypeVariable v = (DataTypeVariable) VariableGenerator.parse(varName, variableExpression);	
@@ -44,7 +44,7 @@ public class VariableGeneratorTest {
   * @throws IOException
   */
   @Test
-  public void parseExpressionVariableWithAsterixAndEvaluatingJavaFunction() throws IOException {
+  void parseExpressionVariableWithAsterixAndEvaluatingJavaFunction() throws IOException {
 	  String varName = "var1";
 	  String variableExpression = "OBX.5 *, GeneralUtils.testFunction(x, y)";
 	  ExpressionVariable v = (ExpressionVariable) VariableGenerator.parse(varName, variableExpression);	

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
@@ -29,7 +29,7 @@ import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
-public class HL7ADTMessageTest {
+class HL7ADTMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final Logger LOGGER = LoggerFactory.getLogger(HL7ADTMessageTest.class);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
@@ -39,7 +39,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
     @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
-    public void test_adt_a01_mininum_segments(String message) throws IOException {
+    void test_adt_a01_mininum_segments(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -73,7 +73,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
     @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
-    public void test_adt_a01_minimum_plus_PROCEDURE_group(String message) throws IOException {
+    void test_adt_a01_minimum_plus_PROCEDURE_group(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -112,7 +112,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
     @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
-    public void test_adt_a01_full_with_OBXtypeTX_and_no_groups(String message) throws IOException {
+    void test_adt_a01_full_with_OBXtypeTX_and_no_groups(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -173,7 +173,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
     @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
-    public void test_adt_a01_full_plus_multiple_PROCEDURE_group(String message) throws IOException {
+    void test_adt_a01_full_plus_multiple_PROCEDURE_group(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -237,7 +237,7 @@ public class HL7ADTMessageTest {
 
     @Test
     @Disabled("adt-a02 not yet supported")
-    public void test_adta02_patient_encounter_present() throws IOException {
+    void test_adta02_patient_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A02|controlID|P|2.6\n"
                 + "EVN|A01|20150502090000|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -271,7 +271,7 @@ public class HL7ADTMessageTest {
 
     @Test
     @Disabled("adt-a03 not yet supported")
-    public void test_adta03_patient_encounter_present() throws IOException {
+    void test_adta03_patient_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A03|controlID|P|2.6\n"
                 + "EVN|A01|20150502090000|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -305,7 +305,7 @@ public class HL7ADTMessageTest {
     @Test
     @Disabled("adt-a28 not yet supported")
     //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
-    public void test_adta28_patient_encounter_present() throws IOException {
+    void test_adta28_patient_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\n"
                 + "EVN|A01|20150502090000|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -339,7 +339,7 @@ public class HL7ADTMessageTest {
     @Test
     @Disabled("adt-a31 not yet supported")
     //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
-    public void test_adta31_patient_encounter_present() throws IOException {
+    void test_adta31_patient_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\n"
                 + "EVN|A01|20150502090000|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -376,7 +376,7 @@ public class HL7ADTMessageTest {
                                                         * , "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48",
                                                         * "ADT^A49"
                                                         */ })
-    public void test_adt_a30_mininum_segments(String message) throws IOException {
+    void test_adt_a30_mininum_segments(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -412,7 +412,7 @@ public class HL7ADTMessageTest {
                                                         * , "ADT^A35", "ADT^A36", "ADT^A46", "ADT^A47", "ADT^A48",
                                                         * "ADT^A49"
                                                         */ })
-    public void test_adt_a30_full(String message) throws IOException {
+    void test_adt_a30_full(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -448,7 +448,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
     @ValueSource(strings = { /* "ADT^A39", */ "ADT^A40"/* , "ADT^A41", "ADT^A42" */ })
-    public void test_adt_a39_min_segments(String message) throws IOException {
+    void test_adt_a39_min_segments(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -481,7 +481,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
     @ValueSource(strings = { /* "ADT^A39", */ "ADT^A40"/* , "ADT^A41", "ADT^A42" */ })
-    public void test_adt_a39_min_with_multiple_PATIENT_groups(String message) throws IOException {
+    void test_adt_a39_min_with_multiple_PATIENT_groups(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -518,7 +518,7 @@ public class HL7ADTMessageTest {
     @ParameterizedTest
     // ADT_A39 structure is also used by ADT_A40, ADT_A41, ADT_A42.  We can reuse this for those messages if we choose to support them in the future.
     @ValueSource(strings = { /* "ADT^A39", */ "ADT^A40"/* , "ADT^A41", "ADT^A42" */ })
-    public void test_adt_a39_full_with_multiple_PATIENT_groups(String message) throws IOException {
+    void test_adt_a39_full_with_multiple_PATIENT_groups(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7CustomMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7CustomMessageTest.java
@@ -42,7 +42,7 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 // The custom message is placed in src/test/resources/additional_custom_resources/hl7/message/CUSTOM_PAT.yml
 // The custom packages class is placed in src/test/java/custom_packages/2.6 and references the custom package /org/foo/hl7/custom/
 
-public class Hl7CustomMessageTest {
+class Hl7CustomMessageTest {
 
     // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     // NOTE VALIDATION IS INTENTIONALLY NOT USED BECAUSE WE ARE CREATING RESOURCES THAT ARE NOT STANDARD
@@ -57,21 +57,21 @@ public class Hl7CustomMessageTest {
     static String originalConfigHome;
   
     @BeforeAll
-    public static void saveConfigHomeProperty() {
+    static void saveConfigHomeProperty() {
       originalConfigHome = System.getProperty(CONF_PROP_HOME);
       ConverterConfiguration.reset();
       ResourceReader.reset();
     }
   
     @AfterEach
-    public void reset() {
+    void reset() {
       System.clearProperty(CONF_PROP_HOME);
       ConverterConfiguration.reset();
       ResourceReader.reset();
     }
   
     @AfterAll
-    public static void reloadPreviousConfigurations() {
+    static void reloadPreviousConfigurations() {
       if (originalConfigHome != null)
         System.setProperty(CONF_PROP_HOME, originalConfigHome);
       else
@@ -79,7 +79,7 @@ public class Hl7CustomMessageTest {
     }
 
     @Test
-    public void testCustomPatMessage() throws IOException {
+    void testCustomPatMessage() throws IOException {
 
         // Set up the config file
     	  commonConfigFileSetup();

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MDMMessageTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7MDMMessageTest {
+class Hl7MDMMessageTest {
 
     //An example message for reference:
     // "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||MDM^T06|<MESSAGEID>|P|2.6\n"
@@ -42,7 +42,7 @@ public class Hl7MDMMessageTest {
     // This test assures we don't have data mixing in the placer / filler identifiers.
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void noMixingOfParamsInDocumentReference(String message) throws IOException {
+    void noMixingOfParamsInDocumentReference(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||MDM^T02|" + message + "|P|2.6\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 + "PV1|1|O|2GY^2417^W||||D||||||||||OTW|<HospitalID>|||||||||||||||||||||||||20180115102400|20180118104500\n"
@@ -153,7 +153,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_mininum_with_OBXtypeTXtoDocumenReference(String message) throws IOException {
+    void test_mdm_mininum_with_OBXtypeTXtoDocumenReference(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -179,7 +179,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_mininum_with_OBXnotTX(String message) throws IOException {
+    void test_mdm_mininum_with_OBXnotTX(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -208,7 +208,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_mininum_with_multiple_OBXtypeTXtoDocumentReference(String message) throws IOException {
+    void test_mdm_mininum_with_multiple_OBXtypeTXtoDocumentReference(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -236,7 +236,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_mininum_with_multipleOBXnotTX(String message) throws IOException {
+    void test_mdm_mininum_with_multipleOBXnotTX(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -267,7 +267,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_ORDER_group_and_OBXtypeTX(String message) throws IOException {
+    void test_mdm_ORDER_group_and_OBXtypeTX(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -298,7 +298,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_ORDER_with_OBXnotTX(String message) throws IOException {
+    void test_mdm_ORDER_with_OBXnotTX(String message) throws IOException {
         // Also check NTE working for MDM messages.
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
@@ -364,7 +364,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_multiple_ORDERs_and_multiple_OBXtypeTX(String message) throws IOException {
+    void test_mdm_multiple_ORDERs_and_multiple_OBXtypeTX(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -401,7 +401,7 @@ public class Hl7MDMMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "MDM^T02", "MDM^T06" })
-    public void test_mdm_multiple_ORDERs_and_multiple_OBXnotTX(String message) throws IOException {
+    void test_mdm_multiple_ORDERs_and_multiple_OBXnotTX(String message) throws IOException {
         String hl7message = "MSH|^~\\&|HNAM|W|RAD_IMAGING_REPORT|W|20180118111520||" + message + "|<MESSAGEID>|P|2.6\r"
                 + "EVN||20150502090000|\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7MessageTest.java
@@ -34,13 +34,13 @@ import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.resource.ResourceReader;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7MessageTest {
+class Hl7MessageTest {
     private static FHIRContext context = new FHIRContext(true, false);
     private static HL7MessageEngine engine = new HL7MessageEngine(context);
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MessageTest.class);
 
     @Test
-    public void test_patient() throws IOException {
+    void test_patient() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Patient");
 
@@ -70,7 +70,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_patient_encounter() throws IOException {
+    void test_patient_encounter() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Patient");
         HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
@@ -116,7 +116,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_patient_encounter_only() throws IOException {
+    void test_patient_encounter_only() throws IOException {
 
         ResourceModel encounter = ResourceReader.getInstance().generateResourceModel("resource/Encounter");
         HL7FHIRResourceTemplateAttributes attributesEncounter = new HL7FHIRResourceTemplateAttributes.Builder()
@@ -146,7 +146,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_observation() throws IOException {
+    void test_observation() throws IOException {
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Observation");
 
         HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
@@ -180,7 +180,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_observation_multiple() throws IOException {
+    void test_observation_multiple() throws IOException {
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Observation");
 
         HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
@@ -217,7 +217,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_observation_NM_result() throws IOException {
+    void test_observation_NM_result() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Observation");
 
@@ -249,7 +249,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_condition() throws IOException {
+    void test_condition() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Condition");
 
@@ -277,7 +277,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_observation_condition() throws IOException {
+    void test_observation_condition() throws IOException {
 
         ResourceModel obsModel = ResourceReader.getInstance().generateResourceModel("resource/Observation");
         HL7FHIRResourceTemplateAttributes attributesObs = new HL7FHIRResourceTemplateAttributes.Builder()
@@ -332,7 +332,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_messageHeader_with_ADT() throws IOException {
+    void test_messageHeader_with_ADT() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/MessageHeader");
 
@@ -386,7 +386,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_messageHeader_with_ORU() throws IOException {
+    void test_messageHeader_with_ORU() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/MessageHeader");
 
@@ -440,7 +440,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_specimen() throws IOException {
+    void test_specimen() throws IOException {
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Specimen");
 
         HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()
@@ -470,7 +470,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_specimen_multiple() throws IOException {
+    void test_specimen_multiple() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Specimen");
 
@@ -501,7 +501,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_specimen_multiple_type_coding() throws IOException {
+    void test_specimen_multiple_type_coding() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Specimen");
 
@@ -533,7 +533,7 @@ public class Hl7MessageTest {
     }
 
     @Test
-    public void test_encounter_with_observation() throws IOException {
+    void test_encounter_with_observation() throws IOException {
 
         ResourceModel rsm = ResourceReader.getInstance().generateResourceModel("resource/Patient");
         HL7FHIRResourceTemplateAttributes attributes = new HL7FHIRResourceTemplateAttributes.Builder()

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7OMPMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7OMPMessageTest.java
@@ -26,7 +26,7 @@ import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
-public class Hl7OMPMessageTest {
+class Hl7OMPMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
             .withValidateResource().withPrettyPrint().build();
@@ -43,7 +43,7 @@ public class Hl7OMPMessageTest {
     // + "OBX|1|NM|Most Current Weight^Most current measured weight (actual)||90|kg\r"
 
     @Test
-    public void test_OMPO09_min_PATIENT_and_min_ORDER_groups() throws IOException {
+    void test_OMPO09_min_PATIENT_and_min_ORDER_groups() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r"
                 + "ORC|OP|1000|9999999||||^3 times daily^^20210401\r"
@@ -74,7 +74,7 @@ public class Hl7OMPMessageTest {
     }
 
     @Test
-    public void test_OMPO09_PATIENT_with_PATIENT_VISIT_and_min_ORDER_groups() throws IOException {
+    void test_OMPO09_PATIENT_with_PATIENT_VISIT_and_min_ORDER_groups() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r"
                 + "PV1||I|||||||||||||||||1400|||||||||||||||||||||||||199501102300\r"
@@ -111,7 +111,7 @@ public class Hl7OMPMessageTest {
     }
 
     @Test
-    public void test_OMPO09_full_PATIENT_with_PATIENT_VISIT_and_min_ORDER_groups() throws IOException {
+    void test_OMPO09_full_PATIENT_with_PATIENT_VISIT_and_min_ORDER_groups() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r"
                 + "PD1|||||||||||01|N||||A\r"
@@ -157,7 +157,7 @@ public class Hl7OMPMessageTest {
     }
 
     @Test
-    public void test_OMPO09_ORDER_with_multiple_OBSERVATIONS_with_OBXnonTX() throws IOException {
+    void test_OMPO09_ORDER_with_multiple_OBSERVATIONS_with_OBXnonTX() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r" //Even though PID is optional, I had to provide it in order to get results from the converter
                 //1st order
@@ -201,7 +201,7 @@ public class Hl7OMPMessageTest {
     }
 
     @Test
-    public void test_OMPO09_ORDER_with_multiple_OBSERVATIONS_with_OBXtypeTX() throws IOException {
+    void test_OMPO09_ORDER_with_multiple_OBSERVATIONS_with_OBXtypeTX() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r" //Even though PID is optional, I had to provide it in order to get results from the converter
                 + "ORC|OP|1000|9999999||||^3 times daily^^20210401\r"
@@ -244,7 +244,7 @@ public class Hl7OMPMessageTest {
     }
 
     @Test
-    public void test_OMPO09_with_multiple_ORDERs_with_and_without_OBXtypeTX() throws IOException {
+    void test_OMPO09_with_multiple_ORDERs_with_and_without_OBXtypeTX() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r" //Even though PID is optional, I had to provide it in order to get results from the converter
                 // first order group

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORMMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORMMessageTest.java
@@ -14,10 +14,10 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Test;
 
-public class Hl7ORMMessageTest {
+class Hl7ORMMessageTest {
 
     @Test
-    public void test_ORMO01_patient_encounter_present() throws IOException {
+    void test_ORMO01_patient_encounter_present() throws IOException {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|IBMWATSON_LAB|IBM|20210407191758||ORM^O01|MSGID_e30a3471-7afd-4aa2-a3d5-e93fd89d24b3|T|2.3\n"
                 + "PID|1||0a1f7838-4230-4752-b8f6-948b07c38b25^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator||9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900|||||Account_0a1f7838-4230-4752-b8f6-948b07c38b25|123-456-7890||||BIRTH PLACE\n"
                 + "PV1||IP|^^^Toronto^^5642 Hilly Av||||2905^Doctor^Attending^M^IV^^M.D|5755^Doctor^Referring^^Sr|770542^Doctor^Consulting^Jr||||||||59367^Doctor^Admitting|IP^I|Visit_0a1f7838-4230-4752-b8f6-948b07c38b25|||||||||||||||||||||||||20210407191758\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
@@ -23,11 +23,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7PPRMessageTest {
+class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_min_VISIT_and_PROBLEM_groups(String message) throws IOException {
+    void test_ppr_pc1_with_min_VISIT_and_PROBLEM_groups(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -48,7 +48,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_min_VISIT_and_PROBLEM_with_multiple_PROBLEM_OBSERVATION_groups(String message) throws IOException {
+    void test_ppr_pc1_with_min_VISIT_and_PROBLEM_with_multiple_PROBLEM_OBSERVATION_groups(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -79,7 +79,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_min_VISIT_and_PROBLEM_with_multiple_PROBLEM_OBSERVATION_groups_OBXtypeTX(String message) throws IOException {
+    void test_ppr_pc1_with_min_VISIT_and_PROBLEM_with_multiple_PROBLEM_OBSERVATION_groups_OBXtypeTX(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -110,7 +110,7 @@ public class Hl7PPRMessageTest {
     
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_full_VISIT_and_PROBLEM_with_min_ORDER_groups(String message) throws IOException {
+    void test_ppr_pc1_with_full_VISIT_and_PROBLEM_with_min_ORDER_groups(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -144,7 +144,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_multiple_PROBLEM_with_ORDER_groups(String message) throws IOException {
+    void test_ppr_pc1_with_multiple_PROBLEM_with_ORDER_groups(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -180,7 +180,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_VISIT_and_PROBLEM_with_ORDER_group_with_OBXnonTX(String message) throws IOException {
+    void test_ppr_pc1_with_VISIT_and_PROBLEM_with_ORDER_group_with_OBXnonTX(String message) throws IOException {
         String hl7message = 
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -222,7 +222,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_VISIT_and_PROBLEM_with_ORDER_group_withOBXtypeTX(String message) throws IOException {
+    void test_ppr_pc1_with_VISIT_and_PROBLEM_with_ORDER_group_withOBXtypeTX(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -266,7 +266,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_VISIT_and_PROBLEM_with_multiple_full_ORDER_groups_OBXtypeTX(String message) throws IOException {
+    void test_ppr_pc1_with_VISIT_and_PROBLEM_with_multiple_full_ORDER_groups_OBXtypeTX(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -316,7 +316,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_VISIT_and_PROBLEM_with_multiple_full_ORDER_groups_OBXnotTX(String message) throws IOException {
+    void test_ppr_pc1_with_VISIT_and_PROBLEM_with_multiple_full_ORDER_groups_OBXnotTX(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"
@@ -372,7 +372,7 @@ public class Hl7PPRMessageTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */ })
-    public void test_ppr_pc1_with_VISIT_and_PROBLEM_with_multiple_PROBLEM_OBSERVATIONs_and_multiple_full_ORDER_groups(String message) throws IOException {
+    void test_ppr_pc1_with_VISIT_and_PROBLEM_with_multiple_PROBLEM_OBSERVATIONs_and_multiple_full_ORDER_groups(String message) throws IOException {
         String hl7message =
             "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message + "|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson|||M||||||||||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7RDEMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7RDEMessageTest.java
@@ -27,7 +27,7 @@ import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
-public class Hl7RDEMessageTest {
+class Hl7RDEMessageTest {
     private static FHIRContext context = new FHIRContext();
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
             .withValidateResource().withPrettyPrint().build();
@@ -38,7 +38,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
@@ -74,7 +74,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
     // In the HL7 spec RXR is required for these messages, however, we can handle having no RXR.
-    public void test_RDE_medRequest_patient_present_withoutRXR(String msh) throws IOException {
+    void test_RDE_medRequest_patient_present_withoutRXR(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
@@ -108,7 +108,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_encounter_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_encounter_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
@@ -149,7 +149,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_encounter_withExtraSegments_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_encounter_withExtraSegments_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "PD1|||||||||||01|N||||A\r"
@@ -192,7 +192,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_encounter_allergy_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_encounter_allergy_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
@@ -239,7 +239,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_observation_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_observation_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "ORC|RE|||3200|||||20210407191342||2799^BY^VERIFIED||||20210407191342||||||ORDERING FAC NAME||||||||I\r"
@@ -279,7 +279,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_encounter_observation_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_encounter_observation_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"
@@ -325,7 +325,7 @@ public class Hl7RDEMessageTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void test_RDE_medRequest_patient_encounter_allergy_observation_present(String msh) throws IOException {
+    void test_RDE_medRequest_patient_encounter_allergy_observation_present(String msh) throws IOException {
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "PV1||I|||||||||||||||||Visit_0a4d960d-c528-45c9-bb10-7e9929968247|||||||||||||||||||||||||20210407191342\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7VXUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7VXUMessageTest.java
@@ -28,7 +28,7 @@ import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Hl7VXUMessageTest {
+class Hl7VXUMessageTest {
     private static FHIRContext context = new FHIRContext(true, false);
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7VXUMessageTest.class);
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder()
@@ -38,7 +38,7 @@ public class Hl7VXUMessageTest {
         .build();
 
     @Test
-    public void test_VXU_with_minimum_segments() throws IOException {
+    void test_VXU_with_minimum_segments() throws IOException {
   	    String hl7message =
   		    "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
   		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r";
@@ -63,7 +63,7 @@ public class Hl7VXUMessageTest {
     }
 
     @Test
-    public void test_VXU_with_patient_group_that_has_minimum_segments() throws IOException {
+    void test_VXU_with_patient_group_that_has_minimum_segments() throws IOException {
   	    String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
   		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -94,7 +94,7 @@ public class Hl7VXUMessageTest {
     }
 
     @Test
-    public void test_VXU_with_patient_group_that_has_all_segments() throws IOException {
+    void test_VXU_with_patient_group_that_has_all_segments() throws IOException {
   	    String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
   		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -127,7 +127,7 @@ public class Hl7VXUMessageTest {
     }
 
     @Test
-    public void test_VXU_with_full_patient_group_and_minimum_order_group() throws IOException {
+    void test_VXU_with_full_patient_group_and_minimum_order_group() throws IOException {
   	    String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
   		    + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -167,7 +167,7 @@ public class Hl7VXUMessageTest {
     }
 
     @Test
-    public void test_VXU_with_minimum_patient_group_plus_order_group_without_OBX() throws IOException {
+    void test_VXU_with_minimum_patient_group_plus_order_group_without_OBX() throws IOException {
         String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
             + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -206,7 +206,7 @@ public class Hl7VXUMessageTest {
   }
 
     @Test
-    public void test_VXU_with_minimum_patient_group_plus_order_group_with_OBX_but_no_observations() throws IOException {
+    void test_VXU_with_minimum_patient_group_plus_order_group_with_OBX_but_no_observations() throws IOException {
         String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
             + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -249,7 +249,7 @@ public class Hl7VXUMessageTest {
 }
 
     @Test
-    public void test_VXU_with_minimum_patient_group_plus_order_group_with_OBX_with_observations() throws IOException {
+    void test_VXU_with_minimum_patient_group_plus_order_group_with_OBX_with_observations() throws IOException {
         String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
             + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -295,7 +295,7 @@ public class Hl7VXUMessageTest {
     }
 
     @Test
-    public void test_VXU_with_minimum_patient_group_plus_multiple_order_groups() throws IOException {
+    void test_VXU_with_minimum_patient_group_plus_multiple_order_groups() throws IOException {
         String hl7message = 
             "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\r"
             + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/message/SegmentUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/SegmentUtilTest.java
@@ -27,7 +27,7 @@ import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
 import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
 import io.github.linuxforhealth.hl7.parsing.result.ParsingResult;
 
-public class SegmentUtilTest {
+class SegmentUtilTest {
     private static final String NORMAL_LV_CHAMBER_SIZE_WITH_MILD_CONCENTRIC_LVH = "NORMAL LV CHAMBER SIZE WITH MILD CONCENTRIC LVH";
 
     private static final ArrayList<String> ORDER_GROUP_LIST = Lists.newArrayList("PROBLEM", "ORDER", "ORDER_DETAIL",
@@ -97,7 +97,7 @@ public class SegmentUtilTest {
 
     // Tests for extracting segment from group
     @Test
-    public void test_single_order_group() throws HL7Exception {
+    void test_single_order_group() throws HL7Exception {
 
         Message hl7message = getMessage(messageSingleOrderGroup);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -110,7 +110,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_single_problem_group_wrong_group_list_provided() throws HL7Exception {
+    void test_single_problem_group_wrong_group_list_provided() throws HL7Exception {
 
         Message hl7message = getMessage(messageSingleProblemGroup);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -121,7 +121,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_single_problem_group() throws HL7Exception {
+    void test_single_problem_group() throws HL7Exception {
 
         Message hl7message = getMessage(messageSingleProblemGroup);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -134,7 +134,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_parent_repeat() throws HL7Exception {
+    void test_parent_repeat() throws HL7Exception {
         Message hl7message = getMessage(messageRepeat);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
         List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
@@ -150,7 +150,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_parent_repeat_additional_segment_under_parent() throws HL7Exception {
+    void test_parent_repeat_additional_segment_under_parent() throws HL7Exception {
         Message hl7message = getMessage(messageRepeat);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
         List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
@@ -169,7 +169,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_parent_repeat_additional_segment_under_group() throws HL7Exception {
+    void test_parent_repeat_additional_segment_under_group() throws HL7Exception {
         Message hl7message = getMessage(messageRepeat);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
         List<SegmentGroup> segmentGroups = SegmentExtractorUtil.extractSegmentGroups(ORDER_GROUP_LIST,
@@ -188,7 +188,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_parent_repeat_additional_segment_under_group_with_group_name()
+    void test_parent_repeat_additional_segment_under_group_with_group_name()
             throws HL7Exception {
         Message hl7message = getMessage(messageRepeatMultiplePRB);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -214,7 +214,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_repeating_primary_segment_with_repeating_parent_group()
+    void test_repeating_primary_segment_with_repeating_parent_group()
             throws HL7Exception {
         String message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
                 + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
@@ -258,7 +258,7 @@ public class SegmentUtilTest {
     // Test for extracting segments outside of group
 
     @Test
-    public void test_get_segments() throws HL7Exception {
+    void test_get_segments() throws HL7Exception {
 
         Message hl7message = getMessage(hl7ADTmessage);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -281,7 +281,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_single_segment() throws HL7Exception {
+    void test_single_segment() throws HL7Exception {
 
         Message hl7message = getMessage(hl7ADTmessage);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -297,7 +297,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_single_segment_with_additional_segment() throws HL7Exception {
+    void test_single_segment_with_additional_segment() throws HL7Exception {
 
         Message hl7message = getMessage(hl7ADTmessage);
         HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
@@ -317,7 +317,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_child_segment_with_additional_parent_segment() throws HL7Exception {
+    void test_child_segment_with_additional_parent_segment() throws HL7Exception {
         String message = "MSH|^~\\\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|ORU^R01|MSGID000005|T|2.6\r"
                 + "PID||45483|45483||SMITH^SUZIE^||20160813|M|||123 MAIN STREET^^SCHENECTADY^NY^12345||(123)456-7890|||||^^^T||||||||||||\r"
                 + "OBR|1||986^IA PHIMS Stage^2.16.840.1.114222.4.3.3.5.1.2^ISO|112^Final Echocardiogram Report|||20151009173644|||||||||||||002|||||F|||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^||||3065^Mahoney^Paul^J|\r"
@@ -344,7 +344,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_VUX_no_rep() throws HL7Exception {
+    void test_VUX_no_rep() throws HL7Exception {
         String hl7VUXmessageNoRep = "MSH|^~\\&|ImmunizationGenerator^1.4|^2|||20121217134645||VXU^V04^VXU_V04|64443|P^|2.5.1^^^^^^^^^^^^|||ER||||\r"
                 + "PID|||1234^^^^PI^||HASBRO^ANDY^JOHN^^^^L^|SLINKY^FUN^^^^^L^|20010606|M|||1564 MONROE^^BROOKLYN^HI^56808^^^^^^|||||||||||||||||||\r"
                 + "PD1|||||||||||01|N||||A\r"
@@ -375,7 +375,7 @@ public class SegmentUtilTest {
     }
 
     @Test
-    public void test_VUX_rep() throws HL7Exception {
+    void test_VUX_rep() throws HL7Exception {
         String hl7VUXmessageRep = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
                 + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
                 + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/parsing/HL7DataExtractorTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/parsing/HL7DataExtractorTest.java
@@ -20,10 +20,10 @@ import ca.uhn.hl7v2.model.primitive.IS;
 import ca.uhn.hl7v2.model.v26.datatype.CX;
 import ca.uhn.hl7v2.model.v26.datatype.ST;
 import ca.uhn.hl7v2.model.v26.segment.AL1;
-public class HL7DataExtractorTest {
+class HL7DataExtractorTest {
 
   @Test
-  public void returns_segment_if_exists() throws IOException {
+  void returns_segment_if_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -40,7 +40,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_segment_if_exists_group() throws IOException {
+  void returns_segment_if_exists_group() throws IOException {
     String message =
         "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
@@ -60,7 +60,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_segment_if_exists_group_no_segment() throws IOException {
+  void returns_segment_if_exists_group_no_segment() throws IOException {
     String message =
         "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
@@ -80,7 +80,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void get_group_then_segment_for_non_existing_segment() throws IOException {
+  void get_group_then_segment_for_non_existing_segment() throws IOException {
     String message =
         "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
             + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
@@ -104,7 +104,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_segment_does_not_exists() throws IOException {
+  void returns_null_if_segment_does_not_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -121,7 +121,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_segment_does_not_exists_when_querying_all_repititions()
+  void returns_null_if_segment_does_not_exists_when_querying_all_repititions()
       throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -139,7 +139,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_segment_name_is_invalid() throws IOException {
+  void returns_null_if_segment_name_is_invalid() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -157,7 +157,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_list_of_segment_for_repititions() throws IOException {
+  void returns_list_of_segment_for_repititions() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
@@ -184,7 +184,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_requested_repetition_of_segment() throws IOException {
+  void returns_requested_repetition_of_segment() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
@@ -210,7 +210,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_requested_repetition_of_segment_does_not_exists() throws IOException {
+  void returns_null_if_requested_repetition_of_segment_does_not_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
@@ -235,7 +235,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_field_value_for_specific_rep_if_exists() throws IOException {
+  void returns_field_value_for_specific_rep_if_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -259,7 +259,7 @@ public class HL7DataExtractorTest {
   }
 
   @Test
-  public void returns_all_field_values_if_exists() throws IOException {
+  void returns_all_field_values_if_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -286,7 +286,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_field_value_for_repitition_does_not_exists() throws IOException {
+  void returns_null_if_field_value_for_repitition_does_not_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -312,7 +312,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_component_value_for_specific_rep_if_exists() throws IOException {
+  void returns_component_value_for_specific_rep_if_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -335,7 +335,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_component_value_for_does_not_exists() throws IOException {
+  void returns_null_if_component_value_for_does_not_exists() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
@@ -356,7 +356,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_component_and_subcomponent_value_for_specific_rep_if_exists()
+  void returns_component_and_subcomponent_value_for_specific_rep_if_exists()
       throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -380,7 +380,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_if_component_subcomponent_value_for_does_not_exists()
+  void returns_null_if_component_subcomponent_value_for_does_not_exists()
       throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -403,7 +403,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void extracts_component_from_variable_type_primitive() throws IOException {
+  void extracts_component_from_variable_type_primitive() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
@@ -426,7 +426,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void extracts_component_from_variable_type_compositive() throws IOException {
+  void extracts_component_from_variable_type_compositive() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
         + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
@@ -448,7 +448,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void extracts_component_from_variable_type_compositive_with_subcomponent()
+  void extracts_component_from_variable_type_compositive_with_subcomponent()
       throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -471,7 +471,7 @@ public class HL7DataExtractorTest {
 
 
   @Test
-  public void returns_null_from_variable_type_compositive_with_subcomponent_if_subcomponent_does_not_exists()
+  void returns_null_from_variable_type_compositive_with_subcomponent_if_subcomponent_does_not_exists()
       throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/resource/HL7ResourceReaderTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/resource/HL7ResourceReaderTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.github.linuxforhealth.core.config.ConverterConfiguration;
 import io.github.linuxforhealth.hl7.message.HL7MessageModel;
 
-public class HL7ResourceReaderTest {
+class HL7ResourceReaderTest {
 
   private static final String CONF_PROP_HOME = "hl7converter.config.home";
 
@@ -31,19 +31,19 @@ public class HL7ResourceReaderTest {
   static String originalConfigHome;
 
   @BeforeAll
-  public static void saveConfigHomeProperty() {
+  static void saveConfigHomeProperty() {
     originalConfigHome = System.getProperty(CONF_PROP_HOME);
   }
 
   @AfterEach
-  public void reset() {
+  void reset() {
     System.clearProperty(CONF_PROP_HOME);
     ConverterConfiguration.reset();
     ResourceReader.reset();
   }
 
   @AfterAll
-  public static void reloadPreviousConfigurations() {
+  static void reloadPreviousConfigurations() {
     if (originalConfigHome != null)
       System.setProperty(CONF_PROP_HOME, originalConfigHome);
     else
@@ -53,7 +53,7 @@ public class HL7ResourceReaderTest {
   // This tests that messagetemplates are still loaded the old way via class path
   // Create a config without base.path.resource and additional.resources.location properties forcing the files to be found via classpath
   @Test
-  public void testGetMessageTemplatesViaClasspath() throws IOException {
+  void testGetMessageTemplatesViaClasspath() throws IOException {
     try {
       // Set up the config file
       File configFile = new File(folder, "config.properties");
@@ -74,7 +74,7 @@ public class HL7ResourceReaderTest {
 
   // This tests that messagetemplates are loaded the new way via configured path + alternate path
   @Test
-  public void testGetMessageTemplatesViaAdditionalLocation() throws IOException {
+  void testGetMessageTemplatesViaAdditionalLocation() throws IOException {
     try {
       // Set up the config file
       File configFile = new File(folder, "config.properties");
@@ -98,7 +98,7 @@ public class HL7ResourceReaderTest {
   // This tests that messagetemplates are loaded the new way via configured path + alternate path
   // AND that they are found when supported.hl7.messages is omitted and defaults to *
   @Test
-  public void testGetMessageTemplatesViaAdditionalLocationWithDefaultSupportedList() throws IOException {
+  void testGetMessageTemplatesViaAdditionalLocationWithDefaultSupportedList() throws IOException {
     try {
       // Set up the config file
       File configFile = new File(folder, "config.properties");

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7EventTypeFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7EventTypeFHIRConversionTest.java
@@ -28,12 +28,12 @@ import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
-public class HL7EventTypeFHIRConversionTest {
+class HL7EventTypeFHIRConversionTest {
 
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
 
     @Test
-    public void validate_evn_segment() {
+    void validate_evn_segment() {
         String hl7message = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 // + "EVN||||851||20210319134735|\r"  // TODO, not working with this value
                 + "EVN||||O||20210319134735|\r"
@@ -74,7 +74,7 @@ public class HL7EventTypeFHIRConversionTest {
     }
 
     @Test
-    public void validate_evn_segment_no_period_override() {
+    void validate_evn_segment_no_period_override() {
         String hl7message = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 // + "EVN||||7525||20210319134735|\r"  // TODO, not working with this value
                 + "EVN||||O||20210319134735|\r"
@@ -117,7 +117,7 @@ public class HL7EventTypeFHIRConversionTest {
     }
 
     @Test
-    public void validateEVNsegmentWithOBXreference() {
+    void validateEVNsegmentWithOBXreference() {
         // When there is an OBX record, it should create a reason reference in the encounter segment
         String hl7message = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 + "EVN||||7525|||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7MergeFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7MergeFHIRConversionTest.java
@@ -24,11 +24,11 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 /*** Tests the MRG segment ***/
 
-public class HL7MergeFHIRConversionTest {
+class HL7MergeFHIRConversionTest {
 
     // Test ADT_A34 with one MRG segment (the most it supports).
     @Test
-    public void validateHappyPathADT_A34WithMRG() {
+    void validateHappyPathADT_A34WithMRG() {
 
         String hl7message = "MSH|^~\\&|SENDING_APPLICATION|SENDING_FACILITY|RECEIVING_APPLICATION|RECEIVING_FACILITY|||ADT^A34||P|2.3||||\r"
                 + "EVN|A40|20110613122406637||01\r"
@@ -180,7 +180,7 @@ public class HL7MergeFHIRConversionTest {
 
     // Test ADT_A40 with one MRG segment.
     @Test
-    public void validateHappyPathADT_A40WithMRG() {
+    void validateHappyPathADT_A40WithMRG() {
 
         String hl7message = "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40^ADT_A39|00000003|P|2.6\r"  
                 + "EVN|A40|200301051530\r"
@@ -275,7 +275,7 @@ public class HL7MergeFHIRConversionTest {
 
     // Tests ADT_A40 message with 2 MRG segments.
     @Test
-    public void validateTwoMRGs() {
+    void validateTwoMRGs() {
 
         String hl7message = "MSH|^~\\&|REGADT|MCM|RSP1P8|MCM|200301051530|SEC|ADT^A40^ADT_A39|00000003|P|2.6\r"
                 + "EVN|A40|200301051530\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AddressFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AddressFHIRConversionTest.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 
-public class Hl7AddressFHIRConversionTest {
+class Hl7AddressFHIRConversionTest {
 
   @Test
-  public void patient_address_extended_test() {
+  void patient_address_extended_test() {
 
     String patientAddress =
     "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
@@ -55,7 +55,7 @@ public class Hl7AddressFHIRConversionTest {
   }
 
   @Test
-  public void patient_address_date_ranges_test() {
+  void patient_address_date_ranges_test() {
 
     String patientAddress =
     "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
@@ -124,7 +124,7 @@ public class Hl7AddressFHIRConversionTest {
   // District / County conversion testing is unique because it behaves differently when there are multiple addresses
   // Use these tests to also test multiple addresses 
   // See Hl7RelatedGeneralUtils.getAddressDistrict for details on when district and county apply.
-  public void patient_address_district_and_multiple_address_conversion_test() {
+  void patient_address_district_and_multiple_address_conversion_test() {
 
     // When there is no county XAD.9 in the address, and there is only one address, use the PID county.
     String patientSingleAddressYesAddressCountyNoPatientCounty =
@@ -208,7 +208,7 @@ public class Hl7AddressFHIRConversionTest {
   }
 
   @Test
-  public void patient_postal_mail_test() {
+  void patient_postal_mail_test() {
 
     String patientAddressWithPostalMail =
     "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||NE|AL||||||RI543763\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AllergyFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7AllergyFHIRConversionTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7AllergyFHIRConversionTest {
+class Hl7AllergyFHIRConversionTest {
 
     @Test
-    public void test_allergy_single() {
+    void test_allergy_single() {
         String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\r"
                 + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
                 + "AL1|1|DA|^PENICILLIN|MI|PRODUCES HIVES~RASH|MI\r"
@@ -36,7 +36,7 @@ public class Hl7AllergyFHIRConversionTest {
     }
 
     @Test
-    public void test_allergy_no_severity_no_coding_system() {
+    void test_allergy_no_severity_no_coding_system() {
         String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\r"
                 + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\r"
                 + "AL1|1|DA|00000741^OXYCODONE||HYPOTENSION\r";
@@ -58,7 +58,7 @@ public class Hl7AllergyFHIRConversionTest {
     /**
      * Verifies AL1-6 is put into AllergyIntolerance.onsetDateTime; AllergyIntolerance.reaction.onset is not set.
      */
-    public void test_allergy_onset() {
+    void test_allergy_onset() {
         String hl7message = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\r"
                 + "PID|0010||PID1234||DOE^JANE|||F\r"
                 + "AL1|1|DA|00000741^OXYCODONE||HYPOTENSION|20210101\r";

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7DocumentReferenceFHIRConversionTest.java
@@ -30,7 +30,7 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7DocumentReferenceFHIRConversionTest {
+class Hl7DocumentReferenceFHIRConversionTest {
 
     private static FHIRContext context = new FHIRContext();
 
@@ -39,7 +39,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_has_all_fields_in_yaml(String segment) {
+    void doc_ref_has_all_fields_in_yaml(String segment) {
         //every field covered in the yaml should be listed here
         String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
@@ -71,7 +71,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_authenticator_and_author_test(String segment) {
+    void doc_ref_authenticator_and_author_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -117,7 +117,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_content_test(String segment) {
+    void doc_ref_content_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -184,7 +184,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void docRefContextAndServiceRequestPresenceTest(String segment) {
+    void docRefContextAndServiceRequestPresenceTest(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -264,7 +264,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_date_test(String segment) {
+    void doc_ref_date_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -283,7 +283,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_description_test(String segment) {
+    void doc_ref_description_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -302,7 +302,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_doc_status_test(String segment) {
+    void doc_ref_doc_status_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -352,7 +352,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
             "MDM^T02", "MDM^T06"
     })
     @Disabled("TODO: TXA-13 is not yet mapped in DocumentReference.yml")
-    public void doc_ref_relates_to_test(String segment) {
+    void doc_ref_relates_to_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -390,7 +390,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_security_label_test(String segment) {
+    void doc_ref_security_label_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -412,7 +412,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_status_test(String segment) {
+    void doc_ref_status_test(String segment) {
         // Check TXA.19
         // TXA.19 value maps to status; OBR.25 is ignored
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
@@ -463,7 +463,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_subject_test(String segment) {
+    void doc_ref_subject_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -496,7 +496,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_master_identifier_test(String segment) {
+    void doc_ref_master_identifier_test(String segment) {
         // Test masterIdentifier uses the value(12.1) but does not require a system if 12.2 is empty
         String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
@@ -547,7 +547,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "MDM^T02", "MDM^T06"
     })
-    public void doc_ref_type_test(String segment) {
+    void doc_ref_type_test(String segment) {
         String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|" + segment
                 + "^MDM_T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n"
@@ -569,7 +569,7 @@ public class Hl7DocumentReferenceFHIRConversionTest {
     @ValueSource(strings = {
             "PPR^PC1", /* "PPR^PC2", "PPR^PC3" */
     })
-    public void doc_ref_ppr_test(String messageType) {
+    void doc_ref_ppr_test(String messageType) {
         String documentReferenceMessage = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|"
                 + messageType + "|1|P^I|2.6||||||ASCII||\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -47,14 +47,14 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7EncounterFHIRConversionTest {
+class Hl7EncounterFHIRConversionTest {
 
     private static FHIRContext context = new FHIRContext(true, false);
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7EncounterFHIRConversionTest.class);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
 
     @Test
-    public void test_encounter_visitdescription_present() {
+    void test_encounter_visitdescription_present() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
@@ -96,7 +96,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void test_encounter_visitdescription_missing() {
+    void test_encounter_visitdescription_missing() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
@@ -136,7 +136,7 @@ public class Hl7EncounterFHIRConversionTest {
             "RDE^O11", "RDE^O25",
             "VXU^V04"
     })
-    public void test_encounter_with_serviceProvider_from_PV2(String message) {
+    void test_encounter_with_serviceProvider_from_PV2(String message) {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
@@ -183,7 +183,7 @@ public class Hl7EncounterFHIRConversionTest {
             "RDE^O11", "RDE^O25",
             "VXU^V04"
     })
-    public void test_encounter_PV1_serviceProvider(String message) {
+    void test_encounter_PV1_serviceProvider(String message) {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\r"
@@ -229,7 +229,7 @@ public class Hl7EncounterFHIRConversionTest {
             "RDE^O11", "RDE^O25",
             "VXU^V04"
     })
-    public void test_encounter_with_serviceProvider_from_PV1_3_4(String message) {
+    void test_encounter_with_serviceProvider_from_PV1_3_4(String message) {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
                 + "EVN|A01|20150502090000|\r"
@@ -264,7 +264,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void test_encounter_PV2_serviceProvider_idfix() {
+    void test_encounter_PV2_serviceProvider_idfix() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
@@ -298,7 +298,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void test_encounter_class() {
+    void test_encounter_class() {
         // PV1.2 has mapped value and should returned fhir value
         String hl7message = "MSH|^~\\&|PROSOLV|SENTARA|WHIA|IBM|20151008111200|S1|ADT^A01^ADT_A01|MSGID000001|T|2.6|10092|PRPA008|AL|AL|100|8859/1|ENGLISH|ARM|ARM5007\n"
                 + "EVN|A04|20151008111200|20171013152901|O|OID1006|20171013153621|EVN1009\n"
@@ -329,7 +329,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void testEncounterReasonCode() {
+    void testEncounterReasonCode() {
         // EVN.4 and PV2.3 for reasonCode; both with known codes
         String hl7message = "MSH|^~\\&|||||20151008111200||ADT^A01^ADT_A01|MSGID000001|T|2.6|||||||||\n"
                 + "EVN|A04|20151008111200||O|||\n"
@@ -377,7 +377,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void testEncounterLength() {
+    void testEncounterLength() {
 
         // Both start PV1.44 and end PV1.45 must be present to use either value as part of length
         // When both are present, the calculation value is provided in "Minutes"
@@ -433,7 +433,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void testEncounterModeOfArrival() {
+    void testEncounterModeOfArrival() {
         String hl7message = "MSH|^~\\&|PROSOLV|SENTARA|WHIA|IBM|20151008111200|S1|ADT^A01^ADT_A01|MSGID000001|T|2.6|10092|PRPA008|AL|AL|100|8859/1|ENGLISH|ARM|ARM5007\n"
                 + "EVN|A04|20151008111200|20171013152901|O|OID1006|20171013153621|EVN1009\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -460,7 +460,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void test_encounter_modeOfarrival_invalid_singlevalue() {
+    void test_encounter_modeOfarrival_invalid_singlevalue() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
@@ -487,7 +487,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void test_encounter_modeOfarrival_invalid_with_codeAndDisplay() {
+    void test_encounter_modeOfarrival_invalid_with_codeAndDisplay() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
@@ -513,7 +513,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void test_encounter_modeOfarrival_invalid_with_system() {
+    void test_encounter_modeOfarrival_invalid_with_system() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
                 + "PID|1||0a8a1752-e336-43e1-bf7f-0c8f6f437ca3^^^MRN||Patient^Load^Generator||19690720|M|Patient^Alias^Generator|AA|9999^^CITY^STATE^ZIP^CAN|COUNTY|(866)845-0900||ENGLISH^ENGLISH|SIN|NONE|Account_0a8a1752-e336-43e1-bf7f-0c8f6f437ca3|123-456-7890|||N|BIRTH PLACE|N||||||N\n"
@@ -550,7 +550,7 @@ public class Hl7EncounterFHIRConversionTest {
             "RDE^O11", "RDE^O25",
             "VXU^V04"
     })
-    public void test_encounter_PV2segment_missing(String message) {
+    void test_encounter_PV2segment_missing(String message) {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210330144208|8078780|" + message
                 + "|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||ADT_EVENT|007|20210309140700\n"
@@ -569,7 +569,7 @@ public class Hl7EncounterFHIRConversionTest {
     }
 
     @Test
-    public void testEncounterParticipantList() {
+    void testEncounterParticipantList() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR||||20210330144208||ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||||\n"
                 + "PID|1||ABC12345^^^MRN||DOE^JANE|||||||||||||||\n"
@@ -661,7 +661,7 @@ public class Hl7EncounterFHIRConversionTest {
      * Sparse data test. Only one participant is created.
      */
     @Test
-    public void testEncounterParticipantMissing() {
+    void testEncounterParticipantMissing() {
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR||||20210330144208||ADT^A01|MSGID_4e1c575f-6c6d-47b2-ab9f-829f20c96db2|T|2.3\n"
                 + "EVN||20210330144208||||\n"
                 + "PID|1||ABC12345^^^MRN||DOE^JANE|||||||||||||||\n"
@@ -700,7 +700,7 @@ public class Hl7EncounterFHIRConversionTest {
      * Testing Encounter correctly references Observation
      */
     @Test
-    public void testEncounterReferencesObservation() throws IOException {
+    void testEncounterReferencesObservation() throws IOException {
         String hl7message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
                 + "PV1|1|O|Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\n"
@@ -729,7 +729,7 @@ public class Hl7EncounterFHIRConversionTest {
      * Testing Encounter correctly references Observation AND Diagnosis when both are present.
      */
     @Test
-    public void testEncounterReferencesObservationAndDiagnosis() throws IOException {
+    void testEncounterReferencesObservationAndDiagnosis() throws IOException {
         String hl7message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F|||||||||||||||||||||\n"
                 + "PV1|1|O|Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -32,10 +32,10 @@ import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 
-public class Hl7IdentifierFHIRConversionTest {
+class Hl7IdentifierFHIRConversionTest {
 
     @Test
-    public void patientIdentifiersTest() {
+    void patientIdentifiersTest() {
         String patientIdentifiers = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
                 // Three ID's for testing, plus a SSN in field 19.
                 + "PID|1||MRN12345678^^^ID-XYZ^MR~111223333^^^USA^SS~MN1234567^^^MNDOT^DL|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||||||||444556666|D-12445889-Z||||||||||\n";
@@ -113,7 +113,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void patientIdentifiersSpecialCasesTest() {
+    void patientIdentifiersSpecialCasesTest() {
         String patientIdentifiersSpecialCases = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
                 // First ID has blanks in the authority.  Second ID has no authority provided.  Third ID has an unknown CODE in the standard v2 table.
                 + "PID|1||MRN12345678^^^Regional Health ID^MR~111223333^^^^SS~A100071402^^^^AnUnknownCode|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";
@@ -171,7 +171,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void allergyIdentifierTest() {
+    void allergyIdentifierTest() {
         // This identifier uses the logic from BUILD_IDENTIFIER_FROM_CWE (AL1.3) the three different messages test the three different outcomes
 
         // AL1-3.1 and AL1-3.3, concatenate together with a dash
@@ -226,7 +226,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void conditionPrbIdentifierTest() {
+    void conditionPrbIdentifierTest() {
         // Test with PV1-19.1 for visit number, no PRB-4
         String withoutPRB4 = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\n"
                 + "PID|||10290^^^WEST^MR||||20040530|M||||||||||||||||||||||N\n"
@@ -285,7 +285,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void conditionDg1IdentifierTest() {
+    void conditionDg1IdentifierTest() {
 
         String withoutDG120 = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 + "PID|||10290^^^WEST^MR||||20040530|M||||||||||88654||||||||||||N\n"
@@ -410,7 +410,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void observationIdentifierTest() {
+    void observationIdentifierTest() {
         // identifier uses the logic from BUILD_IDENTIFIER_FROM_CWE (OBX.3) and joins FILL or PLAC values with it
 
         // Filler from OBR-3; OBX-3.1/OBX-3.3
@@ -496,7 +496,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void diagnosticReportIdentifierTest() {
+    void diagnosticReportIdentifierTest() {
         // Filler and placer from ORC
         String diagnosticReport = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170825010500||ORU^R01|MSGID22102712|T|2.6\n"
                 + "PID|||1234||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -593,7 +593,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void encounterIdentifierTest() {
+    void encounterIdentifierTest() {
         // Test: Visit number from PV1-19
         String encounterMsg = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "EVN|A01|20130617154644||01\r"
@@ -688,7 +688,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void immunizationIdentifierTest() {
+    void immunizationIdentifierTest() {
         // RXA-5.1 and RXA-5.3, concatenate together with a dash
         String field1AndField3 = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "PID|1||432155^^^ANF^MR||Patient^Johnny^New^^^^L\r"
@@ -745,7 +745,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void procedureIdentifierTest() {
+    void procedureIdentifierTest() {
         // with PR1 and PID segments used to create identifiers
         String procedureMsg = "MSH|^~\\&|HL7Soup|Instance1|MCM||200911021022|Security|ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM|CDP|^4086::132:2A57:3C28^IPV6|^4086::132:2A57:3C25^IPV6|\n"
                 + "PID|1||000054321^^^MRN|||||||||||||M|CAT|78654^^^ACME||||N\n"
@@ -818,7 +818,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void documentReferenceIdentifierTest() {
+    void documentReferenceIdentifierTest() {
         // Filler and placer from ORC, extId from MSH-7
         String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 +
@@ -993,7 +993,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void serviceRequestIdentifierTest1() {
+    void serviceRequestIdentifierTest1() {
         // Test 1 removed:  OMP_O09 messages do not create a service request
 
         // Test 2:
@@ -1114,7 +1114,7 @@ public class Hl7IdentifierFHIRConversionTest {
     // NOTE: ORU_RO1 records do not create the ServiceRequest directly.  They create a DiagnosticReport and it creates the ServiceRequest.
     // This test makes sure the specification for ORU_RO1.DiagnosticReport is specifying PID and PV1 correctly in AdditionalSegments.
     @Test
-    public void serviceRequestIdentifierTest2() {
+    void serviceRequestIdentifierTest2() {
         // Test 1:
         //  - Visit number with PV1.19
         //  - filler and placer from OBR
@@ -1302,7 +1302,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void medicationRequestIdentifierTest() {
+    void medicationRequestIdentifierTest() {
         // Visit number from PID-18, extID from RXO-1.1
         String medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||OMP^O09|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "PID|1||000054321^^^MRN|||||||||||||||78654\r"
@@ -1521,7 +1521,7 @@ public class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    public void medicationAdministration_identifier_test() {
+    void medicationAdministration_identifier_test() {
         // TODO
         // Currently no messages generate MedicationAdministration resources
     }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7ImmunizationFHIRConversionTest {
+class Hl7ImmunizationFHIRConversionTest {
 
     @Test
-    public void testImmunization() throws IOException {
+    void testImmunization() throws IOException {
 
         // RXA.20 is "completed" this takes precedence over rxa.18 having a value and orc.5
         String hl7VUXmessageRep = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1|||NE|AL||||||RI543763\r"
@@ -267,7 +267,7 @@ public class Hl7ImmunizationFHIRConversionTest {
     // The following checks for a situation where non-manufacturer RXA Immunizations interfered with the creation of manufacturer Immununization
     // The test will ensure the problem doesn't come back.
     @Test
-    public void testMultipleImmunizationsNoInterference() throws IOException {
+    void testMultipleImmunizationsNoInterference() throws IOException {
 
         String hl7VUXmessageRep = "MSH|^~\\&|||||20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.5.1||||||||||\r"
                 + "PID|1||12345^^^^MR||TestPatient^Jane^^^^^L||||||\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7MedicationRequestFHIRConversionTest.java
@@ -25,13 +25,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 import io.github.linuxforhealth.core.config.ConverterConfiguration;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7MedicationRequestFHIRConversionTest {
+class Hl7MedicationRequestFHIRConversionTest {
 
     // private static FHIRContext context = new FHIRContext(true, false);
     //     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MedicationRequestFHIRConversionTest.class);
 
     @Test
-    public void test_medicationreq_patient() {
+    void test_medicationreq_patient() {
         String hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON,CARL|0148^ADDISON,JAMES||SUR|||||||0100^ANDERSON,CARL|S|V446911|A|||||||||||||||||||SF|K||||20180622230000\n"
@@ -61,7 +61,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
     }
 
     @Test
-    public void test_medicationreq_status() {
+    void test_medicationreq_status() {
 
         //ORC.5 = A -> Expected medication status = (ACTIVE ORC.1 is present but ORC.5 takes precedence)
         String hl7message = "MSH|^~\\&|APP|FAC|WHIA|IBM|20180622230000||RDE^O11^RDE_O11|MSGID221xx0xcnvMed31|T|2.6\n"
@@ -188,7 +188,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
 
     // Test that OMP_O09 messages don't create ServiceRequests, they create MedicationRequests
     @Test
-    public void medicationFromOMPTest() {
+    void medicationFromOMPTest() {
         // Minimal valid ORC message.  Requires RXO and RXR segments.
         String hl7message = "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210101000000|90103687|OMP^O09|MSGID|T|2.6\n"
                 + "PID|||1234||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -216,7 +216,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
             "MSH|^~\\&||||||S1|RDE^O11||T|2.6|||||||||\r",
             "MSH|^~\\&||||||S1|RDE^O25||T|2.6|||||||||\r",
     })
-    public void test_medicationCodeableConcept_authoredOn_and_intent_in_rde_with_rxO_with_rxe(String msh) {
+    void test_medicationCodeableConcept_authoredOn_and_intent_in_rde_with_rxO_with_rxe(String msh) {
 
         //AuthoredOn comes from ORC.9 (the backup value) No RXE.32
         String hl7message = msh
@@ -266,7 +266,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
             "MSH|^~\\&||||||S1|RDE^O11||T|2.6|||||||||\r",
             "MSH|^~\\&||||||S1|RDE^O25||T|2.6|||||||||\r",
     })
-    public void test_medicationCodeableConcept_authoredOn_and_intent_in_rde_with_just_rxe(String msh) {
+    void test_medicationCodeableConcept_authoredOn_and_intent_in_rde_with_just_rxe(String msh) {
 
         //AuthoredOn comes from RXE.32
         String hl7message = msh
@@ -316,7 +316,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
             // --UNCOMMENT BELOW WHEN CONVERTER SUPPORTS THIS MESSAGE TYPE-- 
             "MSH|^~\\&||||||S1|ORM^O01||T|2.6|||||||||\r",
     })
-    public void test_medicationCodeableConcept_and_intent_in_OMP_and_ORM(String msh) {
+    void test_medicationCodeableConcept_and_intent_in_OMP_and_ORM(String msh) {
 
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -358,7 +358,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
     // "MSH|^~\\&||||||S1|PPR^PC2||T|2.6|||||||||\r",
     // "MSH|^~\\&||||||S1|PPR^PC3||T|2.6|||||||||\r",
     })
-    public void test_medicationCodeableConcept_and_intent_in_PPR(String msh) {
+    void test_medicationCodeableConcept_and_intent_in_PPR(String msh) {
 
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -402,7 +402,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
     // "MSH|^~\\&||||||S1|PPR^PC2||T|2.6|||||||||\r",
     // "MSH|^~\\&||||||S1|PPR^PC3||T|2.6|||||||||\r",
     })
-    public void testMedicationRequestInPPRWithAPatientVisit() {
+    void testMedicationRequestInPPRWithAPatientVisit() {
 
         String hl7message = "MSH|^~\\&||||||S1|PPR^PC1||T|2.6|||||||||\r"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
@@ -437,7 +437,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
     }
 
     @Test
-    public void test_MedicationRequest_ReasonCode() {
+    void test_MedicationRequest_ReasonCode() {
         //reason code from RXE.27
         String hl7message = "MSH|^~\\&||||||S1|RDE^O11||T|2.6|||||||||\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -501,7 +501,7 @@ public class Hl7MedicationRequestFHIRConversionTest {
     }
 
     @Test
-    public void test_MedicationRequest_category_requester_and_dispenseRequest() {
+    void test_MedicationRequest_category_requester_and_dispenseRequest() {
         String hl7message = "MSH|^~\\&||||||S1|RDE^O11||T|2.6|||||||||\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 + "ORC|NW|||||E|10^BID^D4^^^R||20180622230000|||3122^PROVIDER^ORDERING^^^DR|||20190606193536||||||||||||||I\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -34,7 +34,7 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 // High level note creation for other messages is done:
 // For MDM_T0x in test_mdm_ORDER_with_OBXnotTX
 
-public class Hl7NoteFHIRConverterTest {
+class Hl7NoteFHIRConverterTest {
 
     // Tests NTE creation for OBX (Observations) and ORC/OBRs (ServiceRequests)
     // Test associated Practitioners and references created. (NTE.4)
@@ -50,7 +50,7 @@ public class Hl7NoteFHIRConverterTest {
 
     @ParameterizedTest
     @MethodSource("provideParmsForNoteCreationServiceRequestMutipleOBX")
-    public void testNoteCreationServiceRequestMutipleOBX(String message, int numExpectedDiagnosticReports) {
+    void testNoteCreationServiceRequestMutipleOBX(String message, int numExpectedDiagnosticReports) {
         String hl7ORU = "MSH|^~\\&|||||20180924152907||" + message + "|213|T|2.3.1|||||||||||\n"
                 + "PID|||Pract1ID^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 // TODO: Future work, handle NTE's on PID
@@ -173,7 +173,7 @@ public class Hl7NoteFHIRConverterTest {
 
     @ParameterizedTest
     @MethodSource("parmsTestMedicationRequestNoteCreation")
-    public void testMedicationRequestNoteCreation(String message, String medicalRequestSegments) {
+    void testMedicationRequestNoteCreation(String message, String medicalRequestSegments) {
         // Minimal valid ORC message.  Requires RXO and RXR segments.
         String hl7message = "MSH|^~\\&||||IBM|20210101000000||" + message + "|MSGID|T|2.6\n"
                 + "PID|||1234||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -270,7 +270,7 @@ public class Hl7NoteFHIRConverterTest {
     // Test that multiple problems (PRB) each with multiple notes (NTE) are associated with the correct NTE / PRB 
     // and that there is no "bleed"
     @Test
-    public void testNoteCreationMutiplePPR() throws IOException {
+    void testNoteCreationMutiplePPR() throws IOException {
         // TODO: Add PC2 and PC3 tests in future            
         String message = "PPR^PC1";
         String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|" + message

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ObservationFHIRConversionTest.java
@@ -47,7 +47,7 @@ import io.github.linuxforhealth.hl7.resource.ResourceReader;
 import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7ObservationFHIRConversionTest {
+class Hl7ObservationFHIRConversionTest {
     private static FHIRContext context = new FHIRContext();
     private static HL7MessageEngine engine = new HL7MessageEngine(context);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
@@ -68,7 +68,7 @@ public class Hl7ObservationFHIRConversionTest {
     private HL7MessageModel message = new HL7MessageModel("ADT", Lists.newArrayList(observation));
 
     @Test
-    public void testObservationNmResult() throws IOException {
+    void testObservationNmResult() throws IOException {
         String hl7message = baseMessage + "OBX|1|NM|0135-4^TotalProtein||7.3|gm/dl|5.9-8.4|||R|F";
         String json = message.convert(hl7message, engine);
 
@@ -105,7 +105,7 @@ public class Hl7ObservationFHIRConversionTest {
      * @throws IOException
      */
     @Test
-    public void testObservationSN_valueQuantity_result() throws IOException {
+    void testObservationSN_valueQuantity_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|28-1^Ampicillin Islt MIC^LN||<^0.06|ug/mL^^UCUM|||";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
@@ -131,7 +131,7 @@ public class Hl7ObservationFHIRConversionTest {
      * @throws IOException
      */
     @Test
-    public void testObservationSN_valueQuantity_equals_comparator_result() throws IOException {
+    void testObservationSN_valueQuantity_equals_comparator_result() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|SN|24467-3^CD3+CD4+ (T4 helper) cells [#/volume] in Blood^LN||=^440|{Cells}/uL^cells per microliter^UCUM|649-1346 cells/mcL|L|||F";
 
@@ -175,7 +175,7 @@ public class Hl7ObservationFHIRConversionTest {
      * @throws IOException
      */
     @Test
-    public void testObservationSN_valueQuantity_notnull_separator_result() throws IOException {
+    void testObservationSN_valueQuantity_notnull_separator_result() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|SN|24467-3^CD3+CD4+ (T4 helper) cells [#/volume] in Blood^LN||=^440^.|{Cells}/uL^cells per microliter^UCUM|||||F";
 
@@ -195,7 +195,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationSN_valueQuantity_missing_comparator_result() throws IOException {
+    void testObservationSN_valueQuantity_missing_comparator_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|1554-5^GLUCOSE||^182|mg/dl|70_105||||F";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
@@ -228,7 +228,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationSN_valueRatio_colon_result() throws IOException {
+    void testObservationSN_valueRatio_colon_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|111^LabWithRatio||^2^:^3|";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
@@ -243,7 +243,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationSN_valueRatio_slash_result() throws IOException {
+    void testObservationSN_valueRatio_slash_result() throws IOException {
         String hl7message = baseMessage + "OBX|1|SN|111^LabWithRatio||^2^/^3|";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
@@ -258,7 +258,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationSTResult() throws IOException {
+    void testObservationSTResult() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|ST|^Type of protein feed^L||Fourth Line: HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%||||||F||||Alex||";
 
@@ -274,7 +274,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationSTMultiplePartsResult() throws IOException {
+    void testObservationSTMultiplePartsResult() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|ST|^Type of protein feed^L||HYPERDYNAMIC LV SYSTOLIC FUNCTION, VISUAL EF 80%~Fifth line, as part of a repeated field||||||F||";
 
@@ -291,7 +291,7 @@ public class Hl7ObservationFHIRConversionTest {
 
     // NOTE that even though we are testing for it CE is not part of HL7 V2.6
     @Test
-    public void testObservationCeResultUnknownSystem() throws IOException {
+    void testObservationCeResultUnknownSystem() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
 
@@ -311,7 +311,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationCeResultKnownSystem() throws IOException {
+    void testObservationCeResultKnownSystem() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^LN";
 
@@ -331,7 +331,7 @@ public class Hl7ObservationFHIRConversionTest {
     }
 
     @Test
-    public void testObservationStNullResult() throws IOException {
+    void testObservationStNullResult() throws IOException {
         String hl7message = baseMessage
                 + "OBX|1|ST|14151-5^HCO3 BldCo-sCnc^LN|TEST|||||||F|||20210311122016|||||20210311122153||||";
 
@@ -374,7 +374,7 @@ public class Hl7ObservationFHIRConversionTest {
             //"MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|PPR^PC3|||2.6||||||||2.6\r",
             "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|VXU^V04|||2.6||||||||2.6\r",
     })
-    public void extendedObservationTestMostMessages(String msh) throws IOException {
+    void extendedObservationTestMostMessages(String msh) throws IOException {
         String hl7message = msh
                 + "OBX|1|CWE|DQW^Some text 1^SNM3|100|DQW^Other text 2^SNM3|mm^Text 3^SNM3|56-98|IND|25|ST|F|20210322153839|LKJ|20210320153850|N56|1111^ClinicianLastName^ClinicianFirstName^^^^Title|Manual^Text the 4th^SNM3|Device_1234567^mySystem|20210322153925|Observation Site^Text 5^SNM3|INST^Instance Identifier System||Radiology^Radiological Services|467 Albany Hospital^^Albany^NY|Cardiology^ContactLastName^Jane^Q^^Dr.^MD\r";
 
@@ -492,7 +492,7 @@ public class Hl7ObservationFHIRConversionTest {
 
     // A companion test to extendedObservationCWEtest that looks for edge cases
     @Test
-    public void extendedObservationUnusualRangesAndOtherTest() throws IOException {
+    void extendedObservationUnusualRangesAndOtherTest() throws IOException {
         String ORU_r01 = "MSH|^~\\&|NIST Test Lab APP|NIST Lab Facility||NIST EHR Facility|20150926140551||ORU^R01|NIST-LOI_5.0_1.1-NG|T|2.5.1|||AL|AL|||||\r"
                 + "PID|1||||DOE^JANE||||||||||||\r"
                 + "ORC|NW|ORD448811^NIST EHR|R-511^NIST Lab Filler||||||20120628070100|||5742200012^Radon^Nicholas^^^^^^NPI^L^^^NPI\r"
@@ -550,7 +550,7 @@ public class Hl7ObservationFHIRConversionTest {
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O11|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r",
             "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB||IBM|20210407191342|25739|RDE^O25|MSGID_f209e83f-20db-474d-a7ae-82e5c3894273|T|2.6\r"
     })
-    public void extendedObservationTestForRDEMessages(String msh) throws IOException {
+    void extendedObservationTestForRDEMessages(String msh) throws IOException {
 
         String hl7message = msh
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7OrderRequestFHIRConversionTest.java
@@ -31,14 +31,14 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Hl7OrderRequestFHIRConversionTest {
+class Hl7OrderRequestFHIRConversionTest {
 
   private static FHIRContext context = new FHIRContext(true, false);
   private static final Logger LOGGER = LoggerFactory.getLogger(Hl7MedicationRequestFHIRConversionTest.class);
 
   // Read comments carefully.  Tests
   @Test
-  public void testBroadORCFields() {
+  void testBroadORCFields() {
 
     String hl7message =
 
@@ -146,7 +146,7 @@ public class Hl7OrderRequestFHIRConversionTest {
   // This test is a companion to testBroadORCFields.   ORC and OBR records often have repeated data; one taking priority over the other.
   // Read comments carefully.  This sometimes tests the secondary value and may be the opposite to the tests in testBroadORCFields.
   @Test
-  public void testBroadORCPlusOBRFields() {
+  void testBroadORCPlusOBRFields() {
 
     String hl7message = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
         // PID.18 is used as backup identifier visit number because PV1.19 is empty
@@ -281,7 +281,7 @@ public class Hl7OrderRequestFHIRConversionTest {
   }
 
   @Test
-  public void testBroadORCPlusOBRFields2() {
+  void testBroadORCPlusOBRFields2() {
 
     String hl7message = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
             // PID.18 is empty, MSH.7 will be used as identifier visit number 
@@ -332,7 +332,7 @@ public class Hl7OrderRequestFHIRConversionTest {
   }
 
   @Test
-  public void testAdditionalOBRFieldsNoORCSegment() {
+  void testAdditionalOBRFieldsNoORCSegment() {
 
     String hl7message =
 
@@ -386,7 +386,7 @@ public class Hl7OrderRequestFHIRConversionTest {
   // This test assures the MDM_T02 is properly enabled. 
   // It focuses on _differences_ in MDM not tested above, then does general confirmation of other fields
   @Test
-  public void testMDMT02ServiceRequest() {
+  void testMDMT02ServiceRequest() {
 
     String hl7message =
         "MSH|^~\\&|Epic|PQA|WHIA|IBM|20170920141233||MDM^T02^MDM_T02|M1005|D|2.6\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -37,7 +37,7 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-public class Hl7PatientFHIRConversionTest {
+class Hl7PatientFHIRConversionTest {
 
   private static FHIRContext context = new FHIRContext(true, false);
   private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PatientFHIRConversionTest.class);
@@ -61,7 +61,7 @@ public class Hl7PatientFHIRConversionTest {
     "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O25|||2.6|\r",
     "MSH|^~\\&|hl7Integration|hl7Integration|||||VXU^V04|||2.6|\r",
     })
-    public void test_patient_additional_demographics(String msh) {
+    void test_patient_additional_demographics(String msh) {
         String hl7message = msh
                 + "PID|1||1234^^^AssigningAuthority^MR||TEST^PATIENT|\r"
                 + "PD1|||Sample Family Practice^^2222|1111^LastName^ClinicianFirstName^^^^Title||||||||||||A|\r"
@@ -90,7 +90,7 @@ public class Hl7PatientFHIRConversionTest {
      */
 
     @Test
-    public void patient_deceased_conversion_test() {
+    void patient_deceased_conversion_test() {
 
         String patientMsgDeceasedEmpty = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
                 + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA||||\n";
@@ -156,7 +156,7 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patient_multiple_birth_conversion_test() {
+    void patient_multiple_birth_conversion_test() {
 
         /**
          * Simplified logic for multiple birth
@@ -222,7 +222,7 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patient_use_name_conversion_test() {
+    void patient_use_name_conversion_test() {
         String patientUseName = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
                 +
                 "PID|1||PA123456^^^MYEMR^MR||TestPatient^John^M^^^^B|MILLER^MARTHA^G^^^^M|20140227|M||2106-3^WHITE^CDCREC|1234 W FIRST ST^^BEVERLY HILLS^CA^90210^^H||^PRN^PH^^^555^5555555||ENG^English^HL70296|||||||2186-5^ not Hispanic or Latino^CDCREC||Y|2\r";
@@ -236,7 +236,7 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patientNameTest() {
+    void patientNameTest() {
         String patientHasMiddleName = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
                 // PID 5 fields (name) are extracted and tested
                 + "PID|1||PA123456^^^MYEMR^MR||JONES^GEORGE^Q^III^MR^^B||||||||||||||||||||\r";
@@ -259,7 +259,7 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patientGenderTest() {
+    void patientGenderTest() {
         String patientEmptyGenderField = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
                 +
                 "PID|0010||||DOE^JOHN^A^|||||||\r";
@@ -279,7 +279,7 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patientMaritalStatusTest() {
+    void patientMaritalStatusTest() {
         String marriedPatientWithVersion = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
                 +
                 "PID|1||12345678^^^MRN||TestPatient^Jane|||||||||||M^^^^^^47||||||\r";
@@ -310,7 +310,7 @@ public class Hl7PatientFHIRConversionTest {
     }
 
     @Test
-    public void patientCommunicationLanguage() {
+    void patientCommunicationLanguage() {
 
         String patientSpeaksEnglishWithSystem = "MSH|^~\\&|MyEMR|DE-000001| |CAIRLO|20160701123030-0700||VXU^V04^VXU_V04|CA0001|P|2.6|||ER|AL|||||Z22^CDCPHINVS|DE-000001\r"
                 +
@@ -466,7 +466,7 @@ public class Hl7PatientFHIRConversionTest {
 
     // Tests Data lineage for a ORU^R01 message
     @Test
-    public void verify_data_lineage_ORU() {
+    void verify_data_lineage_ORU() {
 
         String hl7message = "MSH|^~\\&|SendingApplication|Sending^Facility|Receiving-Application|ReceivingFacility|20060915210000||ORU^R01|1473973200100600|P|2.3|||NE|NE\n"
                 + "PID|1||1234^^^AssigningAuthority^MR||TEST^PATIENT|\n"
@@ -476,7 +476,7 @@ public class Hl7PatientFHIRConversionTest {
 
     // Tests Data lineage for a message with milliseconds in MSH-7
     @Test
-    public void verify_data_lineage_milliseconds_timestamp() {
+    void verify_data_lineage_milliseconds_timestamp() {
         String hl7message = "MSH|^~\\&|SendingApplication|Sending^Facility|Receiving-Application|ReceivingFacility|20060915210000.567||ORU^R01|1473973200100600|P|2.3|||NE|NE\n"
                 + "PID|1||1234^^^AssigningAuthority^MR||TEST^PATIENT|\n"
                 + "PD1|||Sample Family Practice^^2222|1111^LastName^ClinicianFirstName^^^^Title||||||||||||A|";
@@ -485,7 +485,7 @@ public class Hl7PatientFHIRConversionTest {
 
     // Tests Data lineage for a ADT^A01 message
     @Test
-    public void verify_data_lineage_ADT() {
+    void verify_data_lineage_ADT() {
         String hl7message = "MSH|^~\\&|SendingApplication|hl7Integration|||20060915210000||ADT^A01|1473973200100600||2.3|\r"
                 + "EVN|A01|20130617154644\r"
                 + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^Sr^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -497,7 +497,7 @@ public class Hl7PatientFHIRConversionTest {
 
     // Tests Data lineage for a VXU^V04 message
     @Test
-    public void verify_data_lineage_VXU() {
+    void verify_data_lineage_VXU() {
         String hl7message = "MSH|^~\\&|SendingApplication|RI88140101|KIDSNET_IFL|RIHEALTH|20060915210000||VXU^V04|1473973200100600|P|2.3|||NE|AL||||||RI543763\r"
                 + "PID|1||432155^^^^MR||Patient^Johnny^New^^^^L|Smith^Sally|20130414|M||2106-3^White^HL70005|123 Any St^^Somewhere^WI^54000^^M\r"
                 + "NK1|1|Patient^Sally|MTH^mother^HL70063|123 Any St^^Somewhere^WI^54000^^M|^PRN^PH^^^608^5551212|||||||||||19820517||||eng^English^ISO639\r"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ServiceRequestFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ServiceRequestFHIRConversionTest.java
@@ -32,14 +32,14 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
  * Tests focused on Service Requests details created by different message events
  *
  */
-public class Hl7ServiceRequestFHIRConversionTest {
+class Hl7ServiceRequestFHIRConversionTest {
 
     private static FHIRContext context = new FHIRContext(true, false);
     private static final Logger LOGGER = LoggerFactory.getLogger(Hl7ServiceRequestFHIRConversionTest.class);
     private static final ConverterOptions OPTIONS = new Builder().withValidateResource().build();
 
     @Test
-    public void test_ppr_pc1_service_request() throws IOException {
+    void test_ppr_pc1_service_request() throws IOException {
         // Currently only tests limited items, TODO add tests for other field
 
         String hl7message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|202101010000|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 
-public class Hl7TelecomFHIRConversionTest {
+class Hl7TelecomFHIRConversionTest {
 
   @Test
-  public void patient_telcom_test() {
+  void patient_telcom_test() {
 
     String patientPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
         // Home has 2 phones and an email, work has one phone and two emails
@@ -77,7 +77,7 @@ public class Hl7TelecomFHIRConversionTest {
   }
 
   @Test
-  public void patient_no_telcom_test() {
+  void patient_no_telcom_test() {
 
     String patientNoPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
         + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This does only one thing to make it easy to review.  `public` is removed on all 350+ test methods where it was flagged by SonarQube.  Removing will get rid of much of the "noise" in SonarQube reports.

@jgrant22  tag