### PR TITLE
OML_O21 support updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The converter supports the following message segments:
 * SPM - Specimen
 * TXA - Transcription Document Header
 
-The converter _partially_ supports the following message types/events (To utilize the partial support, add the message to src/main/resources/config.properties):
+The converter _partially_ supports the following message types/events:
 * OML_O21 - Laboratory Order
     * Repeating ORDER groups are not supported
     * ServiceRequest resources are only created when both ORC and OBR are provided

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The converter supports the following message segments:
 * SPM - Specimen
 * TXA - Transcription Document Header
 
+The converter _partially_ supports the following message types/events (To utilize the partial support, add the message to src/main/resources/config.properties):
+* OML_O21 - Laboratory Order
+    * Repeating ORDER groups are not supported
+    * ServiceRequest resources are only created when both ORC and OBR are provided
+    * PID must be provided to avoid FHIR validation errors
+
 If you need another message type/event . . .  contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md)!
 
 ## Additional Documentation

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The converter _partially_ supports the following message types/events:
     * Repeating ORDER groups are not supported
     * ServiceRequest resources are only created when both ORC and OBR are provided
     * PID must be provided to avoid FHIR validation errors
+    * OBX and Observations are not yet supported
 
 If you need another message type/event . . .  contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md)!
 

--- a/src/main/resources/hl7/message/OML_O21.yml
+++ b/src/main/resources/hl7/message/OML_O21.yml
@@ -80,7 +80,6 @@ resources:
           - .OBR
           - MSH
 
-# TODO: AL1 allergy support to be added
 # TODO: IN1 insurance support to be added
 # TODO: Add support to create a ServiceRequest from ORC when there is no OBR
 #    Note that OML_O21 messages are different than ORU_R01 messages:

--- a/src/main/resources/hl7/message/OML_O21.yml
+++ b/src/main/resources/hl7/message/OML_O21.yml
@@ -43,6 +43,22 @@ resources:
           - .OBR
           - MSH
 
+    - resourceName: AllergyIntolerance
+      segment: .AL1
+      resourcePath: resource/AllergyIntolerance
+      group: PATIENT
+      repeats: true
+      additionalSegments:
+          - MSH
+
+    - resourceName: AllergyIntolerance
+      segment: .PRIOR_RESULT.AL1
+      resourcePath: resource/AllergyIntolerance
+      group: ORDER.OBSERVATION_REQUEST
+      repeats: true
+      additionalSegments:
+          - MSH
+
     - resourceName: Condition
       segment: .DG1
       group: ORDER.OBSERVATION_REQUEST
@@ -53,6 +69,7 @@ resources:
           - .OBR
           - MSH
 
+# Note: According to the HL7 spec, DG1 is not allowed at this level.  However, including this here given it was a user contribution to include this Condition.
     - resourceName: Condition
       segment: .DG1
       group: ORDER.OBSERVATION_REQUEST.PRIOR_RESULT.ORDER_PRIOR
@@ -63,6 +80,13 @@ resources:
           - .OBR
           - MSH
 
+# TODO: AL1 allergy support to be added
+# TODO: IN1 insurance support to be added
+# TODO: Add support to create a ServiceRequest from ORC when there is no OBR
+#    Note that OML_O21 messages are different than ORU_R01 messages:
+#    For ORU_R01: DiagnosticReport is required.  ServiceRequest is optional.
+#    For OML_O21, this should be updated such that: DiagnosticReport is OPTIONAL.  ServiceRequest is REQUIRED.
+
     - resourceName: DiagnosticReport
       segment: .OBSERVATION_REQUEST.OBR
       group: ORDER
@@ -70,9 +94,6 @@ resources:
       repeats: true
       additionalSegments:
           - .ORC
-          - .NTE
-          - .SPECIMEN.SPM
-          - .DG1
           - MSH
 
     - resourceName: DiagnosticReport
@@ -82,7 +103,4 @@ resources:
       repeats: true
       additionalSegments:
           - .ORC
-          - .NTE
-          - .SPECIMEN.SPM
-          - .DG1
-          - MSH 
+          - MSH

