### PR TITLE
Handle 40+ additional SonarQube warnings; Format

### DIFF
--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -208,7 +208,7 @@ class Hl7RelatedGeneralUtilsTest {
     }
 
     @Test
-    void test_getAddressUse() {
+    void test_getAddressUse1() {
         String ANYTHING = "anything";
         // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("C", "", ANYTHING)).isEqualTo("temp");
@@ -229,6 +229,13 @@ class Hl7RelatedGeneralUtilsTest {
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, ANYTHING, "Y")).isEqualTo("old");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(ANYTHING, null, "Y")).isEqualTo("old");
         assertThat(Hl7RelatedGeneralUtils.getAddressUse(null, null, "Y")).isEqualTo("old");
+        // More tests of getAddressUse in test_getAddressUse2
+    }
+
+    @Test
+    void test_getAddressUse2() {
+        String ANYTHING = "anything";
+        // Inputs are XAD.7 Type, XAD.16 Temp Indicator, XAD.17 Bad address indicator
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", ANYTHING, ANYTHING)).isEmpty();
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("BA", null, ANYTHING)).isEmpty();
         assertThat(Hl7RelatedGeneralUtils.getAddressUse("H", ANYTHING, ANYTHING)).isEqualTo("home");

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/ResourceExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/ResourceExpressionTest.java
@@ -58,7 +58,7 @@ class ResourceExpressionTest {
 
         Map<String, Object> result = (Map<String, Object>) value.getValue();
         assertThat(result.get("use")).isNull();
-        assertThat(result.get("value")).isEqualTo("000010016");
+        assertThat(result).containsEntry("value", "000010016");
 
     }
 
@@ -116,7 +116,7 @@ class ResourceExpressionTest {
         assertThat(value).isNotNull();
         Map<String, Object> result = (Map<String, Object>) value.getValue();
         assertThat(result.get("use")).isNull();
-        assertThat(result.get("value")).isEqualTo("000010017");
+        assertThat(result).containsEntry("value", "000010017");
         assertThat(result.get("type")).isNull();
 
     }
@@ -149,7 +149,8 @@ class ResourceExpressionTest {
 
         Map<String, Object> result = (Map<String, Object>) results.get(0);
         assertThat(result.get("use")).isNull();
-        assertThat(result.get("value")).isEqualTo("000010016");
+        assertThat(result).containsEntry("value", "000010016");
+
         assertThat(result.get("system")).isNull();
         assertThat(result.get("type")).isNotNull();
 
@@ -179,7 +180,8 @@ class ResourceExpressionTest {
                 new SimpleEvaluationResult(s));
         Map<String, Object> result = (Map<String, Object>) value.getValue();
         assertThat(result.get("use")).isNull();
-        assertThat(result.get("value")).isEqualTo("1234");
+        assertThat(result).containsEntry("value", "1234");
+
         assertThat(result.get("system")).isNull();
 
     }
