### PR TITLE
…

### DIFF
--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -350,10 +350,8 @@ V3ReligiousAffiliation:
   # Unknown
   # VAR:   NO REASONABLE MATCH
 
-DiagnosisRole:
+DiagnosisRole: # maps DG1.6 to Encounter.diagnosis.use
    A: AD
-   F: DD # F stands for final DD stands for discharge Diagnosis which is the final diagnosis before being discharged
-   W: CC # When the patient presents with a chief complaint, such as cough, the provider considers the most common diseases that present with cough, forming a working differential diagnosis list
 
 MedicationRequestStatus:
    AF: active

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -352,6 +352,8 @@ V3ReligiousAffiliation:
 
 DiagnosisRole:
    A: AD
+   F: DD # F stands for final DD stands for discharge Diagnosis which is the final diagnosis before being discharged
+   W: CC # When the patient presents with a chief complaint, such as cough, the provider considers the most common diseases that present with cough, forming a working differential diagnosis list
 
 MedicationRequestStatus:
    AF: active

--- a/src/main/resources/hl7/message/ADT_A03.yml
+++ b/src/main/resources/hl7/message/ADT_A03.yml
@@ -30,18 +30,20 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PV2
-             - EVN
-             - MSH
-             - OBX
+        - PV2
+        - EVN
+        - MSH
+        - DG1
 
     - resourceName: Condition
       segment: DG1
       resourcePath: resource/Condition
-      repeats: true
       isReferenced: true
+      repeats: true
       additionalSegments:
         - MSH
+        - PID
+        - PV1
 
     - resourceName: Observation
       segment: OBX

--- a/src/main/resources/hl7/message/ADT_A04.yml
+++ b/src/main/resources/hl7/message/ADT_A04.yml
@@ -6,52 +6,77 @@
 # FHIR Resources to extract from ADT_A04 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-             - EVN
-   
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PD1
-             - MSH
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PV2
-             - EVN
-             - MSH
-             - OBX
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
 
-    - resourceName: Observation
-      segment: OBX
-      resourcePath: resource/Observation
-      repeats: true
-      isReferenced: true
-      additionalSegments:
-             - MSH
 
-    - resourceName: AllergyIntolerance
-      segment: AL1
-      resourcePath: resource/AllergyIntolerance
-      repeats: true
-      additionalSegments:
-             - MSH
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH
+      - DG1
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
-      repeats: true
-      additionalSegments:
-             - MSH
+  - resourceName: Condition
+    segment: DG1
+    resourcePath: resource/Condition
+    isReferenced: true
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
+
+  - resourceName: Observation
+    segment: OBX
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - MSH
+
+  - resourceName: AllergyIntolerance
+    segment: AL1
+    resourcePath: resource/AllergyIntolerance
+    repeats: true
+    additionalSegments:
+      - MSH
+
+  - resourceName: Procedure
+    segment: .PR1
+    group: PROCEDURE
+    resourcePath: resource/Procedure
+    repeats: true
+    additionalSegments:
+      - .ROL
+      - MSH
+      - PID
+      - PV1
+
+  - resourceName: Coverage
+    segment: .IN1
+    group: INSURANCE
+    resourcePath: resource/Coverage
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1

--- a/src/main/resources/hl7/message/ADT_A28.yml
+++ b/src/main/resources/hl7/message/ADT_A28.yml
@@ -29,10 +29,20 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PV2
-             - EVN
-             - MSH
-             - OBX
+        - PV2
+        - EVN
+        - MSH
+        - DG1
+
+    - resourceName: Condition
+      segment: DG1
+      resourcePath: resource/Condition
+      isReferenced: true
+      repeats: true
+      additionalSegments:
+        - MSH
+        - PID
+        - PV1
 
     - resourceName: Observation
       segment: OBX
@@ -40,18 +50,32 @@ resources:
       repeats: true
       isReferenced: true
       additionalSegments:
-             - MSH
+        - MSH
 
     - resourceName: AllergyIntolerance
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
       additionalSegments:
-             - MSH
+        - MSH
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
+    - resourceName: Procedure
+      segment: .PR1
+      group: PROCEDURE
+      resourcePath: resource/Procedure
+      repeats: true
+      additionalSegments:
+        - .ROL
+        - MSH
+        - PID
+        - PV1
+
+    - resourceName: Coverage
+      segment: .IN1
+      group: INSURANCE
+      resourcePath: resource/Coverage
       repeats: true
       additionalSegments:
         - MSH
+        - PID
+        - PV1

--- a/src/main/resources/hl7/message/ADT_A31.yml
+++ b/src/main/resources/hl7/message/ADT_A31.yml
@@ -29,10 +29,20 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PV2
-             - EVN
-             - MSH
-             - OBX
+        - PV2
+        - EVN
+        - MSH
+        - DG1
+
+    - resourceName: Condition
+      segment: DG1
+      resourcePath: resource/Condition
+      isReferenced: true
+      repeats: true
+      additionalSegments:
+        - MSH
+        - PID
+        - PV1
 
     - resourceName: Observation
       segment: OBX
@@ -40,18 +50,32 @@ resources:
       repeats: true
       isReferenced: true
       additionalSegments:
-             - MSH
+        - MSH
 
     - resourceName: AllergyIntolerance
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
       additionalSegments:
-             - MSH
+        - MSH
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
+    - resourceName: Procedure
+      segment: .PR1
+      group: PROCEDURE
+      resourcePath: resource/Procedure
+      repeats: true
+      additionalSegments:
+        - .ROL
+        - MSH
+        - PID
+        - PV1
+
+    - resourceName: Coverage
+      segment: .IN1
+      group: INSURANCE
+      resourcePath: resource/Coverage
       repeats: true
       additionalSegments:
         - MSH
+        - PID
+        - PV1


### PR DESCRIPTION
Data bleed caused by missing segment in the message yaml. 
Same thing for Encounter.diagnosis.use

This PR includes fixes for the two threads in slack from the test team.
Both fixes were simple I completely over thought the first issue which is why I moved it here to start clean.

**Problem 1**: One of our testers discovered a scenario where an Identifier with no system still had a system.  If PV1.4 is available then we use it for the system in this case, PV1.4 was not available but we still got a system
```
what we got:
value: 1001918
system: urn:id:1001918
expected:
value: 1001918
```

**Problem 2**:  One of our testers discovered a scenario we were missing a few mappings and that Encounter.diagnosis.use was not cycling through each DG1 segment 

