### PR TITLE
#366 Improved RelPerson Id

### DIFF
--- a/src/main/resources/hl7/datatype/CodeableConcept_var.yml
+++ b/src/main/resources/hl7/datatype/CodeableConcept_var.yml
@@ -12,6 +12,11 @@ coding:
     valueOf: datatype/Coding
     expressionType: resource
     condition: $code NOT_NULL
+    # Coding uses these scope vars: 
+    # $code
+    # $system
+    # $display
+    # $version
 
 text:  
      valueOf: $text

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -1,12 +1,12 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 # Creates an identifier, you must provide all the values and variables, including those for CodeableConcept_var
 ---
 
-# Used when a coding is not availble but separate values are
+# Used when a coding is not available but separate values are
 type_1: 
    condition: $code NOT_NULL && $coding NULL
    valueOf: datatype/CodeableConcept_var

--- a/src/main/resources/hl7/datatype/Identifier_var.yml
+++ b/src/main/resources/hl7/datatype/Identifier_var.yml
@@ -5,10 +5,26 @@
 #
 # Creates an identifier, you must provide all the values and variables, including those for CodeableConcept_var
 ---
-type: 
+
+# Used when a coding is not availble but separate values are
+type_1: 
+   condition: $code NOT_NULL && $coding NULL
    valueOf: datatype/CodeableConcept_var
    generateList: true
    expressionType: resource
+    # CodeableConcept_var uses these scope vars: 
+    # $code (for CodeableConcept.Coding.code)
+    # $system (for CodeableConcept.Coding.system)
+    # $display (for CodeableConcept.Coding.display)
+    # $version (for CodeableConcept.Coding.version)
+    # $text (for CodeableConcept.text)
+
+# Used when a coding is available
+type_2:
+    condition: $coding NOT_NULL && $code NULL 
+    valueOf: datatype/CodeableConcept
+    generateList: true
+    expressionType: resource
     
 value:
    type: STRING

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -23,11 +23,14 @@ identifier:
    generateList: true
    expressionType: resource
    vars:
+      # For identifier.value
       valueIn: String, IN1.49.1 
-   constants:
-      system: http://terminology.hl7.org/CodeSystem/v2-0203
-      code: XV
-      display: "Health Plan Identifier"
+      # For identifier.system; systemCX will process and remove spaces
+      systemCX: IN1.49.4
+      # For identifier.type, code, system, & display.
+      # Because IN1.49.5 is an ID code, this will create a correct coding
+      # because it knows the table from position and looks up the display
+      coding: CODING_SYSTEM_V2_IDENTIFIER, IN1.49.5
 
 patient: 
    valueOf: datatype/Reference

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,7 +23,8 @@ identifier:
    generateList: true
    expressionType: resource
    vars:
-      # For identifier.value
+      # For identifier.value; required for valid identifier, 
+      # does not require and not dependent on IN1.49.4 or IN1.49.5
       valueIn: String, IN1.49.1 
       # For identifier.system; systemCX will process and remove spaces
       systemCX: IN1.49.4

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -250,8 +250,8 @@ class Hl7FinancialInsuranceTest {
     })
     // Tests IN1.17 coverage by related person. A related person should be created and cross-referenced.
     // Also tests backup field for coverage.order
-    void testInsuranceCoverageByRelatedFields(String messageType) throws IOException {
 
+    void testInsuranceCoverageByRelatedFields(String messageType) throws IOException {
         String hl7message = "MSH|^~\\&|||||20151008111200||"+messageType+"|MSGID000001|T|2.6|||||||||\n"
                 + "EVN||20210407191342||||||\n"
                 + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
@@ -287,8 +287,12 @@ class Hl7FinancialInsuranceTest {
                 // IN1.43 to RelatedPerson.gender
                 // IN1.46 to Identifier 3
                 // IN1.49 to RelatedPerson.identifier
+                //    IN1.49.1 to RelatedPerson.identifier.value
+                //    IN1.49.4 to RelatedPerson.identifier.system
+                //    IN1.49.5 to RelatedPerson.identifier.type.code (must be from terminology.hl7.org/3.0.0/CodeSystem-v2-0203.html)
+                //      NOTE: Purposely XX to ensure we are doing a lookup, and not getting bleed from other hard-coded XV uses
                 // IN1.50 through IN1.53 NOT REFERENCED
-                + "|MEMBER36|||||||F|||Value46|||J494949||||\n";
+                + "|MEMBER36|||||||F|||Value46|||J494949^^^Large HMO^XX||||\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -322,10 +326,10 @@ class Hl7FinancialInsuranceTest {
 
         // Check RelatedPerson identifier
         assertThat(related.getIdentifier()).hasSize(1);
-        assertThat(related.getIdentifier().get(0).getValue()).isEqualTo("J494949"); // IN1.49
-        assertThat(related.getIdentifier().get(0).getSystem()).isNull();
-        DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(0).getType(), "XV",
-                "Health Plan Identifier",
+        assertThat(related.getIdentifier().get(0).getValue()).isEqualTo("J494949"); // IN1.49.1
+        assertThat(related.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:Large_HMO"); // IN1.49.4
+        DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(0).getType(), "XX", // IN1.49.5
+                "Organization identifier",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Check RelatedPerson name. IN1.16 name is standard XPN, tested exhaustively in other tests.        

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -329,7 +329,7 @@ class Hl7FinancialInsuranceTest {
         assertThat(related.getIdentifier().get(0).getValue()).isEqualTo("J494949"); // IN1.49.1
         assertThat(related.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:Large_HMO"); // IN1.49.4
         DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(0).getType(), "XX", // IN1.49.5
-                "Organization identifier",
+                "Organization identifier", // Display value looked up from code 'XX'
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Check RelatedPerson name. IN1.16 name is standard XPN, tested exhaustively in other tests.        


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This makes some small but important changes to RelatedPerson identifier so that the display and code are looked up, rather than hard coded.

Adds capability to Identifier_var to use a coding.
Uses CODING_SYSTEM_V2_IDENTIFIER to create a coding.
Added documentation about scope variables for Identifier_var and CodeableConcept_var.

