### PR TITLE
#411 Support for IN2, Relate SSN & telecom

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The converter supports the following message segments:
 * DG1 - Diagnosis
 * EVN - Event Type
 * IN1 - Insurance
+* IN2 - Insurance Additional Information
 * MRG - Merge Patient Information
 * MSH - Message Header
 * NTE - Notes and Comments

--- a/src/main/resources/hl7/message/ADT_A01.yml
+++ b/src/main/resources/hl7/message/ADT_A01.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -79,3 +79,4 @@ resources:
         - MSH
         - PID
         - PV1
+        - .IN2

--- a/src/main/resources/hl7/message/ADT_A03.yml
+++ b/src/main/resources/hl7/message/ADT_A03.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -80,3 +80,4 @@ resources:
         - MSH
         - PID
         - PV1
+        - .IN2

--- a/src/main/resources/hl7/message/ADT_A04.yml
+++ b/src/main/resources/hl7/message/ADT_A04.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -80,3 +80,4 @@ resources:
       - MSH
       - PID
       - PV1
+      - .IN2

--- a/src/main/resources/hl7/message/ADT_A28.yml
+++ b/src/main/resources/hl7/message/ADT_A28.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -79,3 +79,4 @@ resources:
         - MSH
         - PID
         - PV1
+        - .IN2        

--- a/src/main/resources/hl7/message/ADT_A31.yml
+++ b/src/main/resources/hl7/message/ADT_A31.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -79,3 +79,5 @@ resources:
         - MSH
         - PID
         - PV1
+        - .IN2        
+

--- a/src/main/resources/hl7/message/DFT_P03.yml
+++ b/src/main/resources/hl7/message/DFT_P03.yml
@@ -45,6 +45,7 @@ resources:
     additionalSegments:
       - MSH
       - PID
+      - .IN2
 
   - resourceName: ServiceRequest
     segment: .ORC

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -17,7 +17,7 @@ id:
    valueOf: UUID.randomUUID()
    expressionType: JEXL
 
-identifier:
+identifier_1:
    condition: $valueIn NOT_NULL
    valueOf: datatype/Identifier_var
    generateList: true
@@ -32,6 +32,19 @@ identifier:
       # Because IN1.49.5 is an ID code, this will create a correct coding
       # because it knows the table from position and looks up the display
       coding: CODING_SYSTEM_V2_IDENTIFIER, IN1.49.5
+
+# Gets the SSN from IN2.2, formats and adds it as an ID
+identifier_2:
+   condition: $valueIn NOT_NULL
+   valueOf: datatype/Identifier_var
+   generateList: true
+   expressionType: resource
+   vars:
+      valueIn: String, IN2.2
+   constants:
+      system: http://terminology.hl7.org/CodeSystem/v2-0203
+      code: SS
+      display: Social Security number    
 
 patient: 
    valueOf: datatype/Reference
@@ -70,4 +83,10 @@ address:
    expressionType: resource
    specs: IN1.19 
 
-
+telecom:
+   valueOf: datatype/ContactPoint
+   generateList: true
+   expressionType: resource
+   specs: IN2.63
+   constants:
+     use: home


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Add additional fields for Coverage / RelatedPerson from IN2 record.

IN2.2 (SSN) to RelatedPerson.identifier
IN2.63 to RelatedPerson.telecom

Add associated tests.