### PR TITLE
Fix Org.contact.telecom.use; better telecom test

### DIFF
--- a/src/main/resources/hl7/secondary/Contact.yml
+++ b/src/main/resources/hl7/secondary/Contact.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,5 +23,4 @@ telecom:
    generateList: true
    expressionType: resource
    specs: $contactPointXTN
-   constants:
-      use: work
+

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -518,7 +518,7 @@ class Hl7FinancialInsuranceTest {
         assertThat(org.getContact().get(0).getTelecom()).hasSize(1);
         ContactPoint contactPoint = org.getContact().get(0).getTelecomFirstRep(); // telecom is type ContactPoint
         assertThat(contactPoint.getSystemElement().getCode()).hasToString("phone"); // default type hardcoded.
-        assertThat(contactPoint.getUseElement().getCode()).hasToString("work"); // IN1.7.2
+        assertThat(contactPoint.hasUseElement()).isFalse(); // IN1.7.2 is not mapped 
         assertThat(contactPoint.getValue()).hasToString("(800) 333 4444"); // IN1.7.6, IN1.7.7 via getFormattedTelecomNumberValue
 
         List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

We don't want to map IN1.7.2 to Organization.Contact.telecom.use.  Previously hard-coded to `work`, this seemed redundant.

We're creating a FHIR ContactPoint.  `use` is optional, BUT if it is present it MUST be from this value set: `home | work | temp | old | mobile`   Explained, here: 
https://build.fhir.org/valueset-contact-point-use.html

IN1.7.2 has these values:  (It’s an XTN and comes from table 201)
https://hl7-definition.caristix.com/v2/HL7v2.6/Tables/0201

Because we _must_ map to `home | work | temp | old | mobile`, there isn't a really good mapping:
```
ASN. null
BPN. null (or mobile)
EMR. null (is it mobile or work or home?)
NET. null (not a phone)
ORN. HOME
PRN. HOME
PRS. HOME ??
VHN. HOME ??
WPN. WORK
```
At this point, it seems better just to leave it empty and unmapped.

This defect also adds a test for a situation fixed in https://github.com/LinuxForHealth/hl7v2-fhir-converter/pull/405.

The issue was that some phone numbers were not getting processed to telecom.  This test is added to ensure the problem doesn't return.