--- a/src/main/resources/hl7/message/OML_O21.yml
+++ b/src/main/resources/hl7/message/OML_O21.yml
@@ -34,13 +34,12 @@ resources:
           - MSH
 
     - resourceName: Specimen
-      segment: .SPECIMEN.SPM
-      group: ORDER.OBSERVATION_REQUEST
+      segment: OBSERVATION_REQUEST.SPECIMEN.SPM
+      group: ORDER
       resourcePath: resource/Specimen
       repeats: true
       isReferenced: true
       additionalSegments:
-          - .OBR
           - MSH
 
     - resourceName: AllergyIntolerance
@@ -93,7 +92,11 @@ resources:
       repeats: true
       additionalSegments:
           - .ORC
+          - .OBSERVATION_REQUEST.NTE
           - MSH
+          - PATIENT.PID
+          - PATIENT.PATIENT_VISIT.PV1
+          # NOTE:  PID and PV1 are passed because they are used by the created Service Request
 
     - resourceName: DiagnosticReport
       segment: .OBR
@@ -102,4 +105,5 @@ resources:
       repeats: true
       additionalSegments:
           - .ORC
+          - .NTE
           - MSH

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7OMLMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7OMLMessageTest.java
@@ -175,12 +175,12 @@ public class HL7OMLMessageTest {
         List<Resource> diagnosticresource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticresource).hasSize(1); //from OBR
 
-        // TODO: Need to figure out why the reference is no longer there after merging the fork into master
-        // DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticresource.get(0), context);
-        // List<Reference> spmRef = diag.getSpecimen();
-        // assertThat(spmRef.isEmpty()).isFalse();
-        // assertThat(spmRef).hasSize(1); //from SPM
-        // assertThat(spmRef.get(0).isEmpty()).isFalse();
+        // Verify the specimen reference
+        DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticresource.get(0), context);
+        List<Reference> spmRef = diag.getSpecimen();
+        assertThat(spmRef.isEmpty()).isFalse();
+        assertThat(spmRef).hasSize(1); //from SPM
+        assertThat(spmRef.get(0).isEmpty()).isFalse();
 
         // Confirm that there are no extra resources
         assertThat(e.size()).isEqualTo(4);

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7OMLMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7OMLMessageTest.java
@@ -20,8 +20,6 @@ import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import io.github.linuxforhealth.fhir.FHIRContext;
 import io.github.linuxforhealth.hl7.ConverterOptions;
 import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
@@ -30,7 +28,6 @@ import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 public class HL7OMLMessageTest {
     private static FHIRContext context = new FHIRContext();
-    private static final Logger LOGGER = LoggerFactory.getLogger(HL7OMLMessageTest.class);
     private static final ConverterOptions OPTIONS_PRETTYPRINT = new Builder()
             .withBundleType(BundleType.COLLECTION)
             .withValidateResource()
@@ -48,30 +45,21 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); //from PID
 
-        List<Resource> serviceResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceResource).hasSize(1); //from ORC
 
-        List<Resource> diagnosticresource = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticresource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticresource).hasSize(1); //from OBR
 
-        List<Resource> conditionresource = e.stream()
-                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> conditionresource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionresource).hasSize(1); //from DG1
 
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticresource.get(0), context);
@@ -96,20 +84,15 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); //from PID
 
-        List<Resource> encounterResource = e.stream()
-                .filter(v -> ResourceType.Encounter == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounterResource).hasSize(1); //from PV1
 
         // TODO: When function is added to create ServiceRequest from ORC then also check for ServiceRequest
@@ -137,31 +120,22 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); //from PID
 
-        List<Resource> diagnosisResource = e.stream()
-                .filter(v -> ResourceType.Condition == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosisResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(diagnosisResource).hasSize(2); //from DG1
 
-        List<Resource> serviceResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceResource).hasSize(2); //from ORC
 
-        List<Resource> diagnosticresource = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticresource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticresource).hasSize(2); //from OBR
 
         DiagnosticReport diag = ResourceUtils.getResourceDiagnosticReport(diagnosticresource.get(0), context);
