### PR TITLE
#403 tenant prepend, run time parameters

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -1,5 +1,5 @@
-# Coding and Testing Best Practices for
-##General
+# Coding and Testing Best Practices
+## General
 In addition to general Java best practices, these are additional requirements and recommendations 
 for keeping the increasingly large converter code maintable.  
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ If you need another message type/event . . .  contributions are welcome! See [CO
 * [Templating Configuration](./TEMPLATING.md)
 * [Development Guide](./DEVELOPMENT.md)
 * [HL7 to FHIR Conversion Design](./HL7FHIR.md)
+* [Techniques](./TECHNIQUES.md)
+* [Coding and Testing Best Practices](./BEST_PRACTICES.md)
 
 ## Development Quickstart
 
@@ -68,7 +70,7 @@ cd hl7v2-fhir-converter
 ./gradlew build
 ```
 
-## Using The Converter In A Java Application
+## Using the Converter in a Java Application
 
 The HL7 to FHIR converter library is available as a maven dependency. 
 
@@ -121,6 +123,16 @@ The config.properties file location is searched in the following order:
    ``` -Dhl7converter.config.home=/opt/converter/config_home_folder/```
 
 * Lastly, the local classpath resource folder will be searched for config.properties
+
+## Converter Runtime Parameters
+
+The converter allows passing of certain parameters at run time through the options.
+ 
+| Parameter Name           | Description                                                                                                                                                                       | Example Call on Options Creation                    |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| ZoneIdText     | ZoneId override, passed as a valid ZoneId text string.  It is converted to a ZoneId.                                                            | options.withZoneIdText("+07:00")      |
+| Property (Key/Value)  | A string property expressed as a key / value pair.  Properties become available as variables to the templates.  A property `TENANT` with value `myTenantId` is utilized in templates as `$TENANT`.             | options.withProperty("TENANT","myTenantId")      |
+
 
 ### PHI (Protected Health Information)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The converter configuration file, config.properties, supports the following sett
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
 | base.path.resource      | Path to resource templates (optional). If not specified the library's default resources under src/resources are used.                                                            | /opt/converter/resources        |
 | supported.hl7.messages  | Comma delimited list of hl7 message/event types. An asterisk `*` may be used to indicate all messages found in sub-directory `/hl7/messages` under the `base.path.resource` and sub-directory `/hl7/messages` under `additional.resources.location` are supported. If not specified, defaults to `*`.                                                                                                                             | ADT_A01, ORU_R01, PPR_PC1       |
-| default.zoneid          | ISO 8601 timezone offset (optional). The zoneid is applied to translations when the target FHIR resource field requires a timezone, but the source HL7 field does not include it. | +08:00                          |
+| default.zoneid          | ISO 8601 timezone offset (optional). The zoneid is converted to java.time.ZoneId and applied to translations when the target FHIR resource field requires a timezone, but the source HL7 field does not include it.  Requires a valid string value for java.time.ZoneId. | +08:00                          |
 | additional.conceptmap   | Path to additional concept map configuration. Concept maps are used for mapping one code system to another.                                                                       | /opt/converter/concept-map.yaml |
 | additional.resources.location  | Path to additional resources. These supplement those `base.path.resource`.                                                                         | /opt/supplemental/resources|
 
@@ -130,7 +130,7 @@ The converter allows passing of certain parameters at run time through the optio
  
 | Parameter Name           | Description                                                                                                                                                                       | Example Call on Options Creation                    |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| ZoneIdText     | ZoneId override, passed as a valid ZoneId text string.  It is converted to a ZoneId.                                                            | options.withZoneIdText("+07:00")      |
+| ZoneIdText     | ZoneId override for the ISO 8601 timezone offset. Overrides default.zoneid in config.properties. Requires a valid ZoneId text value, which is converted to a java.time.ZoneId.            | options.withZoneIdText("+07:00")      |
 | Property (Key/Value)  | A string property expressed as a key / value pair.  Properties become available as variables to the templates.  A property `TENANT` with value `myTenantId` is utilized in templates as `$TENANT`.             | options.withProperty("TENANT","myTenantId")      |
 
 

--- a/src/main/java/io/github/linuxforhealth/core/config/ConverterConfiguration.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConverterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -136,6 +136,17 @@ public class ConverterConfiguration {
 
   public ZoneId getZoneId() {
     return zoneId;
+  }
+
+  // Allow override of ZoneId
+  public void setZoneId(String zoneText) {
+    try {
+      zoneId = ZoneId.of(zoneText);
+    } catch (DateTimeException e) {
+      LOGGER.warn("Cannot create ZoneId");
+      LOGGER.debug("Cannot create ZoneId from :" + zoneText, e);
+      // Leave zoneId as it was.
+    }
   }
 
   public String getAdditionalConceptmapFile() {

--- a/src/main/java/io/github/linuxforhealth/core/config/ConverterConfiguration.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConverterConfiguration.java
@@ -138,7 +138,7 @@ public class ConverterConfiguration {
     return zoneId;
   }
 
-  // Allow override of ZoneId
+  // Allow override of the ZoneId used for TimeZone operations
   public void setZoneId(String zoneText) {
     try {
       zoneId = ZoneId.of(zoneText);

--- a/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
+++ b/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
@@ -1,12 +1,14 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 package io.github.linuxforhealth.fhir;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
@@ -30,22 +32,40 @@ public class FHIRContext {
     private IParser parser;
     private static FhirValidator validator;
     private boolean validateResource;
+    private HashMap<String, String> properties = new HashMap<>();
 
     /**
      * Constructor for FHIRContext
      * 
      * @param isPrettyPrint Should PrettyPrint be applied to output formatting
      * @param validateResource Should the output be FHIR validated
+     * @param properties Run-time properties in a Map or Key / value pairs
+     * 
+     */
+    public FHIRContext(boolean isPrettyPrint, boolean validateResource, Map<String,String> properties) {
+        parser = CTX.newJsonParser();
+        parser.setPrettyPrint(isPrettyPrint);
+        this.validateResource = validateResource;
+        this.properties = (HashMap<String, String>) properties;
+
+    }
+
+    /**
+     * Constructor for FHIRContext
+     * 
+     * @param isPrettyPrint Should PrettyPrint be applied to output formatting
+     * @param validateResource Should the output be FHIR validated
+     * 
      */
     public FHIRContext(boolean isPrettyPrint, boolean validateResource) {
         parser = CTX.newJsonParser();
         parser.setPrettyPrint(isPrettyPrint);
         this.validateResource = validateResource;
-
+        this.properties = new HashMap<>();
     }
 
     public FHIRContext() {
-        this(Constants.DEFAULT_PRETTY_PRINT, false);
+        this(Constants.DEFAULT_PRETTY_PRINT, false, new HashMap<>());
     }
 
     public IParser getParser() {
@@ -59,6 +79,10 @@ public class FHIRContext {
     public static FhirValidator getValidator() {
         initValidator();
         return validator;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
     }
 
     public String encodeResourceToString(Bundle bundle){

--- a/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
+++ b/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
@@ -32,14 +32,14 @@ public class FHIRContext {
     private IParser parser;
     private static FhirValidator validator;
     private boolean validateResource;
-    private HashMap<String, String> properties = new HashMap<>();
+    private HashMap<String, String> properties;
 
     /**
      * Constructor for FHIRContext
      * 
      * @param isPrettyPrint Should PrettyPrint be applied to output formatting
      * @param validateResource Should the output be FHIR validated
-     * @param properties Run-time properties in a Map or Key / value pairs
+     * @param properties Run-time properties in a Map of Key / Value String pairs
      * 
      */
     public FHIRContext(boolean isPrettyPrint, boolean validateResource, Map<String,String> properties) {
@@ -58,10 +58,7 @@ public class FHIRContext {
      * 
      */
     public FHIRContext(boolean isPrettyPrint, boolean validateResource) {
-        parser = CTX.newJsonParser();
-        parser.setPrettyPrint(isPrettyPrint);
-        this.validateResource = validateResource;
-        this.properties = new HashMap<>();
+        this(isPrettyPrint, validateResource, new HashMap<>());
     }
 
     public FHIRContext() {

--- a/src/main/java/io/github/linuxforhealth/hl7/ConverterOptions.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/ConverterOptions.java
@@ -99,6 +99,15 @@ public class ConverterOptions {
         return zoneIdText;
     }
 
+    /**
+     * getProperty looks up the value for a property of key
+     * 
+     * @key isPrettyPrint Should PrettyPrint be applied to output formatting
+     * 
+     * @return the value associated with the key or NULL if the key is not found
+     * 
+     */
+
     public String getProperty(String key) {
         Preconditions.checkArgument(key != null, "Property key cannot be null");
         return properties.get(key);

--- a/src/main/java/io/github/linuxforhealth/hl7/ConverterOptions.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/ConverterOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,10 @@
 package io.github.linuxforhealth.hl7;
 
 import org.hl7.fhir.r4.model.Bundle.BundleType;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.common.base.Preconditions;
 import io.github.linuxforhealth.core.Constants;
 
@@ -17,70 +21,91 @@ import io.github.linuxforhealth.core.Constants;
  * @author pbhallam
  */
 public class ConverterOptions {
-  public static final ConverterOptions SIMPLE_OPTIONS = new Builder().build();
+    public static final ConverterOptions SIMPLE_OPTIONS = new Builder().build();
 
-
-  private BundleType bundleType;
-  private boolean prettyPrint;
-  private boolean validateResource;
-
-
-  private ConverterOptions(Builder builder) {
-    if (builder.bundleType != null) {
-      this.bundleType = builder.bundleType;
-    } else {
-      this.bundleType = Constants.DEFAULT_BUNDLE_TYPE;
-    }
-    this.prettyPrint = builder.prettyPrint;
-    this.validateResource = builder.validateResource;
-
-  }
-
-  public static class Builder {
     private BundleType bundleType;
     private boolean prettyPrint;
     private boolean validateResource;
+    private String zoneIdText;
+    private HashMap<String, String> properties;
 
-
-    public Builder withBundleType(BundleType bundleType) {
-      Preconditions.checkArgument(bundleType != null, "Bundle type cannot be null");
-      this.bundleType = bundleType;
-      return this;
+    private ConverterOptions(Builder builder) {
+        if (builder.bundleType != null) {
+            this.bundleType = builder.bundleType;
+        } else {
+            this.bundleType = Constants.DEFAULT_BUNDLE_TYPE;
+        }
+        this.zoneIdText = builder.zoneIdText;
+        this.properties = builder.properties;
+        this.prettyPrint = builder.prettyPrint;
+        this.validateResource = builder.validateResource;
     }
 
-    public Builder withPrettyPrint() {
-      this.prettyPrint = true;
-      return this;
+    public static class Builder {
+        private BundleType bundleType;
+        private boolean prettyPrint;
+        private boolean validateResource;
+        private String zoneIdText;
+        private HashMap<String, String> properties = new HashMap<>();
+
+        public Builder withBundleType(BundleType bundleType) {
+            Preconditions.checkArgument(bundleType != null, "Bundle type cannot be null");
+            this.bundleType = bundleType;
+            return this;
+        }
+
+        public Builder withPrettyPrint() {
+            this.prettyPrint = true;
+            return this;
+        }
+
+        public Builder withValidateResource() {
+            this.validateResource = true;
+            return this;
+        }
+
+        public Builder withZoneIdText(String zoneIdText) {
+            Preconditions.checkArgument(zoneIdText != null, "zoneIdText cannot be null");
+            this.zoneIdText = zoneIdText;
+            return this;
+        }
+
+        public Builder withProperty(String key, String value) {
+            Preconditions.checkArgument(key != null, "Property key cannot be null");
+            Preconditions.checkArgument(value != null, "Property value cannot be null");
+            this.properties.put(key, value);
+            return this;
+        }
+
+        public ConverterOptions build() {
+            return new ConverterOptions(this);
+        }
+
     }
 
-    public Builder withValidateResource() {
-      this.validateResource = true;
-      return this;
+    public BundleType getBundleType() {
+        return bundleType;
     }
 
-
-
-
-
-    public ConverterOptions build() {
-      return new ConverterOptions(this);
+    public boolean isPrettyPrint() {
+        return prettyPrint;
     }
 
+    public boolean isValidateResource() {
+        return validateResource;
+    }
 
-  }
+    public String getZoneIdText() {
+        return zoneIdText;
+    }
 
-  public BundleType getBundleType() {
-    return bundleType;
-  }
+    public String getProperty(String key) {
+        Preconditions.checkArgument(key != null, "Property key cannot be null");
+        return properties.get(key);
+    }
 
-  public boolean isPrettyPrint() {
-    return prettyPrint;
-  }
-
-  public boolean isValidateResource() {
-    return validateResource;
-  }
-
-
+    public Map<String, String> getProperties() {
+        return properties;
+    }
 
 }

--- a/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.util.Hl7InputStreamMessageStringIterator;
+import io.github.linuxforhealth.core.config.ConverterConfiguration;
 import io.github.linuxforhealth.core.terminology.TerminologyLookup;
 import io.github.linuxforhealth.core.terminology.UrlLookup;
 import io.github.linuxforhealth.fhir.FHIRContext;
@@ -138,6 +139,11 @@ public class HL7ToFHIRConverter {
             engine = getMessageEngine(options);
         }
 
+        // If zoneIdText has been provide via run properties, it overrides the default and any value from the config file.
+        if (options.getZoneIdText()!=null) {
+            ConverterConfiguration.getInstance().setZoneId(options.getZoneIdText());
+        }
+
         Message hl7message = getHl7Message(hl7MessageData);
         if (hl7message != null) {
             String messageType = HL7DataExtractor.getMessageType(hl7message);
@@ -154,7 +160,7 @@ public class HL7ToFHIRConverter {
 
     private HL7MessageEngine getMessageEngine(ConverterOptions options){
         Preconditions.checkArgument(options != null, "options cannot be null.");
-        FHIRContext context = new FHIRContext(options.isPrettyPrint(), options.isValidateResource());
+        FHIRContext context = new FHIRContext(options.isPrettyPrint(), options.isValidateResource(), options.getProperties());
 
         return new HL7MessageEngine(context, options.getBundleType());
     }

--- a/src/main/java/io/github/linuxforhealth/hl7/expression/AbstractExpression.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/expression/AbstractExpression.java
@@ -172,14 +172,14 @@ public abstract class AbstractExpression implements Expression {
 
     List<Object> result = new ArrayList<>();
     List<ResourceValue> additionalresourcesresult = new ArrayList<>();
-    List<Object> baseSpecvalues =  // BJCBJC this is key.  I should have two spec values.
+    List<Object> baseSpecvalues =  
         getSpecValues(dataSource, localContextValues, baseinputValue, this.getspecs());
     LOGGER.debug("Base values evaluated {} -----  values {} ", this, baseSpecvalues);
 
 
     if (!baseSpecvalues.isEmpty()) {
       for (Object o : baseSpecvalues) {
-        EvaluationResult gen = generateValue(dataSource, localContextValues,  // BJCBJC SHould give me a value
+        EvaluationResult gen = generateValue(dataSource, localContextValues,  
             EvaluationResultFactory.getEvaluationResult(o));
 
         if (gen != null && gen.getValue() != null && !gen.isEmpty()) {
@@ -238,7 +238,7 @@ public abstract class AbstractExpression implements Expression {
     EvaluationResult specValues;
     if (specs == null || specs.isEmpty()) {
       specValues = baseinputValue;
-    } else {  //BJCBJC could put breakpoint here
+    } else { 
       specValues = SpecificationUtil.extractMultipleValuesForSpec(specs, dataSource,
           ImmutableMap.copyOf(contextValues));
     }

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -233,7 +233,6 @@ public class HL7MessageEngine implements MessageEngine {
     private static String getResultIdentifier(FHIRResourceTemplate resTemplate,
             ResourceResult result) {
 
-        // BJCBJC if (result != null && result.getGroupId() != null && !result.getGroupId().startsWith("OBSERVATION_")) {
         if (result != null && result.getGroupId() != null) {
             return resTemplate.getResourceName() + "_" + result.getGroupId();
         } else {

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -39,6 +39,7 @@ import io.github.linuxforhealth.core.Constants;
 import io.github.linuxforhealth.core.ObjectMapperUtil;
 import io.github.linuxforhealth.core.exception.RequiredConstraintFailureException;
 import io.github.linuxforhealth.core.expression.EvaluationResultFactory;
+import io.github.linuxforhealth.core.expression.SimpleEvaluationResult;
 import io.github.linuxforhealth.core.resource.ResourceResult;
 import io.github.linuxforhealth.core.resource.SimpleResourceValue;
 import io.github.linuxforhealth.fhir.FHIRContext;
@@ -97,6 +98,12 @@ public class HL7MessageEngine implements MessageEngine {
         HL7MessageData hl7DataInput = (HL7MessageData) dataInput;
         Bundle bundle = initBundle();
         Map<String, EvaluationResult> localContextValues = new HashMap<>(contextValues);
+
+        // Add run-time properties to localContextVariables
+        for (Map.Entry<String,String> entry : getFHIRContext().getProperties().entrySet()){
+            localContextValues.put(entry.getKey(), new SimpleEvaluationResult<String>(entry.getValue()));
+        }
+ 
         List<ResourceResult> resourceResultsWithEvalLater = new ArrayList<>();
         for (FHIRResourceTemplate genericTemplate : resources) {
             HL7FHIRResourceTemplate hl7ResourceTemplate = (HL7FHIRResourceTemplate) genericTemplate;

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,9 +17,10 @@ identifier_1:
    vars:
       id: CWE.1 | XON.10 | XON.3
       system: CWE.3 
-# Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier    
-identifier_2:
-   condition: $orgIdValue NOT_NULL
+# Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier
+# This handles case when no $TENANT value is available        
+identifier_2a:
+   condition: $orgIdValue NOT_NULL && $TENANT NULL
    valueOf: datatype/Identifier_var
    generateList: true  
    expressionType: resource
@@ -28,7 +29,22 @@ identifier_2:
       systemCX: $orgIdSystem
       start: $orgIdStart
       end: $orgIdEnd
-      code: $orgIdTypeCode      
+      code: $orgIdTypeCode
+# Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier
+# This handles case when $TENANT is passed at run time          
+identifier_2b:
+   condition: $orgIdValue NOT_NULL && $TENANT NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true  
+   expressionType: resource
+   vars:
+      valueIn: $TENANT + $period + $orgIdValue
+      systemCX: $orgIdSystem
+      start: $orgIdStart
+      end: $orgIdEnd
+      code: $orgIdTypeCode  
+   constants:
+      period: '.'                 
 name_v1:
    type: STRING
    condition: $idValue NULL

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -80,6 +80,14 @@ class ConverterConfigurationTest {
         assertThat(theConvConfig.getAdditionalConceptmapFile())
                 .isEqualTo("src/test/resources/additional_conceptmap.yml");
         assertThat(theConvConfig.getAdditionalResourcesLocation()).isEqualTo("src/test/resources/additional_resources");
+
+        // Test that ZoneId can be overridden
+        theConvConfig.setZoneId("+07:00");
+        assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+07:00");
+
+        // Test that a BAD ZoneId does not override and does not change existing value
+        theConvConfig.setZoneId("BAD_ZONE_ID");
+        assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+07:00");
     }
 
     private void writeProperties(File configFile) throws FileNotFoundException, IOException {

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -82,6 +82,7 @@ class ConverterConfigurationTest {
         assertThat(theConvConfig.getAdditionalResourcesLocation()).isEqualTo("src/test/resources/additional_resources");
 
         // Test that ZoneId can be overridden
+        assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+08:00"); // Double check value before the set (previouly checked line 79)
         theConvConfig.setZoneId("+07:00");
         assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+07:00");
 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,11 +45,15 @@ public class ResourceUtils {
 
     public static FHIRContext context = new FHIRContext();
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtils.class);
-    private static final ConverterOptions OPTIONS = new Builder().withValidateResource().withPrettyPrint().build();
+    private static final ConverterOptions STANDARD_OPTIONS = new Builder().withValidateResource().withPrettyPrint()/*.withZoneIdText("America/Los_Angeles").withProperty("TENANT", "BJCBJC")*/.build(); //.withProperty("TENANT", "BJCBJC")
 
     public static List<BundleEntryComponent> createFHIRBundleFromHL7MessageReturnEntryList(String inputSegment) {
+        return createFHIRBundleFromHL7MessageReturnEntryList(inputSegment, STANDARD_OPTIONS);
+    }
+
+    public static List<BundleEntryComponent> createFHIRBundleFromHL7MessageReturnEntryList(String inputSegment, ConverterOptions options ) {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-        String json = ftv.convert(inputSegment, OPTIONS);
+        String json = ftv.convert(inputSegment, options);
         assertThat(json).isNotBlank();
         LOGGER.debug("FHIR json result:\n" + json);
         FHIRContext context = new FHIRContext();

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/util/ResourceUtils.java
@@ -45,7 +45,7 @@ public class ResourceUtils {
 
     public static FHIRContext context = new FHIRContext();
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtils.class);
-    private static final ConverterOptions STANDARD_OPTIONS = new Builder().withValidateResource().withPrettyPrint()/*.withZoneIdText("America/Los_Angeles").withProperty("TENANT", "BJCBJC")*/.build(); //.withProperty("TENANT", "BJCBJC")
+    private static final ConverterOptions STANDARD_OPTIONS = new Builder().withValidateResource().withPrettyPrint().build(); 
 
     public static List<BundleEntryComponent> createFHIRBundleFromHL7MessageReturnEntryList(String inputSegment) {
         return createFHIRBundleFromHL7MessageReturnEntryList(inputSegment, STANDARD_OPTIONS);


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>
Implements functionality to prepend a tenant id to the organization id.
When the tenant id is provided the organization identifier value should be `<tenantid>` + `period` +  `IN1.3.1`

This PR provides a new method on options object  to pass parameters at run time.  The mechanism is   options.withProperty("TENANT","myTenantId"). 
A string property is expressed as a key / value pair.  Properties become available as variables to the templates.  A property `TENANT` with value `myTenantId` is utilized in templates as `$TENANT`.           

Example added during creation of the options:
`ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint().withProperty("TENANT", "TenantId").build();`

This PR also add the capability to set a ZoneId on the options.  Only light testing has been added.  Full testing will be completed in a future PR.