### PR TITLE
Issue366 support RelatedPerson from Coverage (IN1)

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.EnumUtils;
 
 public enum SimpleDataTypeMapper {
 
-  BOOLEAN(SimpleDataValueResolver.BOOLEAN),
+  BOOLEAN(SimpleDataValueResolver.BOOLEAN), 
   INTEGER(SimpleDataValueResolver.INTEGER),
   STRING(SimpleDataValueResolver.STRING),
   STRING_ALL(SimpleDataValueResolver.STRING_ALL),
@@ -66,6 +66,7 @@ public enum SimpleDataTypeMapper {
   ACT_ENCOUNTER(SimpleDataValueResolver.ACT_ENCOUNTER_CODE_FHIR),
   PERSON_DISPLAY_NAME(SimpleDataValueResolver.PERSON_DISPLAY_NAME),
   DOC_REF_DOC_STATUS(SimpleDataValueResolver.DOC_REF_DOC_STATUS_CODE_FHIR),
+  POLICYHOLDER_RELATIONSHIP(SimpleDataValueResolver.POLICYHOLDER_RELATIONSHIP),
   ENCOUNTER_MODE_ARRIVAL_DISPLAY(SimpleDataValueResolver.ENCOUNTER_MODE_ARRIVAL_DISPLAY);
 
   private ValueExtractor<Object, ?> valueResolver;

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -34,7 +34,6 @@ import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCategory;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCriticality;
 import org.hl7.fhir.r4.model.DiagnosticReport.DiagnosticReportStatus;
 import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
-import org.hl7.fhir.r4.model.Immunization.ImmunizationStatus;
 import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 import org.hl7.fhir.r4.model.ServiceRequest.ServiceRequestStatus;
@@ -45,11 +44,11 @@ import org.hl7.fhir.r4.model.codesystems.ConditionCategory;
 import org.hl7.fhir.r4.model.codesystems.MessageReasonEncounter;
 import org.hl7.fhir.r4.model.codesystems.NameUse;
 import org.hl7.fhir.r4.model.codesystems.V3ReligiousAffiliation;
+import org.hl7.fhir.r4.model.codesystems.V3RoleCode;
 import org.hl7.fhir.r4.model.codesystems.DiagnosisRole;
 import org.hl7.fhir.r4.model.codesystems.ConditionClinical;
 import org.hl7.fhir.r4.model.codesystems.ConditionVerStatus;
 import org.hl7.fhir.r4.model.codesystems.CompositionStatus;
-import org.hl7.fhir.r5.model.Enumerations;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,13 +60,10 @@ import io.github.linuxforhealth.core.terminology.TerminologyLookup;
 import io.github.linuxforhealth.core.terminology.UrlLookup;
 import io.github.linuxforhealth.hl7.data.date.DateUtil;
 
-
-
 public class SimpleDataValueResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDataValueResolver.class);
     private static final String INVALID_CODE_MESSAGE_FULL = "Invalid input: code '%s' could not be mapped to values in system '%s' with original display '%s' and version '%s'.";
     private static final String INVALID_CODE_MESSAGE_SHORT = "Invalid input: code '%s' could not be mapped to values in system '%s'.";
-
 
     public static final ValueExtractor<Object, String> DATE = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
@@ -125,7 +121,8 @@ public class SimpleDataValueResolver {
                 }
             } catch (UnsupportedTemporalTypeException e) {
                 LOGGER.warn("Cannot evaluate time difference.");
-                LOGGER.debug("Cannot evaluate time difference for start: {} , end: {} reason {} ", start, end, e.getMessage());
+                LOGGER.debug("Cannot evaluate time difference for start: {} , end: {} reason {} ", start, end,
+                        e.getMessage());
                 return null;
             }
         }
