### PR TITLE
Fix SubscriberRelationship mapping direction

### DIFF
--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -416,27 +416,31 @@ V3RoleCode:
 # WRD: no good match for Ward of the court  
 
 # HL7 Table 0063 > HAPI SubscriberRelationship code 
+# This is the reverse of the relationship from V3RoleCode
+# IN1.17 is "Insured's Relationship To Patient", but Coverage.relationship is "Beneficiary relationship to the subscriber".
+# To understand the table think: If the patient is a XXXX, the the insurance subscriber is their XXXX
+# As an example, CHD does not map to child, but parent.
 # OTHER is mapped for any connection that is blood or legal (e.g. grandparent, guardian)
 # Nothing is mapped for non-legally binding connections (e.g. friend, manager)
 SubscriberRelationship:
   BRO: other
   CGV: other  # Caregiver
-  CHD: child
+  CHD: parent
   DEP: other  # Handicapped dependent
   DOM: common  # Life partner ~ common law spouse
   EXF: other   # Extended family
-  FCH: child 
+  FCH: parent 
 # FND: no good match for Friend
-  FTH: parent # Father
+  FTH: child # Father of a child
   GCH: other
   GRD: other # Guardian
   GRP: other
-  MTH: parent
-  NCH: child # Natural child 
+  MTH: child
+  NCH: parent # Natural child of a parent
 # NON: no good match for None
   OTH: other     
-  PAR: parent
-  SCH: child # Step-child
+  PAR: child
+  SCH: parent # Step-child of a parent
   SEL: self
   SIB: other
   SIS: other

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -374,9 +374,9 @@ class SimpleDataValueResolverTest {
         // Check supported known input code
         SimpleCode coding = SimpleDataValueResolver.SUBSCRIBER_RELATIONSHIP.apply("CHD");
         assertThat(coding).isNotNull();
-        assertThat(coding.getCode()).isEqualTo("child");
+        assertThat(coding.getCode()).isEqualTo("parent");
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/subscriber-relationship");
-        assertThat(coding.getDisplay()).isEqualTo("Child");
+        assertThat(coding.getDisplay()).isEqualTo("Parent");
 
         // Check unsupported unknown input code
         // Because GOAT has no mapping, we pass it without a system.

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -357,8 +357,8 @@ class Hl7FinancialInsuranceTest {
         assertThat(related.getAddress().get(0).getPostalCode()).isEqualTo("ZIP5"); // IN1.19.5
 
         // Check coverage relationship
-        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getRelationship(), "parent",
-                "Parent",
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getRelationship(), "child",
+                "Child",
                 "http://terminology.hl7.org/CodeSystem/subscriber-relationship", null); // IN1.17
 
         // Check relatedPerson relationship


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

We had the direction of relationship incorrect.  This is now correctly set.