@@ -184,30 +158,21 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); //from PID
 
-        List<Resource> specimenResource = e.stream()
-                .filter(v -> ResourceType.Specimen == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> specimenResource = ResourceUtils.getResourceList(e, ResourceType.Specimen);
         assertThat(specimenResource).hasSize(1); //from SPM
 
-        List<Resource> serviceResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceResource).hasSize(1); //from ORC
 
-        List<Resource> diagnosticresource = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticresource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticresource).hasSize(1); //from OBR
 
         // TODO: Need to figure out why the reference is no longer there after merging the fork into master
@@ -234,30 +199,21 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); //from PID
 
-        List<Resource> allergyResource = e.stream()
-                .filter(v -> ResourceType.AllergyIntolerance == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> allergyResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
         assertThat(allergyResource).hasSize(3); //from AL1
 
-        List<Resource> serviceResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceResource).hasSize(1); //from ORC
 
-        List<Resource> diagnosticresource = e.stream()
-                .filter(v -> ResourceType.DiagnosticReport == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> diagnosticresource = ResourceUtils.getResourceList(e, ResourceType.DiagnosticReport);
         assertThat(diagnosticresource).hasSize(1); //from OBR
 
         // Confirm that there are no extra resources
@@ -275,21 +231,16 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); // from PID
 
-        List<Resource> serviceResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceResource).hasSize(1); //from ORC
 
         // Confirm that there are no extra resources
@@ -309,21 +260,16 @@ public class HL7OMLMessageTest {
         HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
         String json = ftv.convert(hl7message, OPTIONS_PRETTYPRINT);
         assertThat(json).isNotBlank();
-        LOGGER.info("FHIR json result:\n" + json);
         IBaseResource bundleResource = context.getParser().parseResource(json);
         assertThat(bundleResource).isNotNull();
         Bundle b = (Bundle) bundleResource;
         assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
         List<BundleEntryComponent> e = b.getEntry();
 
-        List<Resource> patientResource = e.stream()
-                .filter(v -> ResourceType.Patient == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); //from PID
 
-        List<Resource> serviceResource = e.stream()
-                .filter(v -> ResourceType.ServiceRequest == v.getResource().getResourceType())
-                .map(BundleEntryComponent::getResource).collect(Collectors.toList());
+        List<Resource> serviceResource = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         assertThat(serviceResource).hasSize(2); //from ORC
 
         // Confirm that there are no extra resources

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ORUMessageTest.java
@@ -455,7 +455,7 @@ class Hl7ORUMessageTest {
         List<Resource> practitionerResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
         assertThat(practitionerResource).hasSize(1);
 
-        List<Resource> specimenResource = ResourceUtils.getResourceList(e, ResourceType.Practitioner);
+        List<Resource> specimenResource = ResourceUtils.getResourceList(e, ResourceType.Specimen);
         assertThat(specimenResource).hasSize(1);
 
         // Expecting only the above resources, no extras! 


### PR DESCRIPTION
Signed-off-by: Lisa Dierkhising <lisadier@us.ibm.com>

Updates made:
	•	Removed unused segments NTE, SPM, and DG1 from both DiagnosticReport resources in OML_O21.yml
	•	Added AL1 support
	•	Added necessary unit tests to boost coverage of critical scenarios
	•	Simplified the message content in the tests to focus on the message-level resource testing
	•	Added asserts to ensure that no ‘extra’ resources are created
	•	Updated asserts to check for all expected resources
	•	Discovered that ServiceRequests are not created for ORC segments unless an OBR is provided.
	•	Discovered that only one ORDER group is supported per message.  The HL7 message definition allows the ORDER group to be repeatable but the converter (and parser) do not support multiple ORDER groups.
	•	Discovered that PID must be provided in OML_O21 messages to avoid FHIR validation errors, even though the HL7 message definition doesn’t require PID.  The patient (from PID) is required for ServiceRequest and Condition FHIR resources to be valid.
	•	Discovered that OBX support was not contributed and is not included.
	•	Updated documentation to indicate partial support for OML_O21, with notes about above limitations