@@ -164,8 +161,7 @@ public class SimpleDataValueResolver {
             valfamily = Hl7DataHandlerUtil.getStringValue(xcn.getFamilyName());
             valsuffix = Hl7DataHandlerUtil.getStringValue(xcn.getSuffixEgJRorIII());
 
-        }
-        else if (value instanceof PPN) {
+        } else if (value instanceof PPN) {
             PPN ppn = (PPN) value;
             valprefix = Hl7DataHandlerUtil.getStringValue(ppn.getPrefixEgDR());
             valfirst = Hl7DataHandlerUtil.getStringValue(ppn.getGivenName());
@@ -192,8 +188,8 @@ public class SimpleDataValueResolver {
         String name = sb.toString();
         if (StringUtils.isNotBlank(name)) {
             return name.trim();
-        }
-        else return null;
+        } else
+            return null;
     };
 
     public static final ValueExtractor<Object, String> ADMINISTRATIVE_GENDER_CODE_FHIR = (Object value) -> {
@@ -209,7 +205,7 @@ public class SimpleDataValueResolver {
     };
 
     public static final ValueExtractor<Object, String> MEDREQ_STATUS_CODE_FHIR = (Object value) -> {
-    	String val = Hl7DataHandlerUtil.getStringValue(value);
+        String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, MedicationRequest.MedicationRequestStatus.class);
         if (code != null) {
             return code;
@@ -222,7 +218,8 @@ public class SimpleDataValueResolver {
         String code = getFHIRCode(val, MedicationRequestCategory.class);
         if (code != null) {
             MedicationRequestCategory category = MedicationRequestCategory.fromCode(code);
-            return new SimpleCode(code, "http://terminology.hl7.org/CodeSystem/medicationrequest-category", category.getDisplay()); // category.getSystem() returns http://hl7.org/fhir/medication-request-category which is invalid so we hardcode the system with the proper url
+            return new SimpleCode(code, "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                    category.getDisplay()); // category.getSystem() returns http://hl7.org/fhir/medication-request-category which is invalid so we hardcode the system with the proper url
         } else
             return null;
     };
@@ -231,7 +228,7 @@ public class SimpleDataValueResolver {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         return getFHIRCode(val, ObservationStatus.class);
     };
-   
+
     public static final ValueExtractor<Object, SimpleCode> OBSERVATION_STATUS_FHIR = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, ObservationStatus.class);
@@ -241,11 +238,11 @@ public class SimpleDataValueResolver {
         } else {
             // If code is null, it means the code wasn't known in our table, and can't be looked up.
             // Make a message in the display.
-            String theSystem = ObservationStatus.REGISTERED.getSystem();  
+            String theSystem = ObservationStatus.REGISTERED.getSystem();
             return new SimpleCode(null, theSystem, String.format(INVALID_CODE_MESSAGE_SHORT, val, theSystem));
         }
     };
-    
+
     public static final ValueExtractor<Object, String> SERVICE_REQUEST_STATUS = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         return getFHIRCode(val, ServiceRequestStatus.class);
@@ -261,8 +258,7 @@ public class SimpleDataValueResolver {
         }
     };
 
-    public static final ValueExtractor<Object, SimpleCode> RELIGIOUS_AFFILIATION_FHIR_CC =
-        (Object value) -> {
+    public static final ValueExtractor<Object, SimpleCode> RELIGIOUS_AFFILIATION_FHIR_CC = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, V3ReligiousAffiliation.class);
         String text = Hl7DataHandlerUtil.getOriginalDisplayText(value);
@@ -274,13 +270,13 @@ public class SimpleDataValueResolver {
         } else {
             // // If code is null, it means the code wasn't known in our table, and can't be looked up.
             // // Make a message in the display.
-            String religionSystem = V3ReligiousAffiliation._1028.getSystem(); 
-            return new SimpleCode(null, religionSystem, String.format(INVALID_CODE_MESSAGE_FULL, val, religionSystem, text, version));
-          }
+            String religionSystem = V3ReligiousAffiliation._1028.getSystem();
+            return new SimpleCode(null, religionSystem,
+                    String.format(INVALID_CODE_MESSAGE_FULL, val, religionSystem, text, version));
+        }
     };
 