@@ -210,7 +212,8 @@ class ResourceExpressionTest {
         List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
         Map<String, Object> type = (Map<String, Object>) result.get(0).get("type");
 
-        assertThat(type.get("text")).isEqualTo("some text");
+        assertThat(type).containsEntry("text", "some text");
+
         assertThat(type.get("coding")).isNotNull();
         List<Object> list = (List) type.get("coding");
         SimpleCode scs = (SimpleCode) list.get(0);
@@ -245,7 +248,8 @@ class ResourceExpressionTest {
                 new SimpleEvaluationResult(s));
 
         List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-        assertThat(result.get(0).get("text")).isEqualTo("some text");
+        assertThat(result.get(0)).containsEntry("text", "some text");
+
         assertThat(result.get(0).get("coding")).isNotNull();
         List<Object> list = (List) result.get(0).get("coding");
         SimpleCode scs = (SimpleCode) list.get(0);
@@ -319,7 +323,7 @@ class ResourceExpressionTest {
                 new SimpleEvaluationResult(s));
 
         List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-        assertThat(result.get(0).get("name")).isEqualTo("sanofi");
+        assertThat(result.get(0)).containsEntry("name", "sanofi");
         assertThat(result.get(0).get("identifier")).isNull();
 
         LOGGER.debug("result=" + result);
@@ -389,9 +393,9 @@ class ResourceExpressionTest {
                 new SimpleEvaluationResult(s));
 
         List<Map<String, Object>> result = (List<Map<String, Object>>) value.getValue();
-        assertThat(result.get(0).get("name")).isEqualTo("sanofi");
+        assertThat(result.get(0)).containsEntry("name", "sanofi");
         List<Map<String, Object>> identifiers = (List<Map<String, Object>>) result.get(0).get("identifier");
-        assertThat(identifiers.get(0).get("value")).isEqualTo("PMC");
+        assertThat(identifiers.get(0)).containsEntry("value", "PMC");
 
         LOGGER.debug("result=" + result);
 

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7OMPMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7OMPMessageTest.java
@@ -9,28 +9,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import io.github.linuxforhealth.fhir.FHIRContext;
-import io.github.linuxforhealth.hl7.ConverterOptions;
-import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
-import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 class Hl7OMPMessageTest {
-    private static FHIRContext context = new FHIRContext();
-    private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder().withBundleType(BundleType.COLLECTION)
-            .withValidateResource().withPrettyPrint().build();
-    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7OMPMessageTest.class);
 
     // For reference, here is an example OMP_O09
     // "MSH|^~\\&|WHI_LOAD_GENERATOR|IBM_TORONTO_LAB|MEDORDER|IBM|20210407191342|9022934|OMP^O09|MSGID_bae9ce6a-e35d-4ff5-8d50-c5dde19cc1aa|T|2.5.1\r"
@@ -49,23 +36,12 @@ class Hl7OMPMessageTest {
                 + "ORC|OP|1000|9999999||||^3 times daily^^20210401\r"
                 + "RXO|50111032701^hydrALAZINE HCl 25 MG Oral Tablet^NDC^^^^^^hydrALAZINE (APRESOLINE) 25 MG TABS|||||||||||||||||||||||\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> medicationRequestResource = e.stream()
-                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medicationRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medicationRequestResource).hasSize(1);
 
         // Confirm that there are no extra resources created
@@ -81,28 +57,15 @@ class Hl7OMPMessageTest {
                 + "ORC|OP|1000|9999999||||^3 times daily^^20210401\r"
                 + "RXO|50111032701^hydrALAZINE HCl 25 MG Oral Tablet^NDC^^^^^^hydrALAZINE (APRESOLINE) 25 MG TABS|||||||||||||||||||||||\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> medicationRequestResource = e.stream()
-                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medicationRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medicationRequestResource).hasSize(1);
 
         // Confirm that there are no extra resources created
@@ -123,33 +86,18 @@ class Hl7OMPMessageTest {
                 + "ORC|OP|1000|9999999||||^3 times daily^^20210401\r"
                 + "RXO|50111032701^hydrALAZINE HCl 25 MG Oral Tablet^NDC^^^^^^hydrALAZINE (APRESOLINE) 25 MG TABS|||||||||||||||||||||||\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1);
 
-        List<Resource> allergyResource = e.stream()
-                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> allergyResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
         assertThat(allergyResource).hasSize(3);
 
-        List<Resource> medicationRequestResource = e.stream()
-                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medicationRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medicationRequestResource).hasSize(1);
 
         // Confirm that there are no extra resources created
@@ -171,28 +119,15 @@ class Hl7OMPMessageTest {
                 + "RXO|RX800006^Test15 SODIUM 100 MG CAPSULE|100||mg|||||G||10||5\r"
                 + "OBX|1|ST|TS-F-01-002^Endocrine Disorders^L||obs report||||||F\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> medicationRequestResource = e.stream()
-                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medicationRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medicationRequestResource).hasSize(2);
 
-        List<Resource> observationResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(observationResource).hasSize(4);
 
         // Confirm that there are no extra resources created
@@ -214,29 +149,16 @@ class Hl7OMPMessageTest {
                 + "OBX|1|TX|1234^some text^SCT||First line: Sodium Report||||||F||\n"
                 + "OBX|2|TX|1234^some text^SCT||Second line: Sodium REPORT||||||F||\n";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> medicationRequestResource = e.stream()
-                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medicationRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medicationRequestResource).hasSize(2);
 
-        List<Resource> docRefResource = e.stream()
-                .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(docRefResource).hasSize(0);//TODO: This should be 2 when card 864 is completed
+        List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
+        assertThat(docRefResource).isEmpty();//TODO: This should be 2 when card 864 is completed
 
         // Confirm that there are no extra resources created
         assertThat(e.size()).isEqualTo(3); //TODO: This should be 5 when card 864 is completed
@@ -262,34 +184,19 @@ class Hl7OMPMessageTest {
                 + "ORC|OP|1000|9999999||||^3 times daily^^20210401\r"
                 + "RXO|50111032701^hydrALAZINE HCl 25 MG Oral Tablet^NDC^^^^^^hydrALAZINE (APRESOLINE) 25 MG TABS|||||||||||||||||||||||\r";
 
-        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
-        assertThat(json).isNotBlank();
-        LOGGER.debug("FHIR json result:\n" + json);
-        IBaseResource bundleResource = context.getParser().parseResource(json);
-        assertThat(bundleResource).isNotNull();
-        Bundle b = (Bundle) bundleResource;
-        List<BundleEntryComponent> e = b.getEntry();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
 
-        List<Resource> medicationRequestResource = e.stream()
-                .filter(v -> ResourceType.MedicationRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> medicationRequestResource = ResourceUtils.getResourceList(e, ResourceType.MedicationRequest);
         assertThat(medicationRequestResource).hasSize(3);
 
-        List<Resource> observationResource = e.stream()
-                .filter(v -> ResourceType.Observation == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
         assertThat(observationResource).hasSize(3);
 
-        List<Resource> docRefResource = e.stream()
-                .filter(v -> ResourceType.DocumentReference == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
-        assertThat(docRefResource).hasSize(0); //TODO: This should be 1 when card 864 is completed
+        List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
+        assertThat(docRefResource).isEmpty(); //TODO: This should be 1 when card 864 is completed
 
         // Confirm that there are no extra resources created
         assertThat(e.size()).isEqualTo(7); //TODO: This should be 8 when card 864 is completed

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -571,7 +571,7 @@ class Hl7ORUMessageTest {
 
         //Verify no observations are created
         List<Resource> obsResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
-        assertThat(obsResource).hasSize(0); // TODO: When NTE is implemented, then update this to one.
+        assertThat(obsResource).isEmpty(); // TODO: When NTE is implemented, then update this to one.
 
         ///////////////////////////////////////////
         // Now confirm content of the diagnosticReport because we don't have separate tests for DiagnosticReport
@@ -656,7 +656,7 @@ class Hl7ORUMessageTest {
     // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
     @java.lang.SuppressWarnings("squid:S5961")
     void test_oru_multipleOBXWithMixedType() throws IOException {
-        
+
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(new File("src/test/resources/ORU-multiline-short-mixed.hl7"), OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7PPRMessageTest.java
@@ -16,7 +16,6 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -102,7 +101,7 @@ class Hl7PPRMessageTest {
         assertThat(conditionResource).hasSize(1);
 
         List<Resource> docRefResource = ResourceUtils.getResourceList(e, ResourceType.DocumentReference);
-        assertThat(docRefResource).hasSize(0); //TODO: Expect this to be 1 when card #855 is completed
+        assertThat(docRefResource).isEmpty(); //TODO: Expect this to be 1 when card #855 is completed
 
         // Confirm that no extra resources are created
         assertThat(e.size()).isEqualTo(3); //TODO: Expect this to be 4 when card #855 is completed

--- a/src/test/java/io/github/linuxforhealth/hl7/parsing/HL7DataExtractorTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/parsing/HL7DataExtractorTest.java
@@ -6,9 +6,12 @@
 package io.github.linuxforhealth.hl7.parsing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
+
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.model.Primitive;
@@ -20,493 +23,416 @@ import ca.uhn.hl7v2.model.primitive.IS;
 import ca.uhn.hl7v2.model.v26.datatype.CX;
 import ca.uhn.hl7v2.model.v26.datatype.ST;
 import ca.uhn.hl7v2.model.v26.segment.AL1;
+
 class HL7DataExtractorTest {
 
-  @Test
-  void returns_segment_if_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+    @Test
+    void returns_segment_if_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        assertThat(s).isNotNull();
+        assertThat(s.getName()).isEqualTo("PID");
 
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    assertThat(s).isNotNull();
-    assertThat(s.getName()).isEqualTo("PID");
-
-  }
-
-
-  @Test
-  void returns_segment_if_exists_group() throws IOException {
-    String message =
-        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
-
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PROBLEM", 0, "PRB", 0).getValue();
-    assertThat(s).isNotNull();
-    assertThat(s.getName()).isEqualTo("PRB");
-
-  }
-
-
-  @Test
-  void returns_segment_if_exists_group_no_segment() throws IOException {
-    String message =
-        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
-
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PROBLEM", 0, "NTE", 0).getValue();
-    assertThat(s).isNull();
-
-  }
-
-
-
-  @Test
-  void get_group_then_segment_for_non_existing_segment() throws IOException {
-    String message =
-        "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
-            + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
-            + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
-            + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
-
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PROBLEM", 0).getValue();
-    assertThat(s).isNotNull();
-
-    Structure sub = hl7DTE.getAllStructures(s, "NTE").getValue();
-    assertThat(sub).isNull();
-
-
-  }
-
-
-
-  @Test
-  void returns_null_if_segment_does_not_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PV1", 0).getValue();
-    assertThat(s).isNull();
-
-  }
-
-
-  @Test
-  void returns_null_if_segment_does_not_exists_when_querying_all_repititions()
-      throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-
-    Message hl7message = Unmodifiable.unmodifiableMessage(getMessage(message));
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    List<Structure> s = hl7DTE.getAllStructures("OBX").getValues();
-    assertThat(s).isEmpty();
-
-  }
-
-
-  @Test
-  void returns_null_if_segment_name_is_invalid() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PV67", 0).getValue();
-    assertThat(s).isNull();
-
-  }
-
-
-
-  @Test
-  void returns_list_of_segment_for_repititions() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-
-        + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
-        + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
-        + "AL1|3|DRUG|00004700^INFLUENZA VIRUS VACCINE||\r"
-        + "AL1|4|BRANDNAME|00008604^LEVAQUIN||RASH ITCHING\r"
-        + "AL1|5|BRANDNAME|00010302^PNEUMOVAX 23||\r";
-
-
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    List<Structure> structures = hl7DTE.getAllStructures("AL1").getValues();
-    assertThat(structures).isNotNull();
-    assertThat(structures).hasSize(5);
-    structures.forEach(s -> assertThat(s.getName()).isEqualTo("AL1"));
-
-  }
-
-
-
-  @Test
-  void returns_requested_repetition_of_segment() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-
-        + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
-        + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
-        + "AL1|3|DRUG|00004700^INFLUENZA VIRUS VACCINE||\r"
-        + "AL1|4|BRANDNAME4|00008604^LEVAQUIN||RASH ITCHING\r"
-        + "AL1|5|BRANDNAME5|00010302^PNEUMOVAX 23||\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    List<Structure> structures = hl7DTE.getStructure("AL1", 4).getValues();
-    assertThat(structures).isNotNull();
-    assertThat(structures).hasSize(1);
-    AL1 al1 = (AL1) structures.get(0);
-    assertThat(al1.getAl12_AllergenTypeCode().getCwe1_Identifier().getValue())
-        .isEqualTo("BRANDNAME5");
-
-  }
-
-
-  @Test
-  void returns_null_if_requested_repetition_of_segment_does_not_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-
-        + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
-        + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
-        + "AL1|3|DRUG|00004700^INFLUENZA VIRUS VACCINE||\r"
-        + "AL1|4|BRANDNAME4|00008604^LEVAQUIN||RASH ITCHING\r"
-        + "AL1|5|BRANDNAME5|00010302^PNEUMOVAX 23||\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    List<Structure> structures = hl7DTE.getStructure("AL1", 6).getValues();
-    assertThat(structures).isNotNull();
-    assertThat(structures).isEmpty();
-
-
-  }
-
-
-
-  @Test
-  void returns_field_value_for_specific_rep_if_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    assertThat(s).isNotNull();
-    assertThat(s.getName()).isEqualTo("PID");
-
-    Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
-    assertThat(t).isNotNull();
-    assertThat(t.getName()).isEqualTo("CX");
-    CX cx = (CX) t;
-    assertThat(cx.getCx1_IDNumber().getValue()).isEqualTo("000010017");
-    assertThat(cx.getAssigningAuthority().getHd1_NamespaceID().getValue()).isEqualTo("MR");
-
-
-  }
-
-  @Test
-  void returns_all_field_values_if_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    assertThat(s).isNotNull();
-    assertThat(s.getName()).isEqualTo("PID");
-
-    List<Type> types = hl7DTE.getTypes((Segment) s, 3).getValues();
-    assertThat(types).isNotNull();
-    assertThat(types).hasSize(3);
-    assertThat(types.get(0).getName()).isEqualTo("CX");
-    CX cx = (CX) types.get(0);
-    assertThat(cx.getCx1_IDNumber().getValue()).isEqualTo("000010016");
-    assertThat(cx.getAssigningAuthority().getHd1_NamespaceID().getValue()).isEqualTo("MR");
-
-
-  }
-
-
-
-  @Test
-  void returns_null_if_field_value_for_repitition_does_not_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    assertThat(s).isNotNull();
-    assertThat(s.getName()).isEqualTo("PID");
-
-
-    Type t = hl7DTE.getType((Segment) s, 3, 5).getValue();
-    assertThat(t).isNull();
-
-    List<Type> types = hl7DTE.getType((Segment) s, 3, 5).getValues();
-    assertThat(types).isEmpty();
-
-
-  }
-
-
-
-  @Test
-  void returns_component_value_for_specific_rep_if_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
-    Type comp = hl7DTE.getComponent(t, 1).getValue();
-
-    assertThat(comp).isNotNull();
-    assertThat(comp.getName()).isEqualTo("ST");
-    ST id = (ST) comp;
-    assertThat(id.getValue()).isEqualTo("000010017");
-
-  }
-
-
-
-  @Test
-  void returns_null_if_component_value_for_does_not_exists() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
-    Type comp = hl7DTE.getComponent(t, 6).getValue();
-    assertThat(comp).isNull();
-
-    List<Type> comps = hl7DTE.getComponent(t, 6).getValues();
-    assertThat(comps).isEmpty();
-
-  }
-
-
-  @Test
-  void returns_component_and_subcomponent_value_for_specific_rep_if_exists()
-      throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
-    Type comp = hl7DTE.getComponent(t, 4, 1).getValue();
-
-    assertThat(comp).isNotNull();
-    assertThat(comp.getName()).isEqualTo("IS");
-    IS id = (IS) comp;
-    assertThat(id.getValue()).isEqualTo("MR");
-
-  }
-
-
-
-  @Test
-  void returns_null_if_component_subcomponent_value_for_does_not_exists()
-      throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("PID", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
-    Type comp = hl7DTE.getComponent(t, 4, 2).getValue();
-    assertThat(comp).isNull();
-
-    List<Type> comps = hl7DTE.getComponent(t, 4, 2).getValues();
-    assertThat(comps).isEmpty();
-
-  }
-
-
-
-  @Test
-  void extracts_component_from_variable_type_primitive() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-        + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^|\r";
-
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
-    assertThat(t).isNotNull();
-    Type comp = hl7DTE.getComponent(t, 1).getValue();
-    assertThat(comp).isNotNull();
-    Primitive p = (Primitive) comp;
-    assertThat(p.getValue()).isEqualTo("ECHOCARDIOGRAPHIC REPORT");
-
-
-  }
-
-
-  @Test
-  void extracts_component_from_variable_type_compositive() throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-        + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
-    assertThat(t).isNotNull();
-    Type comp = hl7DTE.getComponent(t, 2).getValue();
-    assertThat(comp).isNotNull();
-    Primitive p = (Primitive) comp;
-    assertThat(p.getValue()).isEqualTo("No significant change was found");
-
-
-  }
-
-
-  @Test
-  void extracts_component_from_variable_type_compositive_with_subcomponent()
-      throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-        + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
-    assertThat(t).isNotNull();
-    Type comp = hl7DTE.getComponent(t, 2, 1).getValue();
-    assertThat(comp).isNotNull();
-    Primitive p = (Primitive) comp;
-    assertThat(p.getValue()).isEqualTo("No significant change was found");
-
-
-  }
-
-
-  @Test
-  void returns_null_from_variable_type_compositive_with_subcomponent_if_subcomponent_does_not_exists()
-      throws IOException {
-    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
-        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
-        + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
-        + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
-    Message hl7message = getMessage(message);
-    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
-
-
-    Structure s = hl7DTE.getStructure("OBX", 0).getValue();
-    Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
-    assertThat(t).isNotNull();
-    Type comp = hl7DTE.getComponent(t, 2, 2).getValue();
-    assertThat(comp).isNull();
-
-
-  }
-
-
-  //
-
-  private static Message getMessage(String message) throws IOException {
-    HL7HapiParser hparser = null;
-
-    try {
-      hparser = new HL7HapiParser();
-      return hparser.getParser().parse(message);
-    } catch (HL7Exception e) {
-      throw new IllegalArgumentException(e);
-    } finally {
-      if (hparser != null) {
-        hparser.getContext().close();
-      }
     }
 
-  }
+    @Test
+    void returns_segment_if_exists_group() throws IOException {
+        String message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PROBLEM", 0, "PRB", 0).getValue();
+        assertThat(s).isNotNull();
+        assertThat(s.getName()).isEqualTo("PRB");
+
+    }
+
+    @Test
+    void returns_segment_if_exists_group_no_segment() throws IOException {
+        String message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PROBLEM", 0, "NTE", 0).getValue();
+        assertThat(s).isNull();
+
+    }
+
+    @Test
+    void get_group_then_segment_for_non_existing_segment() throws IOException {
+        String message = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\r"
+                + "PID|||555444222111^^^MPI&GenHosp&L^MR||james^anderson||19600614|M||C|99 Oakland #106^^qwerty^OH^44889||^^^^^626^5641111|^^^^^626^5647654|||||343132266|||N\r"
+                + "PV1||I|6N^1234^A^GENHOS||||0100^ANDERSON^CARL|0148^ADDISON^JAMES||SUR|||||||0148^ANDERSON^CARL|S|1400|A|||||||||||||||||||SF|K||||199501102300\r"
+                + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PROBLEM", 0).getValue();
+        assertThat(s).isNotNull();
+
+        Structure sub = hl7DTE.getAllStructures(s, "NTE").getValue();
+        assertThat(sub).isNull();
+
+    }
+
+    @Test
+    void returns_null_if_segment_does_not_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PV1", 0).getValue();
+        assertThat(s).isNull();
+
+    }
+
+    @Test
+    void returns_null_if_segment_does_not_exists_when_querying_all_repititions()
+            throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = Unmodifiable.unmodifiableMessage(getMessage(message));
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        List<Structure> s = hl7DTE.getAllStructures("OBX").getValues();
+        assertThat(s).isEmpty();
+
+    }
+
+    @Test
+    void returns_null_if_segment_name_is_invalid() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PV67", 0).getValue();
+        assertThat(s).isNull();
+
+    }
+
+    @Test
+    void returns_list_of_segment_for_repititions() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
+                + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
+                + "AL1|3|DRUG|00004700^INFLUENZA VIRUS VACCINE||\r"
+                + "AL1|4|BRANDNAME|00008604^LEVAQUIN||RASH ITCHING\r"
+                + "AL1|5|BRANDNAME|00010302^PNEUMOVAX 23||\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        List<Structure> structures = hl7DTE.getAllStructures("AL1").getValues();
+        assertThat(structures).isNotNull().hasSize(5);
+        structures.forEach(s -> assertThat(s.getName()).isEqualTo("AL1"));
+
+    }
+
+    @Test
+    void returns_requested_repetition_of_segment() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
+                + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
+                + "AL1|3|DRUG|00004700^INFLUENZA VIRUS VACCINE||\r"
+                + "AL1|4|BRANDNAME4|00008604^LEVAQUIN||RASH ITCHING\r"
+                + "AL1|5|BRANDNAME5|00010302^PNEUMOVAX 23||\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        List<Structure> structures = hl7DTE.getStructure("AL1", 4).getValues();
+        assertThat(structures).isNotNull().hasSize(1);
+        AL1 al1 = (AL1) structures.get(0);
+        assertThat(al1.getAl12_AllergenTypeCode().getCwe1_Identifier().getValue())
+                .isEqualTo("BRANDNAME5");
+
+    }
+
+    @Test
+    void returns_null_if_requested_repetition_of_segment_does_not_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\r"
+                + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r"
+                + "AL1|3|DRUG|00004700^INFLUENZA VIRUS VACCINE||\r"
+                + "AL1|4|BRANDNAME4|00008604^LEVAQUIN||RASH ITCHING\r"
+                + "AL1|5|BRANDNAME5|00010302^PNEUMOVAX 23||\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        List<Structure> structures = hl7DTE.getStructure("AL1", 6).getValues();
+        assertThat(structures).isNotNull().isEmpty();
+
+    }
+
+    @Test
+    void returns_field_value_for_specific_rep_if_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        assertThat(s).isNotNull();
+        assertThat(s.getName()).isEqualTo("PID");
+
+        Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
+        assertThat(t).isNotNull();
+        assertThat(t.getName()).isEqualTo("CX");
+        CX cx = (CX) t;
+        assertThat(cx.getCx1_IDNumber().getValue()).isEqualTo("000010017");
+        assertThat(cx.getAssigningAuthority().getHd1_NamespaceID().getValue()).isEqualTo("MR");
+
+    }
+
+    @Test
+    void returns_all_field_values_if_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        assertThat(s).isNotNull();
+        assertThat(s.getName()).isEqualTo("PID");
+
+        List<Type> types = hl7DTE.getTypes((Segment) s, 3).getValues();
+        assertThat(types).isNotNull().hasSize(3);
+        assertThat(types.get(0).getName()).isEqualTo("CX");
+        CX cx = (CX) types.get(0);
+        assertThat(cx.getCx1_IDNumber().getValue()).isEqualTo("000010016");
+        assertThat(cx.getAssigningAuthority().getHd1_NamespaceID().getValue()).isEqualTo("MR");
+
+    }
+
+    @Test
+    void returns_null_if_field_value_for_repitition_does_not_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        assertThat(s).isNotNull();
+        assertThat(s.getName()).isEqualTo("PID");
+
+        Type t = hl7DTE.getType((Segment) s, 3, 5).getValue();
+        assertThat(t).isNull();
+
+        List<Type> types = hl7DTE.getType((Segment) s, 3, 5).getValues();
+        assertThat(types).isEmpty();
+
+    }
+
+    @Test
+    void returns_component_value_for_specific_rep_if_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
+        Type comp = hl7DTE.getComponent(t, 1).getValue();
+
+        assertThat(comp).isNotNull();
+        assertThat(comp.getName()).isEqualTo("ST");
+        ST id = (ST) comp;
+        assertThat(id.getValue()).isEqualTo("000010017");
+
+    }
+
+    @Test
+    void returns_null_if_component_value_for_does_not_exists() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
+        Type comp = hl7DTE.getComponent(t, 6).getValue();
+        assertThat(comp).isNull();
+
+        List<Type> comps = hl7DTE.getComponent(t, 6).getValues();
+        assertThat(comps).isEmpty();
+
+    }
+
+    @Test
+    void returns_component_and_subcomponent_value_for_specific_rep_if_exists()
+            throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
+        Type comp = hl7DTE.getComponent(t, 4, 1).getValue();
+
+        assertThat(comp).isNotNull();
+        assertThat(comp.getName()).isEqualTo("IS");
+        IS id = (IS) comp;
+        assertThat(id.getValue()).isEqualTo("MR");
+
+    }
+
+    @Test
+    void returns_null_if_component_subcomponent_value_for_does_not_exists()
+            throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("PID", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 3, 1).getValue();
+        Type comp = hl7DTE.getComponent(t, 4, 2).getValue();
+        assertThat(comp).isNull();
+
+        List<Type> comps = hl7DTE.getComponent(t, 4, 2).getValues();
+        assertThat(comps).isEmpty();
+
+    }
+
+    @Test
+    void extracts_component_from_variable_type_primitive() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+                + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^Tsadok^Janetary~2913^Merrit^Darren^F~3065^Mahoney^Paul^J~4723^Loh^Robert^L~9052^Winter^Oscar^|\r";
+
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
+        assertThat(t).isNotNull();
+        Type comp = hl7DTE.getComponent(t, 1).getValue();
+        assertThat(comp).isNotNull();
+        Primitive p = (Primitive) comp;
+        assertThat(p.getValue()).isEqualTo("ECHOCARDIOGRAPHIC REPORT");
+
+    }
+
+    @Test
+    void extracts_component_from_variable_type_compositive() throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+                + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
+        assertThat(t).isNotNull();
+        Type comp = hl7DTE.getComponent(t, 2).getValue();
+        assertThat(comp).isNotNull();
+        Primitive p = (Primitive) comp;
+        assertThat(p.getValue()).isEqualTo("No significant change was found");
+
+    }
+
+    @Test
+    void extracts_component_from_variable_type_compositive_with_subcomponent()
+            throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+                + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
+        assertThat(t).isNotNull();
+        Type comp = hl7DTE.getComponent(t, 2, 1).getValue();
+        assertThat(comp).isNotNull();
+        Primitive p = (Primitive) comp;
+        assertThat(p.getValue()).isEqualTo("No significant change was found");
+
+    }
+
+    @Test
+    void returns_null_from_variable_type_compositive_with_subcomponent_if_subcomponent_does_not_exists()
+            throws IOException {
+        String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+                + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+                + "NK1|1|Wood^John^^^MR|Father||999-9999\r"
+                + "OBX|1|CE|93000&CMP^LIN^CPT4|11|1305^No significant change was found^MEIECG";
+        Message hl7message = getMessage(message);
+        HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+        Structure s = hl7DTE.getStructure("OBX", 0).getValue();
+        Type t = hl7DTE.getType((Segment) s, 5, 0).getValue();
+        assertThat(t).isNotNull();
+        Type comp = hl7DTE.getComponent(t, 2, 2).getValue();
+        assertThat(comp).isNull();
+
+    }
+
+    private static Message getMessage(String message) throws IOException {
+        HL7HapiParser hparser = null;
+
+        try {
+            hparser = new HL7HapiParser();
+            return hparser.getParser().parse(message);
+        } catch (HL7Exception e) {
+            throw new IllegalArgumentException(e);
+        } finally {
+            if (hparser != null) {
+                hparser.getContext().close();
+            }
+        }
+
+    }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/resource/HL7ResourceReaderTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/resource/HL7ResourceReaderTest.java
@@ -65,7 +65,7 @@ class HL7ResourceReaderTest {
 
       // Get the templates
       Map<String, HL7MessageModel> messagetemplates = ResourceReader.getInstance().getMessageTemplates();
-      assertThat(messagetemplates.containsKey("ORU_R01")).isTrue();
+      assertThat(messagetemplates).containsKey("ORU_R01");
       assertThat(messagetemplates.containsKey("ADT_A09")).isFalse();
     } catch (IllegalArgumentException e) {
       throw new IllegalStateException("Failure to initialize the templates for the converter.", e);
@@ -88,8 +88,8 @@ class HL7ResourceReaderTest {
 
       // Get the templates ORU_R01 will be found in the base path and ADT_A09 will be found in the additional path
       Map<String, HL7MessageModel> messagetemplates = ResourceReader.getInstance().getMessageTemplates();
-      assertThat(messagetemplates.containsKey("ORU_R01")).isTrue(); // found in the base path
-      assertThat(messagetemplates.containsKey("ADT_A09")).isTrue(); // found in the additional path
+      assertThat(messagetemplates).containsKey("ORU_R01"); // found in the base path
+      assertThat(messagetemplates).containsKey("ADT_A09"); // found in the additional path
     } catch (IllegalArgumentException e) {
       throw new IllegalStateException("Failure to initialize the templates for the converter.", e);
     }
@@ -112,8 +112,8 @@ class HL7ResourceReaderTest {
 
       // Get the templates ORU_R01 will be found in the base path and ADT_A09 will be found in the additional path
       Map<String, HL7MessageModel> messagetemplates = ResourceReader.getInstance().getMessageTemplates();
-      assertThat(messagetemplates.containsKey("ORU_R01")).isTrue(); // found in the base path
-      assertThat(messagetemplates.containsKey("ADT_A09")).isTrue(); // found in the additional path
+      assertThat(messagetemplates).containsKey("ORU_R01"); // found in the base path
+      assertThat(messagetemplates).containsKey("ADT_A09"); // found in the additional path
     } catch (IllegalArgumentException e) {
       throw new IllegalStateException("Failure to initialize the templates for the converter.", e);
     }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7MergeFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7MergeFHIRConversionTest.java
@@ -8,7 +8,6 @@ package io.github.linuxforhealth.hl7.segments;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -41,9 +40,7 @@ class HL7MergeFHIRConversionTest {
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the patient resources in the FHIR bundle.
-        List<Resource> patientResources = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResources = ResourceUtils.getResourceList(e, ResourceType.Patient);
 
         // There should be 2 - One for the PID segment and one for the MRG segment
         assertThat(patientResources).hasSize(2);
@@ -193,9 +190,7 @@ class HL7MergeFHIRConversionTest {
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the patient resources in the FHIR bundle.
-        List<Resource> patientResources = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResources = ResourceUtils.getResourceList(e, ResourceType.Patient);
 
         // There should be 2 - One for the PID segment and one for the MRG segment
         assertThat(patientResources).hasSize(2);
@@ -274,6 +269,8 @@ class HL7MergeFHIRConversionTest {
     }
 
     // Tests ADT_A40 message with 2 MRG segments.
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
     void validateTwoMRGs() {
 
@@ -292,9 +289,7 @@ class HL7MergeFHIRConversionTest {
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Find the patient resources in the FHIR bundle.
-        List<Resource> patientResources = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResources = ResourceUtils.getResourceList(e, ResourceType.Patient);
 
         // There should be 4 - One for each PID segment and one for each MRG segment
         assertThat(patientResources).hasSize(4);

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -7,8 +7,7 @@ package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.HashMap;
+import java.io.IOException;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.AllergyIntolerance;
@@ -16,6 +15,7 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Immunization;
@@ -24,16 +24,16 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Procedure;
 import org.hl7.fhir.r4.model.ServiceRequest;
-import org.hl7.fhir.r4.model.DocumentReference;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
-import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 
 class Hl7IdentifierFHIRConversionTest {
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @Test
     void patientIdentifiersTest() {
         String patientIdentifiers = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
@@ -153,7 +153,7 @@ class Hl7IdentifierFHIRConversionTest {
         DatatypeUtils.checkCommonCodeableConceptAssertions(cc, "SS", "Social Security number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
-        // Third identifier - unknown code.  Create the following:
+        // Third identifier - handles an unknown code.  Create the following:
         // "identifier": [ {
         //         "type": {
         //           "text": "AnUnknownCode"
@@ -320,24 +320,27 @@ class Hl7IdentifierFHIRConversionTest {
         system = identifier.getSystem();
         assertThat(value).isEqualTo("C56.9-I10"); // DG1.3.1-DG1.3.3
         assertThat(system).isEqualTo("urn:id:extID");
+    }
 
+    @Test
+    void conditionDg1IdentifierTest2() {
         // Test PV1-19 for visit number; extId with DG1-3.1.
         // Also test DG1-20 creates additional identifiers.
         String withDG120 = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 + "PID|||10290^^^WEST^MR||||20040530|M||||||||||||||||||||||N\n"
                 + "PV1||I||||||||SUR||||||||S|8846511^^^ACME|A|||||||||||||||||||SF|K||||20170215080000\n"
                 + "DG1|1|ICD10|B45678|Broken Arm|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326|one^https://terminology.hl7.org/CodeSystem/two^three^https://terminology.hl7.org/CodeSystem/four|S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
-        condition = ResourceUtils.getCondition(withDG120);
+        Condition condition = ResourceUtils.getCondition(withDG120);
 
         // Expect 4 identifiers
         assertThat(condition.hasIdentifier()).isTrue();
         assertThat(condition.getIdentifier()).hasSize(4);
 
-        identifiers = condition.getIdentifier();
+        List<Identifier> identifiers = condition.getIdentifier();
         // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("8846511", identifiers);
+        int posVN = getIdentifierPositionByValue("8846511", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posExtId = getIdentifierPositionByValue("B45678", identifiers);
+        int posExtId = getIdentifierPositionByValue("B45678", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
         int posExtDG20a = getIdentifierPositionByValue("one", identifiers);
         assertThat(posExtDG20a).isNotSameAs(-1);
@@ -345,12 +348,12 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(posExtDG20b).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = condition.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = condition.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("8846511"); // PV1.19.1
         assertThat(system).isEqualTo("urn:id:ACME"); // PV1.19.4
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -374,30 +377,33 @@ class Hl7IdentifierFHIRConversionTest {
         system = identifier.getSystem();
         assertThat(value).isEqualTo("three"); // DG1.20.3
         assertThat(system).isEqualTo("https://terminology.hl7.org/CodeSystem/four"); // DG1.20.4
+    }
 
+    @Test
+    void conditionDg1IdentifierTest3() {
         String withDG132 = "MSH|^~\\&|||||201610015080000||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 + "PID|||10290^^^WEST^MR||||20040530|M||||||||||||||||||||||N\n"
                 + "PV1||I||||||||SUR||||||||S||A|||||||||||||||||||SF|K||||20170215080000\n"
                 + "DG1|1|ICD10|^Ovarian Cancer|Test|20210322154449|A|E123|R45|Y|J76|C|15|1458.98||1|123^DOE^JOHN^A^|C|Y|20210322154326||S1234|Parent Diagnosis|Value345|Group567|DiagnosisG45|Y\r";
-        condition = ResourceUtils.getCondition(withDG132);
+        Condition condition = ResourceUtils.getCondition(withDG132);
 
         // Expect 2 identifiers
         assertThat(condition.hasIdentifier()).isTrue();
         assertThat(condition.getIdentifier()).hasSize(2);
-        identifiers = condition.getIdentifier();
+        List<Identifier> identifiers = condition.getIdentifier();
         // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("201610015080000", identifiers);
+        int posVN = getIdentifierPositionByValue("201610015080000", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posExtId = getIdentifierPositionByValue("Ovarian Cancer", identifiers);
+        int posExtId = getIdentifierPositionByValue("Ovarian Cancer", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = condition.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = condition.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("201610015080000"); // MSH.7
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -544,29 +550,33 @@ class Hl7IdentifierFHIRConversionTest {
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
+    }
+
+    @Test
+    void diagnosticReportIdentifierTestFillerPlacerFromOBR() {
         // Filler and placer from OBR
-        diagnosticReport = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170825010500||ORU^R01|MSGID22102712|T|2.6\n"
+        String diagnosticReport = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170825010500||ORU^R01|MSGID22102712|T|2.6\n"
                 + "PID|||1234||DOE^JANE^|||F||||||||||||||||||||||\n"
                 + "ORC|NW|||PGN001|SC|D|1||20170825010500|MS|MS||||20170825010500|\n"
                 + "OBR|1|CC_000000^OE PHIMS Stage|CD_000000|2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F\n"
                 + "OBX|1|TX|||Impression: 1. Markedly intense metabolic activity corresponding with the area of nodular enhancement in the left oral cavity.||||||F|||20170825010500\n";
-        report = ResourceUtils.getDiagnosticReport(diagnosticReport);
+        DiagnosticReport report = ResourceUtils.getDiagnosticReport(diagnosticReport);
 
         // Expect 3 identifiers
         assertThat(report.hasIdentifier()).isTrue();
         assertThat(report.getIdentifier()).hasSize(3);
-        identifiers = report.getIdentifier();
+        List<Identifier> identifiers = report.getIdentifier();
         // Match the three id's to position; we can't depend on an order.
-        posExtId = getIdentifierPositionByValue("20170825010500", identifiers);
+        int posExtId = getIdentifierPositionByValue("20170825010500", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
-        posFILLER = getIdentifierPositionByValue("CD_000000", identifiers);
+        int posFILLER = getIdentifierPositionByValue("CD_000000", identifiers);
         assertThat(posFILLER).isNotSameAs(-1);
-        posPLACER = getIdentifierPositionByValue("CC_000000", identifiers);
+        int posPLACER = getIdentifierPositionByValue("CC_000000", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
         // Identifier 1: extId with MSH-7
-        identifier = report.getIdentifier().get(posExtId);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = report.getIdentifier().get(posExtId);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("20170825010500"); // MSH-7
         assertThat(system).isEqualTo("urn:id:extID");
 
@@ -576,7 +586,7 @@ class Hl7IdentifierFHIRConversionTest {
         system = identifier.getSystem();
         assertThat(value).isEqualTo("CD_000000"); // OBR-3.1
         assertThat(system).isNull(); // OBR-3.2 is empty
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -617,13 +627,17 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("VN");
         assertThat(coding.getDisplay()).isEqualTo("Visit number");
+    }
+
+    @Test
+    void encounterIdentifierVisitNumberFromPV1() {
 
         // Test: Visit number from PV1-19, plus PV1-50
         String encounterW2Identifiers = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "EVN|A01|20130617154644||01\r"
                 + "PID|||12345^^^^MR||smith^john\r"
                 + "PV1||I||||||||SUR||||||||S|8846511|A|||||||||||||||||||SF|K||||20170215080000||||||POL8009|\r";
-        encounter = ResourceUtils.getEncounter(encounterW2Identifiers); //the first identifier is the same. the second Identifier comes from PV1.50
+        Encounter encounter = ResourceUtils.getEncounter(encounterW2Identifiers); //the first identifier is the same. the second Identifier comes from PV1.50
 
         // Expect 2 identifiers
         assertThat(encounter.hasIdentifier()).isTrue();
@@ -636,13 +650,13 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(posVN2).isNotSameAs(-1);
 
         // Identifier 1:
-        identifier = encounter.getIdentifier().get(posVN1);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = encounter.getIdentifier().get(posVN1);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("8846511"); // PV1-19
         assertThat(system).isNull();
-        type = identifier.getType();
-        coding = type.getCoding().get(0);
+        CodeableConcept type = identifier.getType();
+        Coding coding = type.getCoding().get(0);
         assertThat(type.getText()).isNull();
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("VN");
@@ -660,26 +674,29 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("VN");
         assertThat(coding.getDisplay()).isEqualTo("Visit number");
+    }
 
+    @Test
+    void encounterIdentifierVisitNumberFromMSH7() {
         // Test: Visit number from MSH-7
-        encounterMsg = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+        String encounterMsg = "MSH|^~\\&|MYEHR2.5|RI88140101|KIDSNET_IFL|RIHEALTH|20130531||VXU^V04^VXU_V04|20130531RI881401010105|P|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "EVN|A01|20130617154644||01\r"
                 + "PID|||12345^^^^MR||smith^john\r"
                 + "PV1||I||||||||SUR||||||||S||A\r";
-        encounter = ResourceUtils.getEncounter(encounterMsg);
+        Encounter encounter = ResourceUtils.getEncounter(encounterMsg);
 
         // Expect a single identifier
         assertThat(encounter.hasIdentifier()).isTrue();
         assertThat(encounter.getIdentifier()).hasSize(1);
 
         // Identifier 1: Visit number
-        identifier = encounter.getIdentifier().get(0);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = encounter.getIdentifier().get(0);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("20130531"); // MSH.7
         assertThat(system).isNull(); //PV1.19.4 and PID.18 is empty so system is null
-        type = identifier.getType();
-        coding = type.getCoding().get(0);
+        CodeableConcept type = identifier.getType();
+        Coding coding = type.getCoding().get(0);
         assertThat(type.getText()).isNull();
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("VN");
@@ -852,12 +869,12 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Filler
-        identifier = report.getIdentifier().get(posFILLER);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier2 = report.getIdentifier().get(posFILLER);
+        value = identifier2.getValue();
+        system = identifier2.getSystem();
         assertThat(value).isEqualTo("FON001"); //ORC.3.1
         assertThat(system).isEqualTo("urn:id:OE"); // ORC.3.2
-        CodeableConcept type = identifier.getType();
+        CodeableConcept type = identifier2.getType();
         Coding coding = type.getCoding().get(0);
         assertThat(type.getText()).isNull();
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
@@ -876,9 +893,12 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("PLAC");
         assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
+    }
 
+    @Test
+    void documentReferenceIdentifierTest2() {
         // Filler from OBR, placer from TXA-14
-        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 +
                 "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
                 "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
@@ -886,43 +906,43 @@ class Hl7IdentifierFHIRConversionTest {
                 "OBR|1||CD_000000^OE|2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n"
                 +
                 "TXA|1||B45678|||||||||||PON001^IE||\n";
-        report = ResourceUtils.getDocumentReference(documentReference);
+        DocumentReference report = ResourceUtils.getDocumentReference(documentReferenceMessage);
 
         // Expect 3 identifiers
         assertThat(report.hasIdentifier()).isTrue();
         assertThat(report.getIdentifier()).hasSize(3);
 
-        identifiers = report.getIdentifier();
+        List<Identifier> identifiers = report.getIdentifier();
         // Match the three id's to position; we can't depend on an order.
-        posExtId = getIdentifierPositionByValue("200911021022", identifiers);
+        int posExtId = getIdentifierPositionByValue("200911021022", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
-        posFILLER = getIdentifierPositionByValue("CD_000000", identifiers);
+        int posFILLER = getIdentifierPositionByValue("CD_000000", identifiers);
         assertThat(posFILLER).isNotSameAs(-1);
-        posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        int posPLACER = getIdentifierPositionByValue("PON001", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: extID from MSH-7
-        identifier = report.getIdentifier().get(posExtId);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = report.getIdentifier().get(posExtId);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("200911021022"); // MSH-7
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Filler
-        identifier = report.getIdentifier().get(posFILLER);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier2 = report.getIdentifier().get(posFILLER);
+        value = identifier2.getValue();
+        system = identifier2.getSystem();
         assertThat(value).isEqualTo("CD_000000"); //OBR.3.1
         assertThat(system).isEqualTo("urn:id:OE"); // OBR.3.2
-        type = identifier.getType();
-        coding = type.getCoding().get(0);
+        CodeableConcept type = identifier2.getType();
+        Coding coding = type.getCoding().get(0);
         assertThat(type.getText()).isNull();
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("FILL");
         assertThat(coding.getDisplay()).isEqualTo("Filler Identifier");
 
         // Identifier 3: Placer
-        identifier3 = report.getIdentifier().get(posPLACER);
+        Identifier identifier3 = report.getIdentifier().get(posPLACER);
         value = identifier3.getValue();
         system = identifier3.getSystem();
         assertThat(value).isEqualTo("PON001"); // TXA-14.1
@@ -934,8 +954,12 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(coding.getCode()).isEqualTo("PLAC");
         assertThat(coding.getDisplay()).isEqualTo("Placer Identifier");
 
+    }
+
+    @Test
+    void documentReferenceIdentifierTest3() {
         // Placer from OBR, Filler from TXA-15
-        documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
+        String documentReferenceMessage = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 +
                 "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
                 "PV1|1|I|||||||||||||||||||||||||||||||||||||||||||\n" +
@@ -943,36 +967,36 @@ class Hl7IdentifierFHIRConversionTest {
                 "OBR|1|CD_000000^OE||2244^General Order|||20170825010500||||||Relevant Clinical Information|||||||002|||||F|||550600^Tsadok550600^Janetary~660600^Merrit660600^Darren^F~770600^Das770600^Surjya^P~880600^Winter880600^Oscar^||||770600&Das770600&Surjya&P^^^6N^1234^A|\n"
                 +
                 "TXA|1||B45678||||||||||||FON001^IE\n";
-        report = ResourceUtils.getDocumentReference(documentReference);
+        DocumentReference report = ResourceUtils.getDocumentReference(documentReferenceMessage);
 
         // Expect 3 identifiers
         assertThat(report.hasIdentifier()).isTrue();
         assertThat(report.getIdentifier()).hasSize(3);
 
-        identifiers = report.getIdentifier();
+        List<Identifier> identifiers = report.getIdentifier();
         // Match the three id's to position; we can't depend on an order.
-        posExtId = getIdentifierPositionByValue("200911021022", identifiers);
+        int posExtId = getIdentifierPositionByValue("200911021022", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
-        posFILLER = getIdentifierPositionByValue("FON001", identifiers);
+        int posFILLER = getIdentifierPositionByValue("FON001", identifiers);
         assertThat(posFILLER).isNotSameAs(-1);
-        posPLACER = getIdentifierPositionByValue("CD_000000", identifiers);
+        int posPLACER = getIdentifierPositionByValue("CD_000000", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: extID from MSH-7
-        identifier = report.getIdentifier().get(posExtId);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = report.getIdentifier().get(posExtId);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("200911021022"); // MSH-7
         assertThat(system).isEqualTo("urn:id:extID");
 
         // Identifier 2: Filler
-        identifier3 = report.getIdentifier().get(posFILLER);
+        Identifier identifier3 = report.getIdentifier().get(posFILLER);
         value = identifier3.getValue();
         system = identifier3.getSystem();
         assertThat(value).isEqualTo("FON001"); // TXA-15.1
         assertThat(system).isEqualTo("urn:id:IE"); // TXA.15.2
-        type = identifier3.getType();
-        coding = type.getCoding().get(0);
+        CodeableConcept type = identifier3.getType();
+        Coding coding = type.getCoding().get(0);
         assertThat(type.getText()).isNull();
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0203");
         assertThat(coding.getCode()).isEqualTo("FILL");
@@ -1051,12 +1075,15 @@ class Hl7IdentifierFHIRConversionTest {
         type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+    }
 
+    @Test
+    void serviceRequestIdentifierTest2() {
         // Test 3:
         //  - Visit number with PV1-19
         //  - filler from OBR
         //  - placer from ORC
-        serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
+        String serviceRequest = "MSH|^~\\&|SendTest1|Sendfac1|Receiveapp1|Receivefac1|200603081747|security|PPR^PC1^PPR_PC1|1|P^I|2.6||||||ASCII||\n"
                 +
                 "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +
                 "PV1||I|6N^1234^A^GENERAL HOSPITAL2|||||||SUR||||||||S|8846511|A|||||||||||||||||||SF|K||||20170215080000\n"
@@ -1065,27 +1092,27 @@ class Hl7IdentifierFHIRConversionTest {
                 "ORC||PON001||||E|^Q6H^D10^^^R\n" +
                 "OBR|1||CD150920001336|||20150930000000|20150930164100|||||||||25055^MARCUSON^PATRICIA^L|||||||||F|||5755^DUNN^CHAD^B~25055^MARCUSON^PATRICIA^L|||WEAKNESS|DAS, SURJYA P||SHIELDS, SHARON A|||||||||";
 
-        serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
+        ServiceRequest serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
         // Expect 3 identifiers
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
-        identifiers = serviceReq.getIdentifier();
+        List<Identifier> identifiers = serviceReq.getIdentifier();
         // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("8846511", identifiers);
+        int posVN = getIdentifierPositionByValue("8846511", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posFILLER = getIdentifierPositionByValue("CD150920001336", identifiers);
+        int posFILLER = getIdentifierPositionByValue("CD150920001336", identifiers);
         assertThat(posFILLER).isNotSameAs(-1);
-        posPLACER = getIdentifierPositionByValue("PON001", identifiers);
+        int posPLACER = getIdentifierPositionByValue("PON001", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: visit number
-        identifier = serviceReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = serviceReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("8846511"); // PV1.19
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -1114,7 +1141,7 @@ class Hl7IdentifierFHIRConversionTest {
     // NOTE: ORU_RO1 records do not create the ServiceRequest directly.  They create a DiagnosticReport and it creates the ServiceRequest.
     // This test makes sure the specification for ORU_RO1.DiagnosticReport is specifying PID and PV1 correctly in AdditionalSegments.
     @Test
-    void serviceRequestIdentifierTest2() {
+    void serviceRequestIdentifierTest3() {
         // Test 1:
         //  - Visit number with PV1.19
         //  - filler and placer from OBR
@@ -1174,12 +1201,17 @@ class Hl7IdentifierFHIRConversionTest {
         type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+    }
 
+    // NOTE: ORU_RO1 records do not create the ServiceRequest directly.  They create a DiagnosticReport and it creates the ServiceRequest.
+    // This test makes sure the specification for ORU_RO1.DiagnosticReport is specifying PID and PV1 correctly in AdditionalSegments.
+    @Test
+    void serviceRequestIdentifierTest4() {
         // Test 2
         //  - Visit number with PID.18
         //  - filler from ORC
         //  - placer from ORC
-        serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
+        String serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
                 // PID.18 is used as backup identifier visit number because PV1.19 is empty
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||665544||||||||||||\n"
                 // PV1.19 is empty and not used as visit number identifier 
@@ -1191,27 +1223,27 @@ class Hl7IdentifierFHIRConversionTest {
                 //  11. OBR.3 ignored as Filler
                 + "OBR|1|CD150920001336|CD150920001336|83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C||||||||||||||||||||||||||||||||||||||||||||\n";
 
-        serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
+        ServiceRequest serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
         // Expect 3 identifiers
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
-        identifiers = serviceReq.getIdentifier();
+        List<Identifier> identifiers = serviceReq.getIdentifier();
         // Match the three id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("665544", identifiers);
+        int posVN = getIdentifierPositionByValue("665544", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posFILLER = getIdentifierPositionByValue("248648499", identifiers);
+        int posFILLER = getIdentifierPositionByValue("248648499", identifiers);
         assertThat(posFILLER).isNotSameAs(-1);
-        posPLACER = getIdentifierPositionByValue("248648498", identifiers);
+        int posPLACER = getIdentifierPositionByValue("248648498", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: visit number should be set by PID.18
-        identifier = serviceReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = serviceReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("665544"); // PID.18
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -1234,12 +1266,17 @@ class Hl7IdentifierFHIRConversionTest {
         type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+    }
 
+    // NOTE: ORU_RO1 records do not create the ServiceRequest directly.  They create a DiagnosticReport and it creates the ServiceRequest.
+    // This test makes sure the specification for ORU_RO1.DiagnosticReport is specifying PID and PV1 correctly in AdditionalSegments.
+    @Test
+    void serviceRequestIdentifierTest5() {
         // Test 3:
         //  - MSH.7 as the visit number
         //  - filler from ORC
         //  - placer from ORC
-        serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
+        String serviceRequest = "MSH|^~\\&|||||20180924152907|34001|ORU^R01^ORU_R01|213|T|2.6|||||||||||\n"
                 // PID.18 is empty so MSH.7 with be used as backup identifier visit number 
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 // PV1.19 is empty so MSH.7 with be used as backup identifier visit number 
@@ -1251,7 +1288,7 @@ class Hl7IdentifierFHIRConversionTest {
                 //  11. OBR.3 ignored as Filler
                 + "OBR|1|||83036E^HEMOGLOBIN A1C^PACSEAP^^^^^^HEMOGLOBIN A1C|||||||||||||||||||||||||||||||||||||||||||\n";
 
-        serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
+        ServiceRequest serviceReq = ResourceUtils.getServiceRequest(serviceRequest);
 
         // Expect 3 identifiers
         assertThat(serviceReq.hasIdentifier()).isTrue();
@@ -1260,22 +1297,22 @@ class Hl7IdentifierFHIRConversionTest {
         // Expect 3 identifiers
         assertThat(serviceReq.hasIdentifier()).isTrue();
         assertThat(serviceReq.getIdentifier()).hasSize(3);
-        identifiers = serviceReq.getIdentifier();
+        List<Identifier> identifiers = serviceReq.getIdentifier();
         // Match the three id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("20180924152907", identifiers);
+        int posVN = getIdentifierPositionByValue("20180924152907", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posFILLER = getIdentifierPositionByValue("222299", identifiers);
+        int posFILLER = getIdentifierPositionByValue("222299", identifiers);
         assertThat(posFILLER).isNotSameAs(-1);
-        posPLACER = getIdentifierPositionByValue("222298", identifiers);
+        int posPLACER = getIdentifierPositionByValue("222298", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
 
         // Identifier 1: visit number should be set by MSH.7
-        identifier = serviceReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = serviceReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("20180924152907"); // MSH.7
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -1361,33 +1398,37 @@ class Hl7IdentifierFHIRConversionTest {
         type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "PLAC", "Placer Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+    }
+
+    @Test
+    void medicationRequestIdentifierTest2() throws IOException {
 
         // Test: Visit number from PV1-19, extID from RXO-1.1 and RXO-1.3
-        medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||OMP^O09|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+        String medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||OMP^O09|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "PID|1||000054321^^^MRN|||||||||||||||78654\r"
                 + "PV1||I|||||||||||||||||789789\r"
                 + "ORC|NW|||||E|10^BID^D4^^^R||20170215080000\r"
                 + "RXO|RX700001^DOCUSATE SODIUM 100 MG CAPSULE^ABC|100||mg|||||G||10||5|\r";
-        medReq = ResourceUtils.getMedicationRequest(medicationRequest);
+        MedicationRequest medReq = ResourceUtils.getMedicationRequest(medicationRequest);
 
         // Expect 2 identifiers
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(2);
 
-        identifiers = medReq.getIdentifier();
+        List<Identifier> identifiers = medReq.getIdentifier();
         // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("789789", identifiers);
+        int posVN = getIdentifierPositionByValue("789789", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posExtId = getIdentifierPositionByValue("RX700001-ABC", identifiers);
+        int posExtId = getIdentifierPositionByValue("RX700001-ABC", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = medReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("789789"); // PV1.19
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -1398,33 +1439,38 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(value).isEqualTo("RX700001-ABC"); // RXO-1.1 and RXO-1.3
         assertThat(system).isEqualTo("urn:id:extID");
 
+    }
+
+    @Test
+    void medicationRequestIdentifierTest3() throws IOException {
+
         // Test: Visit number from MSH-7, extID from RXE-2
-        medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||OMP^O09|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+        String medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||OMP^O09|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "PID|1||000054321^^^MRN\r"
                 + "PV1||I||||||||SUR||||||||S||A|||||||||||||||||||SF|K||||20170215080000\r"
                 + "ORC|NW||CD2017071101^RX|||E|10^BID^D4^^^R||20170215080000\r"
                 + "RXO|^DOCUSATE SODIUM 100 MG CAPSULE|100||mg|||||G||10||5|\r";
-        medReq = ResourceUtils.getMedicationRequest(medicationRequest);
+        MedicationRequest medReq = ResourceUtils.getMedicationRequest(medicationRequest);
 
         // Expect 3 identifiers
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(3);
-        identifiers = medReq.getIdentifier();
+        List<Identifier> identifiers = medReq.getIdentifier();
         // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("20170215080000", identifiers);
+        int posVN = getIdentifierPositionByValue("20170215080000", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posExtId = getIdentifierPositionByValue("DOCUSATE SODIUM 100 MG CAPSULE", identifiers);
+        int posExtId = getIdentifierPositionByValue("DOCUSATE SODIUM 100 MG CAPSULE", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
         int posRX = getIdentifierPositionByValue("CD2017071101", identifiers);
         assertThat(posRX).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = medReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("20170215080000"); // MSH-7
         assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -1445,69 +1491,38 @@ class Hl7IdentifierFHIRConversionTest {
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "FILL", "Filler Identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
+    }
+
+    @Test
+    void medicationRequestIdentifierTest4() throws IOException {
+
         // Test: Visit number from MSH-7, no RXO-1
-        medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||RDE^O11^RDE_O11|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+        String medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||RDE^O11^RDE_O11|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
                 + "PID|1||000054321^^^MRN\r"
                 + "PV1||I||||||||SUR||||||||S||A|||||||||||||||||||SF|K||||20170215080000\r"
                 + "ORC|NW|||||E|10^BID^D4^^^R||20170215080000\r"
                 + "RXO|||||||||G||10||5|\r"
                 + "RXE|^^^20170923230000^^R|999^Ampicillin 250 MG TAB^NDC|100||mg|123^test^ABC||||10||5|";
-        medReq = ResourceUtils.getMedicationRequest(medicationRequest);
+        MedicationRequest medReq = ResourceUtils.getMedicationRequest(medicationRequest);
 
         // Expect 2 identifier
         assertThat(medReq.hasIdentifier()).isTrue();
         assertThat(medReq.getIdentifier()).hasSize(2);
 
-        identifiers = medReq.getIdentifier();
+        List<Identifier> identifiers = medReq.getIdentifier();
         // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("20170215080000", identifiers);
+        int posVN = getIdentifierPositionByValue("20170215080000", identifiers);
         assertThat(posVN).isNotSameAs(-1);
-        posExtId = getIdentifierPositionByValue("999-NDC", identifiers);
+        int posExtId = getIdentifierPositionByValue("999-NDC", identifiers);
         assertThat(posExtId).isNotSameAs(-1);
 
         // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
+        Identifier identifier = medReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
         assertThat(value).isEqualTo("20170215080000"); // MSH-7
         assertThat(system).isNull();
-        type = identifier.getType();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-
-        // Identifier 2: extID based on RXE-2.1 and RXE-2.3
-        identifier = medReq.getIdentifier().get(posExtId);
-        value = identifier.getValue();
-        system = identifier.getSystem();
-        assertThat(value).isEqualTo("999-NDC"); // RXE-2.1 and RXE-2.3
-        assertThat(system).isEqualTo("urn:id:extID");
-
-        // Test: Visit number from PV1-19, extID from RXE-2.1 and RXE-2.3
-        medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||RDE^O11^RDE_O11|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
-                + "PID|1||000054321^^^MRN|||||||||||||||78654\r"
-                + "PV1||I|||||||||||||||||789789\r"
-                + "ORC|NW|||||E|10^BID^D4^^^R||20170215080000\r"
-                + "RXE|^^^20170923230000^^R|999^Ampicillin 250 MG TAB^NDC|100||mg|123^test^ABC||||10||5|";
-        medReq = ResourceUtils.getMedicationRequest(medicationRequest);
-
-        // Expect 2 identifiers
-        assertThat(medReq.hasIdentifier()).isTrue();
-        assertThat(medReq.getIdentifier()).hasSize(2);
-
-        identifiers = medReq.getIdentifier();
-        // Match the id's to position; we can't depend on an order.
-        posVN = getIdentifierPositionByValue("789789", identifiers);
-        assertThat(posVN).isNotSameAs(-1);
-        posExtId = getIdentifierPositionByValue("999-NDC", identifiers);
-        assertThat(posExtId).isNotSameAs(-1);
-
-        // Identifier 1: Visit number
-        identifier = medReq.getIdentifier().get(posVN);
-        value = identifier.getValue();
-        system = identifier.getSystem();
-        assertThat(value).isEqualTo("789789"); // PV1.19
-        assertThat(system).isNull();
-        type = identifier.getType();
+        CodeableConcept type = identifier.getType();
         DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
@@ -1521,10 +1536,53 @@ class Hl7IdentifierFHIRConversionTest {
     }
 
     @Test
-    void medicationAdministration_identifier_test() {
-        // TODO
-        // Currently no messages generate MedicationAdministration resources
+    void medicationRequestIdentifierTest5() throws IOException {
+
+        // Test: Visit number from PV1-19, extID from RXE-2.1 and RXE-2.3
+        String medicationRequest = "MSH|^~\\&|PROSLOV|MYHOSPITAL|WHIA|IBM|20170215080000||RDE^O11^RDE_O11|MSGID005520|T|2.6|||AL|NE|764|ASCII||||||^4086::132:2A57:3C28^IPv6\r"
+                + "PID|1||000054321^^^MRN|||||||||||||||78654\r"
+                + "PV1||I|||||||||||||||||789789\r"
+                + "ORC|NW|||||E|10^BID^D4^^^R||20170215080000\r"
+                + "RXE|^^^20170923230000^^R|999^Ampicillin 250 MG TAB^NDC|100||mg|123^test^ABC||||10||5|";
+        MedicationRequest medReq = ResourceUtils.getMedicationRequest(medicationRequest);
+
+        // Expect 2 identifiers
+        assertThat(medReq.hasIdentifier()).isTrue();
+        assertThat(medReq.getIdentifier()).hasSize(2);
+
+        List<Identifier> identifiers = medReq.getIdentifier();
+        // Match the id's to position; we can't depend on an order.
+        int posVN = getIdentifierPositionByValue("789789", identifiers);
+        assertThat(posVN).isNotSameAs(-1);
+        int posExtId = getIdentifierPositionByValue("999-NDC", identifiers);
+        assertThat(posExtId).isNotSameAs(-1);
+
+        // Identifier 1: Visit number
+        Identifier identifier = medReq.getIdentifier().get(posVN);
+        String value = identifier.getValue();
+        String system = identifier.getSystem();
+        assertThat(value).isEqualTo("789789"); // PV1.19
+        assertThat(system).isNull();
+        CodeableConcept type = identifier.getType();
+        DatatypeUtils.checkCommonCodeableConceptAssertions(type, "VN", "Visit number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+
+        // Identifier 2: extID based on RXE-2.1 and RXE-2.3
+        identifier = medReq.getIdentifier().get(posExtId);
+        value = identifier.getValue();
+        system = identifier.getSystem();
+        assertThat(value).isEqualTo("999-NDC"); // RXE-2.1 and RXE-2.3
+        assertThat(system).isEqualTo("urn:id:extID");
+
     }
+
+    // TODO Add this when MedicationAdministration is supported
+    // @Test
+    // @Disabled("Currently no messages generate MedicationAdministration resources")
+    // void medicationAdministration_identifier_test() {
+    //     
+    //     // Currently no messages generate MedicationAdministration resources
+    // }
 
     private static int getIdentifierPositionByValue(String value, List<Identifier> identifiers) {
         for (int i = 0; i < identifiers.size(); i++) {

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7NoteFHIRConverterTest.java
@@ -48,6 +48,8 @@ class Hl7NoteFHIRConverterTest {
                 Arguments.of("ORM^O01", 0));
     }
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @ParameterizedTest
     @MethodSource("provideParmsForNoteCreationServiceRequestMutipleOBX")
     void testNoteCreationServiceRequestMutipleOBX(String message, int numExpectedDiagnosticReports) {
@@ -171,6 +173,8 @@ class Hl7NoteFHIRConverterTest {
                                 + "RXE|^Q24H&0600^^20210407191342^^ROU|0169-6339-10^insulin aspart (NOVOLOG) subcutaneous injection (CORRECTION SCALE INSULIN) 0-16 Units^NDC|0||Units|47^SOLN|||||||\n"));
     }
 
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
     @ParameterizedTest
     @MethodSource("parmsTestMedicationRequestNoteCreation")
     void testMedicationRequestNoteCreation(String message, String medicalRequestSegments) {

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7PatientFHIRConversionTest.java
@@ -8,7 +8,6 @@ package io.github.linuxforhealth.hl7.segments;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
@@ -39,33 +38,32 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 class Hl7PatientFHIRConversionTest {
 
-  private static FHIRContext context = new FHIRContext(true, false);
-  private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PatientFHIRConversionTest.class);
+    private static FHIRContext context = new FHIRContext(true, false);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Hl7PatientFHIRConversionTest.class);
 
-  // Tests the PD1 segment with all supported message types.
-  @ParameterizedTest
-  @ValueSource(strings = { "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A02|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A03|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A04|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A08|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A28|||2.6|\r",
-    // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A31|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A34|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A40|||2.6|\r",
-    // MDM messages are not tested here because they do not contain PD1 segments
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||OMP^O09|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||ORM^O01|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||ORU^R01|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O11|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O25|||2.6|\r",
-    "MSH|^~\\&|hl7Integration|hl7Integration|||||VXU^V04|||2.6|\r",
+    // Tests the PD1 segment with all supported message types.
+    @ParameterizedTest
+    @ValueSource(strings = { "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.6|\r",
+            // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A02|||2.6|\r",
+            // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A03|||2.6|\r",
+            // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A04|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A08|||2.6|\r",
+            // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A28|||2.6|\r",
+            // "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A31|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A34|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A40|||2.6|\r",
+            // MDM messages are not tested here because they do not contain PD1 segments
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||OMP^O09|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||ORM^O01|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||ORU^R01|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O11|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||RDE^O25|||2.6|\r",
+            "MSH|^~\\&|hl7Integration|hl7Integration|||||VXU^V04|||2.6|\r",
     })
     void test_patient_additional_demographics(String msh) {
         String hl7message = msh
                 + "PID|1||1234^^^AssigningAuthority^MR||TEST^PATIENT|\r"
-                + "PD1|||Sample Family Practice^^2222|1111^LastName^ClinicianFirstName^^^^Title||||||||||||A|\r"
-                ;
+                + "PD1|||Sample Family Practice^^2222|1111^LastName^ClinicianFirstName^^^^Title||||||||||||A|\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -73,7 +71,7 @@ class Hl7PatientFHIRConversionTest {
         assertThat(patientResource).hasSize(1);
         Patient patient = getResourcePatient(patientResource.get(0));
         List<Reference> refs = patient.getGeneralPractitioner();
-        assertThat(refs.size()).isGreaterThan(0);
+        assertThat(refs.size()).isPositive();
 
         List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(1);
@@ -90,7 +88,7 @@ class Hl7PatientFHIRConversionTest {
      */
 
     @Test
-    void patient_deceased_conversion_test() {
+    void patient_deceased_conversion_test1() {
 
         String patientMsgDeceasedEmpty = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
                 + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA||||\n";
@@ -100,13 +98,6 @@ class Hl7PatientFHIRConversionTest {
                 + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA|||2006|\n";
         String patientMsgDeceasedDateOnlyYYYYMM = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
                 + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA|||200611|\n";
-        String patientMsgDeceasedDateOnlyYYYYMMDDHHMMSSZZZZ = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-                + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA|||20061120115930+0100|\n";
-
-        String patientMsgDeceasedBooleanYOnly = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-                + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA||||Y\n";
-        String patientMsgDeceasedDateAndBooleanY = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-                + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA|||20061120|Y\n";
 
         Patient patientObjDeceasedEmpty = PatientUtils.createPatientFromHl7Segment(patientMsgDeceasedEmpty);
         assertThat(patientObjDeceasedEmpty.hasDeceased()).isFalse();
@@ -117,13 +108,6 @@ class Hl7PatientFHIRConversionTest {
         assertThat(patientObjNotDeadBooleanN.hasDeceased()).isTrue();
         assertThat(patientObjNotDeadBooleanN.hasDeceasedBooleanType()).isTrue();
         assertThat(patientObjNotDeadBooleanN.getDeceasedBooleanType().booleanValue()).isFalse();
-
-        Patient patientObjDeceasedBooleanYOnly = PatientUtils
-                .createPatientFromHl7Segment(patientMsgDeceasedBooleanYOnly);
-        assertThat(patientObjDeceasedBooleanYOnly.hasDeceased()).isTrue();
-        assertThat(patientObjDeceasedBooleanYOnly.hasDeceasedDateTimeType()).isFalse();
-        assertThat(patientObjDeceasedBooleanYOnly.hasDeceasedBooleanType()).isTrue();
-        assertThat(patientObjDeceasedBooleanYOnly.getDeceasedBooleanType().booleanValue()).isTrue();
 
         Patient patientObjDeceasedDateOnlyYYYY = PatientUtils
                 .createPatientFromHl7Segment(patientMsgDeceasedDateOnlyYYYY);
@@ -138,6 +122,27 @@ class Hl7PatientFHIRConversionTest {
         assertThat(patientObjDeceasedDateOnlyYYYYMM.hasDeceasedDateTimeType()).isTrue();
         assertThat(patientObjDeceasedDateOnlyYYYYMM.hasDeceasedBooleanType()).isFalse();
         assertThat(patientObjDeceasedDateOnlyYYYYMM.getDeceasedDateTimeType().asStringValue()).isEqualTo("2006-11");
+
+        // More related tests in patient_deceased_conversion_test2
+    }
+
+    @Test
+    void patient_deceased_conversion_test2() {
+
+        String patientMsgDeceasedDateOnlyYYYYMMDDHHMMSSZZZZ = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+                + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA|||20061120115930+0100|\n";
+
+        String patientMsgDeceasedBooleanYOnly = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+                + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA||||Y\n";
+        String patientMsgDeceasedDateAndBooleanY = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+                + "PID|1||12345678^^^^MR|ALTID|Mouse^Mickey^J^III^^^|Mother^Micky|20060504|M|Alias^Alias|2106-3^White^ HL70005|12345 testing ave^^Minneapolis^MN^55407^^^^MN053|USAA|^PRN^^^PH^555^5555555|^PRN^^^PH^555^666666|english|married|bhuddist|1234567_account|111-22-3333|||2186-5^not Hispanic or Latino^CDCREC|Born in USA|Y|2|USA|||20061120|Y\n";
+
+        Patient patientObjDeceasedBooleanYOnly = PatientUtils
+                .createPatientFromHl7Segment(patientMsgDeceasedBooleanYOnly);
+        assertThat(patientObjDeceasedBooleanYOnly.hasDeceased()).isTrue();
+        assertThat(patientObjDeceasedBooleanYOnly.hasDeceasedDateTimeType()).isFalse();
+        assertThat(patientObjDeceasedBooleanYOnly.hasDeceasedBooleanType()).isTrue();
+        assertThat(patientObjDeceasedBooleanYOnly.getDeceasedBooleanType().booleanValue()).isTrue();
 
         Patient patientObjDeceasedDateOnlyYYYYMMDDHHMMSSZZZZ = PatientUtils
                 .createPatientFromHl7Segment(patientMsgDeceasedDateOnlyYYYYMMDDHHMMSSZZZZ);
@@ -274,8 +279,7 @@ class Hl7PatientFHIRConversionTest {
 
         Patient patientObjGender = PatientUtils.createPatientFromHl7Segment(patientWithGenderField);
         Enumerations.AdministrativeGender gen = patientObjGender.getGender();
-        assertThat(gen).isNotNull();
-        assertThat(gen).isEqualTo(Enumerations.AdministrativeGender.MALE);
+        assertThat(gen).isNotNull().isEqualTo(Enumerations.AdministrativeGender.MALE);
     }
 
     @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7TelecomFHIRConversionTest.java
@@ -6,85 +6,88 @@
 package io.github.linuxforhealth.hl7.segments;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
-import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.ContactPoint;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
 
 import io.github.linuxforhealth.hl7.segments.util.PatientUtils;
 
 class Hl7TelecomFHIRConversionTest {
 
-  @Test
-  void patient_telcom_test() {
+    // Suppress warnings about too many assertions in a test.  Justification: creating a FHIR message is very costly; we need to check many asserts per creation for efficiency.  
+    @java.lang.SuppressWarnings("squid:S5961")
+    @Test
+    void patient_telcom_test() {
 
-    String patientPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-        // Home has 2 phones and an email, work has one phone and two emails
-        + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^3~^PRN^CP^^22^555^2221313^^^^^^^^^^^1~^NET^X.400^email.test@gmail.com^^^^^^^^^^^^^^2|^PRN^PH^^^555^1111414^889~^^^professional@buisness.com~^^^moose.mickey@buisness.com^^^^^^^^^^^^^^4||||||||||||||||\n";
+        String patientPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+                // Home has 2 phones and an email, work has one phone and two emails
+                + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M|||||^PRN^PH^^22^555^1111313^^^^^^^^^^^3~^PRN^CP^^22^555^2221313^^^^^^^^^^^1~^NET^X.400^email.test@gmail.com^^^^^^^^^^^^^^2|^PRN^PH^^^555^1111414^889~^^^professional@buisness.com~^^^moose.mickey@buisness.com^^^^^^^^^^^^^^4||||||||||||||||\n";
 
-    Patient patient = PatientUtils.createPatientFromHl7Segment(patientPhone);
-    assertThat(patient.hasTelecom()).isTrue();
-    List<ContactPoint> contacts = patient.getTelecom();
-    assertThat(contacts.size()).isEqualTo(6);
+        Patient patient = PatientUtils.createPatientFromHl7Segment(patientPhone);
+        assertThat(patient.hasTelecom()).isTrue();
+        List<ContactPoint> contacts = patient.getTelecom();
+        assertThat(contacts.size()).isEqualTo(6);
 
-    // First home contact
-    ContactPoint contact = contacts.get(0);
-    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.HOME);
-    assertThat(contact.getValue()).hasToString("+22 555 111 1313");
-    assertThat(contact.hasRank()).isTrue();
-    assertThat(contact.getRank()).hasToString("3");
-    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
+        // First home contact
+        ContactPoint contact = contacts.get(0);
+        assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.HOME);
+        assertThat(contact.getValue()).hasToString("+22 555 111 1313");
+        assertThat(contact.hasRank()).isTrue();
+        assertThat(contact.getRank()).hasToString("3");
+        assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
 
-    // Second home contact is mobile
-    contact = contacts.get(1);
-    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.MOBILE);
-    assertThat(contact.getValue()).hasToString("+22 555 222 1313");
-    assertThat(contact.hasRank()).isTrue();
-    assertThat(contact.getRank()).hasToString("1");
-    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
+        // Second home contact is mobile
+        contact = contacts.get(1);
+        assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.MOBILE);
+        assertThat(contact.getValue()).hasToString("+22 555 222 1313");
+        assertThat(contact.hasRank()).isTrue();
+        assertThat(contact.getRank()).hasToString("1");
+        assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
 
-    // Third home contact is an email
-    contact = contacts.get(2);
-    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.HOME);
-    assertThat(contact.getValue()).hasToString("email.test@gmail.com");
-    assertThat(contact.hasRank()).isTrue();
-    assertThat(contact.getRank()).hasToString("2");
-    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
+        // Third home contact is an email
+        contact = contacts.get(2);
+        assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.HOME);
+        assertThat(contact.getValue()).hasToString("email.test@gmail.com");
+        assertThat(contact.hasRank()).isTrue();
+        assertThat(contact.getRank()).hasToString("2");
+        assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
 
-    // First work contact is work phone
-    contact = contacts.get(3);
-    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
-    assertThat(contact.getValue()).hasToString("(555) 111 1414 ext. 889");
-    assertThat(contact.hasRank()).isFalse();
-    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
+        // First work contact is work phone
+        contact = contacts.get(3);
+        assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
+        assertThat(contact.getValue()).hasToString("(555) 111 1414 ext. 889");
+        assertThat(contact.hasRank()).isFalse();
+        assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.PHONE);
 
-    // Second work contact is external work email
-    contact = contacts.get(4);
-    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
-    assertThat(contact.getValue()).hasToString("professional@buisness.com");
-    assertThat(contact.hasRank()).isFalse();
-    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
+        // Second work contact is external work email
+        contact = contacts.get(4);
+        assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
+        assertThat(contact.getValue()).hasToString("professional@buisness.com");
+        assertThat(contact.hasRank()).isFalse();
+        assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
 
-    // Third work contact is internal work email and is ranked for contact
-    contact = contacts.get(5);
-    assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
-    assertThat(contact.getValue()).hasToString("moose.mickey@buisness.com");
-    assertThat(contact.hasRank()).isTrue();
-    assertThat(contact.getRank()).hasToString("4");
-    assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
+        // Third work contact is internal work email and is ranked for contact
+        contact = contacts.get(5);
+        assertThat(contact.getUse()).isEqualTo(ContactPoint.ContactPointUse.WORK);
+        assertThat(contact.getValue()).hasToString("moose.mickey@buisness.com");
+        assertThat(contact.hasRank()).isTrue();
+        assertThat(contact.getRank()).hasToString("4");
+        assertThat(contact.getSystem()).isEqualTo(ContactPoint.ContactPointSystem.EMAIL);
 
-  }
+    }
 
-  @Test
-  void patient_no_telcom_test() {
+    @Test
+    void patient_no_telcom_test() {
 
-    String patientNoPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
-        + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";
+        String patientNoPhone = "MSH|^~\\&|MIICEHRApplication|MIIC|MIIC|MIIC|201705130822||VXU^V04^VXU_V04|test1100|P|2.5.1|||AL|AL|||||Z22^CDCPHINVS|^^^^^MIIC^SR^^^MIIC|MIIC\n"
+                + "PID|1||12345678^^^^MR|ALTID|Moose^Mickey^J^III^^^||20060504|M||||||||||||||||||||||\n";
 
-    Patient patient = PatientUtils.createPatientFromHl7Segment(patientNoPhone);
-    assertThat(patient.hasTelecom()).isFalse();
+        Patient patient = PatientUtils.createPatientFromHl7Segment(patientNoPhone);
+        assertThat(patient.hasTelecom()).isFalse();
 
-  }
+    }
 
 }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This is several other fixes for SonarQube. 
Most of them are:
.* preferred ways todo assertions
.* splitting up tests with too many assertions (or using the exception waiver for SonarQube)

I have also updated code with:
.* use common methods for creation and finding resources
.* formatting