-    public static final ValueExtractor<Object, SimpleCode> DIAGNOSIS_USE =
-        (Object value) -> {
+    public static final ValueExtractor<Object, SimpleCode> DIAGNOSIS_USE = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, DiagnosisRole.class);
         if (code != null) {
@@ -291,18 +287,16 @@ public class SimpleDataValueResolver {
         }
     };
 
-    public static final ValueExtractor<Object, SimpleCode> CONDITION_CLINICAL_STATUS_FHIR =
-        (Object value) -> {
+    public static final ValueExtractor<Object, SimpleCode> CONDITION_CLINICAL_STATUS_FHIR = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
 
         //Test to see if val is a valid code.
         ConditionClinical use = null;
         try {
             use = ConditionClinical.fromCode(val);
-            LOGGER.info("Found ConditionClinical code for '{}'.",val);
-        }
-        catch(FHIRException e) {
-            LOGGER.warn("Could not find ConditionClinical code for '{}'.",val);
+            LOGGER.info("Found ConditionClinical code for '{}'.", val);
+        } catch (FHIRException e) {
+            LOGGER.warn("Could not find ConditionClinical code for '{}'.", val);
         }
 
         if (use != null) { // if it is then setup the simple code
@@ -312,18 +306,16 @@ public class SimpleDataValueResolver {
         }
     };
 
-    public static final ValueExtractor<Object, SimpleCode> CONDITION_VERIFICATION_STATUS_FHIR =
-        (Object value) -> {
+    public static final ValueExtractor<Object, SimpleCode> CONDITION_VERIFICATION_STATUS_FHIR = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
 
-         //Test to see if val is a valid code.
+        //Test to see if val is a valid code.
         ConditionVerStatus use = null;
-        try{
+        try {
             use = ConditionVerStatus.fromCode(val);
-            LOGGER.info("Found ConditionVerStatus code for '{}'.",val);
-        }
-        catch(FHIRException e) {
-            LOGGER.warn("Could not find ConditionVerStatus code for '{}'.",val);
+            LOGGER.info("Found ConditionVerStatus code for '{}'.", val);
+        } catch (FHIRException e) {
+            LOGGER.warn("Could not find ConditionVerStatus code for '{}'.", val);
         }
         if (use != null) { // if it is then setup the simple code
             return new SimpleCode(val, use.getSystem(), use.getDisplay());
@@ -336,13 +328,13 @@ public class SimpleDataValueResolver {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, V3ActCode.class);
         String version = Hl7DataHandlerUtil.getVersion(value);
-        if(code != null){
+        if (code != null) {
             V3ActCode act = V3ActCode.fromCode(code);
-            return new SimpleCode( code , act.getSystem(), act.getDisplay(), version);
+            return new SimpleCode(code, act.getSystem(), act.getDisplay(), version);
         } else if (val != null) { // if code does not map but is present, use the "val" as the code
-            return new SimpleCode(val, null,  null);
-        }
-        else return null;
+            return new SimpleCode(val, null, null);
+        } else
+            return null;
     };
 
     public static final ValueExtractor<Object, String> SPECIMEN_STATUS_CODE_FHIR = (Object value) -> {
@@ -360,28 +352,44 @@ public class SimpleDataValueResolver {
         return getFHIRCode(val, NameUse.class);
     };
 
-
     public static final ValueExtractor<Object, String> ENCOUNTER_MODE_ARRIVAL_DISPLAY = (Object value) -> {
         return getFHIRCode(Hl7DataHandlerUtil.getStringValue(value), "EncounterModeOfArrivalDisplay");
     };
-    
-  public static final ValueExtractor<Object, SimpleCode> MARITAL_STATUS =
-      (Object value) -> {
+
+    public static final ValueExtractor<Object, SimpleCode> POLICYHOLDER_RELATIONSHIP = (Object value) -> {
+        String val = Hl7DataHandlerUtil.getStringValue(value);
+        String text = Hl7DataHandlerUtil.getOriginalDisplayText(value);
+        String code = getFHIRCode(val, V3RoleCode.class);
+        String version = Hl7DataHandlerUtil.getVersion(value);
+        if (code != null) {
+            V3RoleCode relationship = V3RoleCode.fromCode(code);
+            return new SimpleCode(code, relationship.getSystem(), relationship.getDisplay(), version);
+        } else {
+            // If code is null, it means the code wasn't known in our table, and can't be looked up.
+            // Make a message in the display.
+            String theSystem = V3RoleCode.PRN.getSystem();
+            return new SimpleCode(null, theSystem,
+                    String.format(INVALID_CODE_MESSAGE_FULL, val, theSystem, text, version));
+        }
+    };
+
+    public static final ValueExtractor<Object, SimpleCode> MARITAL_STATUS = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String text = Hl7DataHandlerUtil.getOriginalDisplayText(value);
         String code = getFHIRCode(val, V3MaritalStatus.class);
         String version = Hl7DataHandlerUtil.getVersion(value);
-        if(code != null){
+        if (code != null) {
             V3MaritalStatus mar = V3MaritalStatus.fromCode(code);
             return new SimpleCode(code, mar.getSystem(), mar.getDisplay(), version);
         } else {
-          // If code is null, it means the code wasn't known in our table, and can't be looked up.
-          // Make a message in the display.
-          String theSystem = V3MaritalStatus.M.getSystem(); 
-          return new SimpleCode(null, theSystem, String.format(INVALID_CODE_MESSAGE_FULL, val, theSystem, text, version));
+            // If code is null, it means the code wasn't known in our table, and can't be looked up.
+            // Make a message in the display.
+            String theSystem = V3MaritalStatus.M.getSystem();
+            return new SimpleCode(null, theSystem,
+                    String.format(INVALID_CODE_MESSAGE_FULL, val, theSystem, text, version));
         }
-  };
-  
+    };
+
     public static final ValueExtractor<Object, Boolean> BOOLEAN = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         if (null == val) {
@@ -442,10 +450,10 @@ public class SimpleDataValueResolver {
             // Found table and a code. Try looking it up.
             SimpleCode coding = TerminologyLookup.lookup(table, code);
             // A non-null, non-empty value in display means a good code from lookup.
-            if (coding != null && coding.getDisplay()!=null && !coding.getDisplay().isEmpty()) {
+            if (coding != null && coding.getDisplay() != null && !coding.getDisplay().isEmpty()) {
                 return coding;
-            } 
-        }    
+            }
+        }
         // All other situations return null.  
         return null;
     };
@@ -462,11 +470,11 @@ public class SimpleDataValueResolver {
             // Found table and a code. Try looking it up.
             SimpleCode coding = TerminologyLookup.lookup(table, code);
             // A non-null, non-empty value in display means a good code from lookup.
-            if (coding != null && coding.getDisplay()!=null && !coding.getDisplay().isEmpty()) {
+            if (coding != null && coding.getDisplay() != null && !coding.getDisplay().isEmpty()) {
                 return coding;
-            } else { 
+            } else {
                 // Otherwise, must be a user-defined code, so return the code without a system
-                return new SimpleCode(code, null, null, null) ;
+                return new SimpleCode(code, null, null, null);
             }
         } else if (table == null && code != null) {
             // Handle a code with unknown table
@@ -482,11 +490,11 @@ public class SimpleDataValueResolver {
         if (value instanceof CWE) {
             CWE cwe = (CWE) value;
             String table = Hl7DataHandlerUtil.getStringValue(cwe.getCwe6_NameOfAlternateCodingSystem());
-            String code = Hl7DataHandlerUtil.getStringValue(cwe.getCwe4_AlternateIdentifier()); 
+            String code = Hl7DataHandlerUtil.getStringValue(cwe.getCwe4_AlternateIdentifier());
             String text = Hl7DataHandlerUtil.getStringValue(cwe.getCwe5_AlternateText());
             String version = Hl7DataHandlerUtil.getStringValue(cwe.getCwe8_AlternateCodingSystemVersionID());
             return commonCodingSystemV2(table, code, text, version);
-        } 
+        }
         return null;
     };
 
@@ -502,20 +510,20 @@ public class SimpleDataValueResolver {
     // For OBX.5 and other dynamic encoded fields, the real class is wrapped in the Varies class, and must be extracted from data
     private static final Object checkForAndUnwrapVariesObject(Object value) {
         if (value instanceof Varies) {
-            Varies v = (Varies)value;
+            Varies v = (Varies) value;
             value = v.getData();
         }
-        return value;    
+        return value;
     }
 
-    private static final SimpleCode commonCodingSystemV2 (String table, String code, String text, String version) {
+    private static final SimpleCode commonCodingSystemV2(String table, String code, String text, String version) {
         if (table != null && code != null) {
             // Found table and a code. Try looking it up.
             SimpleCode coding = TerminologyLookup.lookup(table, code);
             if (coding != null) {
                 String display = coding.getDisplay();
                 // Successful display confirms a valid code and system 
-                if (display != null ) {
+                if (display != null) {
 
                     if (display.isEmpty()) {
                         // We have a table, code, but unknown display, so we can't tell if it's good, use the original display text
@@ -526,11 +534,12 @@ public class SimpleDataValueResolver {
                     return coding;
                 } else {
                     // Display was not found; create an error message in the display text
-                    return new SimpleCode(null, coding.getSystem(), String.format(INVALID_CODE_MESSAGE_FULL, code, coding.getSystem(), text, version));
+                    return new SimpleCode(null, coding.getSystem(),
+                            String.format(INVALID_CODE_MESSAGE_FULL, code, coding.getSystem(), text, version));
                 }
-            } else { 
+            } else {
                 // No success looking up the code, build our own fall-back system using table name
-                return new SimpleCode(code, "urn:id:"+table, text, version) ;
+                return new SimpleCode(code, "urn:id:" + table, text, version);
             }
         } else if (code != null) {
             // A code but no system: build a simple systemless code
@@ -540,30 +549,30 @@ public class SimpleDataValueResolver {
         }
     }
 
-
     public static final ValueExtractor<Object, String> BUILD_IDENTIFIER_FROM_CWE = (Object value) -> {
-        if (value instanceof Varies){
+        if (value instanceof Varies) {
             Varies variesValue = ((Varies) value);
-            if(variesValue.getData() instanceof CWE) {
+            if (variesValue.getData() instanceof CWE) {
                 value = (CWE) variesValue.getData();
             }
         }
-       if(value instanceof CWE) {
-           CWE newValue = ((CWE) value);
-           String identifier = newValue.getCwe1_Identifier().toString();
-           String text = newValue.getCwe2_Text().toString();
-           String codingSystem = newValue.getCwe3_NameOfCodingSystem().toString();
-           if (identifier != null) {
-               if (codingSystem != null) {
-                   String join = identifier + "-" + codingSystem;
-                   return join;
-               } else {
-                   return identifier;
-               }
-           } else return text;
-       }
+        if (value instanceof CWE) {
+            CWE newValue = ((CWE) value);
+            String identifier = newValue.getCwe1_Identifier().toString();
+            String text = newValue.getCwe2_Text().toString();
+            String codingSystem = newValue.getCwe3_NameOfCodingSystem().toString();
+            if (identifier != null) {
+                if (codingSystem != null) {
+                    String join = identifier + "-" + codingSystem;
+                    return join;
+                } else {
+                    return identifier;
+                }
+            } else
+                return text;
+        }
 
-       return null;
+        return null;
     };
 
     public static final ValueExtractor<Object, String> ALLERGY_INTOLERANCE_CRITICALITY_CODE_FHIR = (Object value) -> {
@@ -584,21 +593,20 @@ public class SimpleDataValueResolver {
     public static final ValueExtractor<Object, String> DOSE_VALUE = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
 
-        if (val.startsWith("999") ){
+        if (val.startsWith("999")) {
             // 999 is used when the vaccination is refused. In this case we should return null.
             return null;
-        }
-        else return val;
+        } else
+            return val;
 
     };
 
     public static final ValueExtractor<Object, String> DOSE_SYSTEM = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String url = UrlLookup.getAssociatedUrl(val);
-        if (url != null){
+        if (url != null) {
             return url;
-        }
-        else {
+        } else {
             if (val != null && val.length() > 0) {
                 return "urn:id:" + val.replace(" ", "_");
             }
@@ -608,9 +616,8 @@ public class SimpleDataValueResolver {
 
     public static final ValueExtractor<Object, String> SYSTEM_URL = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
-      return UrlLookup.getAssociatedUrl(val);
+        return UrlLookup.getAssociatedUrl(val);
     };
-
 
     // Convert an authority string to a valid system value
     // Prepend "urn:id:"; convert any spaces to underscores
@@ -669,7 +676,6 @@ public class SimpleDataValueResolver {
         return null;
     };
 
-
     public static final ValueExtractor<Object, SimpleCode> MESSAGE_REASON_ENCOUNTER = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, MessageReasonEncounter.class);
@@ -677,10 +683,10 @@ public class SimpleDataValueResolver {
             MessageReasonEncounter en = MessageReasonEncounter.fromCode(code);
             return new SimpleCode(code, en.getSystem(), en.getDisplay());
         } else {
-          // If code is null, it means the code wasn't known in our table, and can't be looked up.
-          // Make a message in the display.
-          String theSystem = MessageReasonEncounter.ADMIT.getSystem();  
-          return new SimpleCode(null, theSystem, String.format(INVALID_CODE_MESSAGE_SHORT, val, theSystem));
+            // If code is null, it means the code wasn't known in our table, and can't be looked up.
+            // Make a message in the display.
+            String theSystem = MessageReasonEncounter.ADMIT.getSystem();
+            return new SimpleCode(null, theSystem, String.format(INVALID_CODE_MESSAGE_SHORT, val, theSystem));
         }
     };
 
@@ -715,7 +721,7 @@ public class SimpleDataValueResolver {
     }
 
     public static String getFHIRCode(String hl7Value, Class<?> fhirConceptClassName) {
-    	return getFHIRCode(hl7Value,fhirConceptClassName.getSimpleName());
+        return getFHIRCode(hl7Value, fhirConceptClassName.getSimpleName());
     }
 
     public static String getFHIRCode(String hl7Value, String fhirMappingConceptName) {

--- a/src/main/resources/fhir/resourcemapping.yml
+++ b/src/main/resources/fhir/resourcemapping.yml
@@ -22,3 +22,4 @@ ServiceRequest: org.hl7.fhir.r4.model.ServiceRequest
 MedicationRequest: org.hl7.fhir.r4.model.MedicationRequest
 Device: org.hl7.fhir.r4.model.Device
 Coverage: org.hl7.fhir.r4.model.Coverage
+RelatedPerson: org.hl7.fhir.r4.model.RelatedPerson

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -390,3 +390,30 @@ MedicationRequestStatus:
 MedicationRequestCategory:
   I: inpatient
   O: outpatient
+
+# HL7 Table 0063 > V3 Role code which is to be used for FHIR subscriber-relationship
+V3RoleCode:
+  BRO: BRO
+# CGV: no good match for Care giver
+  CHD: CHILD
+# DEP: no good match for Handicapped dependent
+  DOM: DOMPART
+  EXF: EXT  
+  FCH: CHLDFOST 
+  FND: FRND
+  FTH: FTH 
+  GCH: GRNDCHILD
+# GRD: no good match for Guardian
+  GRP: GRPRN
+  MTH: MTH
+  NCH: NCHILD 
+# NON: no good match for None
+  OTH: O     
+  PAR: PRN
+  SCH: STPCHLD
+  SEL: ONESELF
+  SIB: SIB
+  SIS: SIS
+  SPO: SPS
+  UNK: U
+# WRD: no good match for Ward of the court  

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -100,14 +100,10 @@ subscriber_1:
    valueOf: resource/RelatedPerson
    expressionType: reference
    vars: 
-       relatedRelationshipStr: String, IN1.17
-       relatedRelationshipCWE: IN1.17
-       relatedNameXPN: IN1.16
-       relatedBirthDTM: IN1.18
-       relatedAddressXAD: IN1.19
-       relatedGender: IN1.43
-       relatedId: IN1.49.1
-       patientRef: $Patient
+      relatedRelationshipStr: String, IN1.17
+      # Related person gets many values from scope, so they do not need to be passed in
+      #  IN1 and sub-fields
+      #  $Patient  
 
 # If the subscriber is SEL (self), then reference the patient
 subscriber_2:

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -94,6 +94,40 @@ payor:
        orgContactXCN: IN1.6
        orgContactPointXTN: IN1.7
 
+# If the subscriber is not SEL (self), then create the related person
+subscriber_1:
+   condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr NOT_EQUALS SEL
+   valueOf: resource/RelatedPerson
+   expressionType: reference
+   vars: 
+       relatedRelationshipStr: String, IN1.17
+       relatedRelationshipCWE: IN1.17
+       relatedNameXPN: IN1.16
+       relatedBirthDTM: IN1.18
+       relatedAddressXAD: IN1.19
+       relatedGender: IN1.43
+       relatedId: IN1.49.1
+       patientRef: $Patient
+
+# If the subscriber is SEL (self), then reference the patient
+subscriber_2:
+    condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr EQUALS SEL
+    valueOf: datatype/Reference
+    expressionType: resource
+    specs: $Patient
+    vars: 
+      relatedRelationshipStr: String, IN1.17            
+
+# Relationship may be SEL (self)
+relationship:
+   valueOf: datatype/CodeableConcept
+   expressionType: resource
+   generateList: true
+   condition: $coding NOT_NULL
+   vars:
+      coding: POLICYHOLDER_RELATIONSHIP, IN1.17
+      text: String, IN1.17.2      
+
 beneficiary:
     valueOf: datatype/Reference
     expressionType: resource

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -1,0 +1,63 @@
+#
+# (C) Copyright IBM Corp. 2020, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+resourceType: RelatedPerson
+# Represents data that needs to be extracted for a RelatedPerson Resource in FHIR
+# reference: https://build.fhir.org/relatedperson.html
+id:
+   type: STRING
+   valueOf: UUID.randomUUID()
+   expressionType: JEXL
+
+identifier:
+   condition: $valueIn NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true
+   expressionType: resource
+   vars:
+      valueIn: String, IN1.49.1 | $relatedId
+   constants:
+      system: http://terminology.hl7.org/CodeSystem/v2-0203
+      code: XV
+      display: "Health Plan Identifier"
+
+patient: 
+   valueOf: datatype/Reference
+   expressionType: resource
+   generateList: true
+   specs: $patientRef
+
+relationship:
+   valueOf: datatype/CodeableConcept
+   expressionType: resource
+   generateList: true
+   condition: $coding NOT_NULL
+   vars:
+      coding: POLICYHOLDER_RELATIONSHIP, IN1.17
+      text: String, IN1.17.2     
+
+name:
+   valueOf: datatype/HumanName
+   generateList: true
+   expressionType: resource
+   specs: IN1.16 | $relatedNameXPN
+
+birthDate:
+   type: DATE
+   valueOf: IN1.18 | relatedBirthDTM
+   expressionType: HL7Spec
+
+gender:
+   type: ADMINISTRATIVE_GENDER
+   valueOf: IN1.43 | $relatedGender
+   expressionType: HL7Spec
+
+address:
+   valueOf: datatype/Address
+   generateList: true
+   expressionType: resource
+   specs: IN1.19 | relatedAddressXAD
+
+

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -4,8 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 resourceType: RelatedPerson
+#
 # Represents data that needs to be extracted for a RelatedPerson Resource in FHIR
 # reference: https://build.fhir.org/relatedperson.html
+# 
+# - NOTE- 
+# Related person gets many values from scope, so they do not need to be passed in: 
+#  IN1 and sub-fields
+#  $Patient 
 id:
    type: STRING
    valueOf: UUID.randomUUID()
@@ -17,7 +23,7 @@ identifier:
    generateList: true
    expressionType: resource
    vars:
-      valueIn: String, IN1.49.1 | $relatedId
+      valueIn: String, IN1.49.1 
    constants:
       system: http://terminology.hl7.org/CodeSystem/v2-0203
       code: XV
@@ -27,7 +33,7 @@ patient:
    valueOf: datatype/Reference
    expressionType: resource
    generateList: true
-   specs: $patientRef
+   specs: $Patient
 
 relationship:
    valueOf: datatype/CodeableConcept
@@ -42,22 +48,22 @@ name:
    valueOf: datatype/HumanName
    generateList: true
    expressionType: resource
-   specs: IN1.16 | $relatedNameXPN
+   specs: IN1.16 
 
 birthDate:
    type: DATE
-   valueOf: IN1.18 | relatedBirthDTM
+   valueOf: IN1.18 
    expressionType: HL7Spec
 
 gender:
    type: ADMINISTRATIVE_GENDER
-   valueOf: IN1.43 | $relatedGender
+   valueOf: IN1.43 
    expressionType: HL7Spec
 
 address:
    valueOf: datatype/Address
    generateList: true
    expressionType: resource
-   specs: IN1.19 | relatedAddressXAD
+   specs: IN1.19 
 
 

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -350,4 +350,23 @@ class SimpleDataValueResolverTest {
         assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply("A string")).isNull();
     }
 
+    @Test
+    void testPolicyholderRelationship() {
+
+        // Check supported known input code
+        SimpleCode coding = SimpleDataValueResolver.POLICYHOLDER_RELATIONSHIP.apply("PAR");
+        assertThat(coding).isNotNull();
+        assertThat(coding.getCode()).isEqualTo("PRN");
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v3-RoleCode");
+        assertThat(coding.getDisplay()).isEqualTo("parent");
+
+        // Check unsupported unknown input code
+        // Even though CGV is a valid HL7 code, there is no mapping
+        coding = SimpleDataValueResolver.POLICYHOLDER_RELATIONSHIP.apply("CGV");
+        assertThat(coding.getCode()).isNull();
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v3-RoleCode");
+        assertThat(coding.getDisplay()).isEqualTo(
+                "Invalid input: code 'CGV' could not be mapped to values in system 'http://terminology.hl7.org/CodeSystem/v3-RoleCode' with original display 'null' and version 'null'.");
+    }
+
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/HL7ConditionFHIRConversionTest.java
@@ -55,7 +55,7 @@ class HL7ConditionFHIRConversionTest {
                 + "DG1|1||C56.9^Ovarian Cancer^I10||20210322154449|A|||||||||1|123^DOE^JOHN^A^|||20210322154326|V45|||||\r";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
-        // Verfify no extraneous resources
+        // Verify no extraneous resources
         // Expect encounter, patient, practitioner, condition
         assertThat(e).hasSize(4);
 


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This adds support for RelatedPerson.  Creates the RelatedPerson if the relationship is not empty or SEL (self).
Creates resource references between the Patient and the Related Person.
Supports special case of relationship SEL.  No RelatedPerson is created, but a reference from subscribed to patient is.

Some reformatting of SimpleDataValueResolver.