### PR TITLE
Issue411 IN2.72 backup IN1.17;  tables 0063 & 0344

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -346,12 +346,11 @@ public class SimpleDataValueResolver {
         return getFHIRCode(Hl7DataHandlerUtil.getStringValue(value), "EncounterModeOfArrivalDisplay");
     };
 
-    // Relationships are coded, mapped, and recoded in two different DIRECTIONS:  
-    //  - Insured to Patient.  Example Insured is parent of child patient. SUBSCRIBER_RELATIONSHIP maps IN1.17 to RelatedPerson.relationship.
-    //  - Patient to Insured.  Example: Patient is child of insured parent. POLICYHOLDER_RELATIONSHIP maps IN2.72 to Coverage.relationship.
-    // See detailed notes in v2ToFhirMapping maps V3RoleCode and SubscriberRelationship
+    // Relationships are coded, mapped, and recoded in two different DIRECTIONS.  
+    // See detailed notes in v2ToFhirMapping maps of V3RoleCode and SubscriberRelationship
 
-    // Maps to values in http://terminology.hl7.org/CodeSystem/v3-RoleCode; Insured is Y of patient; e.g. Parent
+    // Maps from IN1.17 and IN2.72 to http://terminology.hl7.org/CodeSystem/v3-RoleCode
+    // Used for Coverage.relationship
     public static final ValueExtractor<Object, SimpleCode> POLICYHOLDER_RELATIONSHIP = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, V3RoleCode.class);
@@ -365,7 +364,8 @@ public class SimpleDataValueResolver {
         }
     };
 
-    // Maps to values in http://terminology.hl7.org/CodeSystem/subscriber-relationship; Patient is X of insured, e.g. Child
+    // Maps from IN1.17 and IN2.72 to http://terminology.hl7.org/CodeSystem/subscriber-relationship
+    // Used for RelatedPerson.relationship.
     public static final ValueExtractor<Object, SimpleCode> SUBSCRIBER_RELATIONSHIP = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, SubscriberRelationship.class);

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -346,7 +346,12 @@ public class SimpleDataValueResolver {
         return getFHIRCode(Hl7DataHandlerUtil.getStringValue(value), "EncounterModeOfArrivalDisplay");
     };
 
-    // Maps 0063 to values in http://terminology.hl7.org/CodeSystem/v3-RoleCode
+    // Relationships are coded, mapped, and recoded in two different DIRECTIONS:  
+    //  - Insured to Patient.  Example Insured is parent of child patient. SUBSCRIBER_RELATIONSHIP maps IN1.17 to RelatedPerson.relationship.
+    //  - Patient to Insured.  Example: Patient is child of insured parent. POLICYHOLDER_RELATIONSHIP maps IN2.72 to Coverage.relationship.
+    // See detailed notes in v2ToFhirMapping maps V3RoleCode and SubscriberRelationship
+
+    // Maps to values in http://terminology.hl7.org/CodeSystem/v3-RoleCode; Insured is Y of patient; e.g. Parent
     public static final ValueExtractor<Object, SimpleCode> POLICYHOLDER_RELATIONSHIP = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, V3RoleCode.class);
@@ -360,7 +365,7 @@ public class SimpleDataValueResolver {
         }
     };
 
-    // Maps 0063 to values in http://terminology.hl7.org/CodeSystem/subscriber-relationship
+    // Maps to values in http://terminology.hl7.org/CodeSystem/subscriber-relationship; Patient is X of insured, e.g. Child
     public static final ValueExtractor<Object, SimpleCode> SUBSCRIBER_RELATIONSHIP = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String code = getFHIRCode(val, SubscriberRelationship.class);

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -470,7 +470,7 @@ SubscriberRelationship:
   19: other # Grandparent 
 # - - - - -  
 # Codes from IN1.17 (values from table 0063) must be REVERSED for Coverage.relationship
-# Think: If the patient is a XXXX, the the insured (subscriber) is their YYYY
+# Think: If the patient is a XXXX, then the insured (subscriber) is their YYYY
   BRO: other
   CGV: other  # Caregiver
   CHD: parent

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -389,113 +389,109 @@ MedicationRequestCategory:
   O: outpatient
 
 ###### IMPORTANT NOTES ON RELATIONSHIP MAPPINGS #########
-# Relationships in tables V3RoleCode and SubscriberRelationship are tricky
-# Relationships in HL7 and FHIR are coded, mapped, and recoded in two different DIRECTIONS:  
-#   1.  Insured [subscriber/policyholder] is X (e.g. parent) of patient.  X is inverse Y.
-#   2.  Patient is Y (e.g. child) of insured [subscriber/policyholder]; 
-# IN1.17 is Insureds relationship to Patient (TYPE 1).  Uses HL7 V2.6 table 0063
-# IN2.72 is Patients relationship to Insured (TYPE 2).  Uses HL7 V2.6 table 0344
-# FHIR RelatedPerson.relationship is Related to Patient. (TYPE 1.) POLICYHOLDER_RELATIONSHIP  Needs coding from V3RoleCode.
-# FHIR Coverage.relationship is Beneficiary (Patient) to Insured (Subscriber) (TYPE 2.) SUBSCRIBER_RELATIONSHIP  Needs coding from SubscriberRelationship. 
+# Relationship mappings in tables V3RoleCode and SubscriberRelationship are coded in two different DIRECTIONS:  
+#  - Insured to Patient.  Example Insured is parent of child patient. Used by IN1.17 and RelatedPerson.relationship.
+#  - Patient to Insured.  Example: Patient is child of insured parent. Used by IN2.72 and Coverage.relationship.
+# Insured is also referred to as Subscriber and Policyholder.  
+# Patient is also referred to as Beneficiary.
 
-# Mapping to V3 Role code (used for POLICYHOLDER_RELATIONSHIP)
+# Mapping to RelatedPerson.relationship via POLICYHOLDER_RELATIONSHIP data resolver.
+# Direction: Insured to Patient
 V3RoleCode:
-# Input codes from IN2.72 (TYPE 2) values from table 0344, need to be REVERSED for TYPE1 POLICYHOLDER_RELATIONSHIP code from V3RoleCode.
-  01: ONESELF # Patient is insured input
-  02: SPS  # Spouse input
-  03: PRN  # Natural child financial responsibility input from Type 2, is Parent in Type 1.
-  04: PRN  # Natural child no financial responsibility input from Type 2, is Parent in Type 1.
-  05: PRN  # Step child input from Type 2, is Parent in Type 1.
-  06: PRN  # Foster child input from Type 2, is Parent in Type 1.
-# 07: no good match for Ward of the court
-# 08: no good match for Employee
-  09: U # 'Unknown' as input
-  10: O # Handicapped dependent input, Other output
-# 11: no good match for Organ donor
-# 12: no good match for Cadaver donor
-  13: GRPRN # Grandchild input from Type 2, is Grandparent Type 1 
-  14: O # Niece/Nephew input, Other output
-# 15: no good match for Injured planitiff
-# 16: no good match for Sponsored dependent
-  17: GRPRN # Minor dependent of a minor dependant input (grandchild dependent) from TYPE 2 is Grandparent Type 1 
-  18: CHILD # Parent input from TYPE 2, is Child in Type 1
-  19: GRNDCHILD # Grandparent input from TYPE 2, is Grandchild in Type 1
-# Input codes from IN1.17 (TYPE 1) values from table 0063 are standard match for TYPE 1 POLICYHOLDER_RELATIONSHIP code from V3RoleCode.  
+# Codes from IN1.17 (values from table 0063) 
   BRO: BRO
-# CGV: no good match for Care giver
+# CGV: Care giver: no good match
   CHD: CHILD
-# DEP: no good match for Handicapped dependent
+# DEP: Handicapped dependent : no good match
   DOM: DOMPART
   EXF: EXT  
   FCH: CHLDFOST 
   FND: FRND
   FTH: FTH 
   GCH: GRNDCHILD
-# GRD: no good match for Guardian
-  GRP: GRPRN
+# GRD: Guardian : no good match
+  GRP: GRP
   MTH: MTH
   NCH: NCHILD 
-# NON: no good match for None
-  OTH: O     
+# NON: None: no good match
+# OTH: Other: no good match
   PAR: PRN
   SCH: STPCHLD
   SEL: ONESELF
   SIB: SIB
   SIS: SIS
   SPO: SPS
-  UNK: U
-# WRD: no good match for Ward of the court  
-
-# SubscriberRelationship codes
-# This is the reverse of the relationships from V3RoleCode.  See IMPORTANT NOTES ON RELATIONSHIP MAPPINGS above.
-# OTHER is mapped for any connection that is blood or legal (e.g. grandparent, guardian)
-# Nothing is mapped for non-legally binding connections (e.g. friend, manager)
+# UNK: Unknown : no good match
+# WRD: Ward of the court : no good match 
+# - - - - -  
+# Codes from IN2.72 (values from table 0344) must be REVERSED for RelatedPerson.relationship.
+  01: ONESELF # Patient is insured : Self
+  02: SPS  # Spouse : Spouse
+  03: PRN  # Natural child financial responsibility : Parent
+  04: PRN  # Natural child no financial responsibility : Parent
+  05: PRN  # Step child : Parent
+  06: PRNFOST  # Foster child : Foster Parent
+# 07: Ward of the court: no good match
+# 08: Employee: no good match
+# 09: Unknown: no good match 
+# 10: Handicapped dependent input: no good match 
+# 11: Organ donor : no good match
+# 12: Cadaver donor : no good match
+  13: GRPRN # Grandchild : Grandparent 
+  14: EXT # Niece/Nephew :  Extended
+# 15: Injured planitiff : no good match
+# 16: Sponsored dependent : no good match
+  17: GRPRN # Minor dependent of a minor dependant input (grandchild dependent) : Grandparent
+  18: CHILD # Parent : Child 
+  19: GRNDCHILD # Grandparent : Grandchild 
+ 
+# Mapping to Coverage.relationship via SUBSCRIBER_RELATIONSHIP data resolver.
+# Direction: Patient to Insured
 SubscriberRelationship:
-# Input codes from IN2.72 (TYPE 2) values from table 0344, are standard match for TYPE 2 SUBSCRIBER_RELATIONSHIP codes from SubscriberRelationship.
-  01: self # Patient is insured input
-  02: spouse  # Spouse input
-  03: child  # Natural child financial responsibility input 
-  04: child  # Natural child no financial responsibility input 
-  05: child  # Step child input 
-  06: child  # Foster child input
-# 07: no good match for Ward of the court
-# 08: no good match for Employee
-# 09: no good match for 'Unknown' as input
-  10: other # Handicapped dependent input, Other output
-# 11: no good match for Organ donor
-# 12: no good match for Cadaver donor
-  13: other # Grandchild input 
-  14: other # Niece/Nephew input, Other output
-# 15: no good match for Injured planitiff
-# 16: no good match for Sponsored dependent
+# Codes from IN2.72 (values from table 0344)
+  01: self # Patient is insured 
+  02: spouse  # Spouse 
+  03: child  # Natural child financial responsibility
+  04: child  # Natural child no financial responsibility
+  05: child  # Step child 
+  06: child  # Foster child 
+# 07: Ward of the court: no good match
+# 08: Employee: no good match
+# 09: Unknown: no good match 
+  10: other # Handicapped dependent 
+# 11: Organ donor : no good match
+# 12: Cadaver donor : no good match
+  13: other # Grandchild 
+  14: other # Niece/Nephew 
+# 15: Injured planitiff : no good match
+# 16: Sponsored dependent : no good match
   17: other # Minor dependent of a minor dependant input (grandchild dependent)
-  18: parent # Parent input
-  19: other # Grandparent input 
-# Input codes from IN1.17 (TYPE1) table 0063 are REVERSED for TYPE2 SUBSCRIBER_RELATIONSHIP codes from SubscriberRelationship
-# IN1.17 is "Insured's Relationship To Patient", but Coverage.relationship is "Beneficiary relationship to the subscriber".
-# To understand the table think: If the patient is a XXXX, the the insurance subscriber is their XXXX
-# As an example, CHD does not map to child, but parent.
+  18: parent # Parent 
+  19: other # Grandparent 
+# - - - - -  
+# Codes from IN1.17 (values from table 0063) must be REVERSED for Coverage.relationship
+# Think: If the patient is a XXXX, the the insured (subscriber) is their YYYY
   BRO: other
   CGV: other  # Caregiver
   CHD: parent
   DEP: other  # Handicapped dependent
-  DOM: common  # Life partner ~ common law spouse
+  DOM: common  # Life partner or common law spouse
   EXF: other   # Extended family
   FCH: parent 
-# FND: no good match for Friend
-  FTH: child # Father of a child
+# FND: Friend: no good match
+  FTH: child # Father
   GCH: other
   GRD: other # Guardian
   GRP: other
   MTH: child
-  NCH: parent # Natural child of a parent
-# NON: no good match for None
+  NCH: parent # Natural child 
+# NON: None: no good match
   OTH: other     
   PAR: child
-  SCH: parent # Step-child of a parent
+  SCH: parent # Step-child
   SEL: self
   SIB: other
   SIS: other
   SPO: spouse
-# UNK: no good match for Unknown
-# WRD: no good match for Ward of the court  
+# UNK: Unknown : no good match
+# WRD: Ward of the court : no good match

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -388,8 +388,39 @@ MedicationRequestCategory:
   I: inpatient
   O: outpatient
 
-# HL7 Table 0063 > V3 Role code (used for POLICYHOLDER_RELATIONSHIP)
+###### IMPORTANT NOTES ON RELATIONSHIP MAPPINGS #########
+# Relationships in tables V3RoleCode and SubscriberRelationship are tricky
+# Relationships in HL7 and FHIR are coded, mapped, and recoded in two different DIRECTIONS:  
+#   1.  Insured [subscriber/policyholder] is X (e.g. parent) of patient.  X is inverse Y.
+#   2.  Patient is Y (e.g. child) of insured [subscriber/policyholder]; 
+# IN1.17 is Insureds relationship to Patient (TYPE 1).  Uses HL7 V2.6 table 0063
+# IN2.72 is Patients relationship to Insured (TYPE 2).  Uses HL7 V2.6 table 0344
+# FHIR RelatedPerson.relationship is Related to Patient. (TYPE 1.) POLICYHOLDER_RELATIONSHIP  Needs coding from V3RoleCode.
+# FHIR Coverage.relationship is Beneficiary (Patient) to Insured (Subscriber) (TYPE 2.) SUBSCRIBER_RELATIONSHIP  Needs coding from SubscriberRelationship. 
+
+# Mapping to V3 Role code (used for POLICYHOLDER_RELATIONSHIP)
 V3RoleCode:
+# Input codes from IN2.72 (TYPE 2) values from table 0344, need to be REVERSED for TYPE1 POLICYHOLDER_RELATIONSHIP code from V3RoleCode.
+  01: ONESELF # Patient is insured input
+  02: SPS  # Spouse input
+  03: PRN  # Natural child financial responsibility input from Type 2, is Parent in Type 1.
+  04: PRN  # Natural child no financial responsibility input from Type 2, is Parent in Type 1.
+  05: PRN  # Step child input from Type 2, is Parent in Type 1.
+  06: PRN  # Foster child input from Type 2, is Parent in Type 1.
+# 07: no good match for Ward of the court
+# 08: no good match for Employee
+  09: U # 'Unknown' as input
+  10: O # Handicapped dependent input, Other output
+# 11: no good match for Organ donor
+# 12: no good match for Cadaver donor
+  13: GRPRN # Grandchild input from Type 2, is Grandparent Type 1 
+  14: O # Niece/Nephew input, Other output
+# 15: no good match for Injured planitiff
+# 16: no good match for Sponsored dependent
+  17: GRPRN # Minor dependent of a minor dependant input (grandchild dependent) from TYPE 2 is Grandparent Type 1 
+  18: CHILD # Parent input from TYPE 2, is Child in Type 1
+  19: GRNDCHILD # Grandparent input from TYPE 2, is Grandchild in Type 1
+# Input codes from IN1.17 (TYPE 1) values from table 0063 are standard match for TYPE 1 POLICYHOLDER_RELATIONSHIP code from V3RoleCode.  
   BRO: BRO
 # CGV: no good match for Care giver
   CHD: CHILD
@@ -415,14 +446,35 @@ V3RoleCode:
   UNK: U
 # WRD: no good match for Ward of the court  
 
-# HL7 Table 0063 > HAPI SubscriberRelationship code 
-# This is the reverse of the relationship from V3RoleCode
-# IN1.17 is "Insured's Relationship To Patient", but Coverage.relationship is "Beneficiary relationship to the subscriber".
-# To understand the table think: If the patient is a XXXX, the the insurance subscriber is their XXXX
-# As an example, CHD does not map to child, but parent.
+# SubscriberRelationship codes
+# This is the reverse of the relationships from V3RoleCode.  See IMPORTANT NOTES ON RELATIONSHIP MAPPINGS above.
 # OTHER is mapped for any connection that is blood or legal (e.g. grandparent, guardian)
 # Nothing is mapped for non-legally binding connections (e.g. friend, manager)
 SubscriberRelationship:
+# Input codes from IN2.72 (TYPE 2) values from table 0344, are standard match for TYPE 2 SUBSCRIBER_RELATIONSHIP codes from SubscriberRelationship.
+  01: self # Patient is insured input
+  02: spouse  # Spouse input
+  03: child  # Natural child financial responsibility input 
+  04: child  # Natural child no financial responsibility input 
+  05: child  # Step child input 
+  06: child  # Foster child input
+# 07: no good match for Ward of the court
+# 08: no good match for Employee
+# 09: no good match for 'Unknown' as input
+  10: other # Handicapped dependent input, Other output
+# 11: no good match for Organ donor
+# 12: no good match for Cadaver donor
+  13: other # Grandchild input 
+  14: other # Niece/Nephew input, Other output
+# 15: no good match for Injured planitiff
+# 16: no good match for Sponsored dependent
+  17: other # Minor dependent of a minor dependant input (grandchild dependent)
+  18: parent # Parent input
+  19: other # Grandparent input 
+# Input codes from IN1.17 (TYPE1) table 0063 are REVERSED for TYPE2 SUBSCRIBER_RELATIONSHIP codes from SubscriberRelationship
+# IN1.17 is "Insured's Relationship To Patient", but Coverage.relationship is "Beneficiary relationship to the subscriber".
+# To understand the table think: If the patient is a XXXX, the the insurance subscriber is their XXXX
+# As an example, CHD does not map to child, but parent.
   BRO: other
   CGV: other  # Caregiver
   CHD: parent

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -390,7 +390,7 @@ MedicationRequestCategory:
 
 ###### IMPORTANT NOTES ON RELATIONSHIP MAPPINGS #########
 # Relationship mappings in tables V3RoleCode and SubscriberRelationship are coded in two different DIRECTIONS:  
-#  - Insured to Patient.  Example Insured is parent of child patient. Used by IN1.17 and RelatedPerson.relationship.
+#  - Insured to Patient.  Example: Insured is parent of child patient. Used by IN1.17 and RelatedPerson.relationship.
 #  - Patient to Insured.  Example: Patient is child of insured parent. Used by IN2.72 and Coverage.relationship.
 # Insured is also referred to as Subscriber and Policyholder.  
 # Patient is also referred to as Beneficiary.
@@ -448,27 +448,6 @@ V3RoleCode:
 # Mapping to Coverage.relationship via SUBSCRIBER_RELATIONSHIP data resolver.
 # Direction: Patient to Insured
 SubscriberRelationship:
-# Codes from IN2.72 (values from table 0344)
-  01: self # Patient is insured 
-  02: spouse  # Spouse 
-  03: child  # Natural child financial responsibility
-  04: child  # Natural child no financial responsibility
-  05: child  # Step child 
-  06: child  # Foster child 
-# 07: Ward of the court: no good match
-# 08: Employee: no good match
-# 09: Unknown: no good match 
-  10: other # Handicapped dependent 
-# 11: Organ donor : no good match
-# 12: Cadaver donor : no good match
-  13: other # Grandchild 
-  14: other # Niece/Nephew 
-# 15: Injured planitiff : no good match
-# 16: Sponsored dependent : no good match
-  17: other # Minor dependent of a minor dependant input (grandchild dependent)
-  18: parent # Parent 
-  19: other # Grandparent 
-# - - - - -  
 # Codes from IN1.17 (values from table 0063) must be REVERSED for Coverage.relationship
 # Think: If the patient is a XXXX, then the insured (subscriber) is their YYYY
   BRO: other
@@ -495,3 +474,26 @@ SubscriberRelationship:
   SPO: spouse
 # UNK: Unknown : no good match
 # WRD: Ward of the court : no good match
+# - - - - -  
+# Codes from IN2.72 (values from table 0344) NOT reversed.
+  01: self # Patient is insured 
+  02: spouse  # Spouse 
+  03: child  # Natural child financial responsibility
+  04: child  # Natural child no financial responsibility
+  05: child  # Step child 
+  06: child  # Foster child 
+# 07: Ward of the court: no good match
+# 08: Employee: no good match
+# 09: Unknown: no good match 
+  10: other # Handicapped dependent 
+# 11: Organ donor : no good match
+# 12: Cadaver donor : no good match
+  13: other # Grandchild 
+  14: other # Niece/Nephew 
+# 15: Injured planitiff : no good match
+# 16: Sponsored dependent : no good match
+  17: other # Minor dependent of a minor dependant input (grandchild dependent)
+  18: parent # Parent 
+  19: other # Grandparent 
+
+

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -106,6 +106,7 @@ subscriber_1:
       #  $Patient  
 
 # If the subscriber is SEL (self), then reference the patient
+# NOT_NULL check is not needed because we have values here, and NOT_NULL is otherwise caught by logic of subscriber_1
 subscriber_2:
     condition: $relatedRelationshipStr EQUALS SEL || $relatedRelationshipStr EQUALS 01
     valueOf: datatype/Reference

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -96,23 +96,23 @@ payor:
 
 # If the subscriber is not SEL (self), then create the related person
 subscriber_1:
-   condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr NOT_EQUALS SEL
+   condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr NOT_EQUALS SEL && $relatedRelationshipStr NOT_EQUALS 01
    valueOf: resource/RelatedPerson
    expressionType: reference
    vars: 
-      relatedRelationshipStr: String, IN1.17
+      relatedRelationshipStr: String, IN1.17 | IN2.72  
       # Related person gets many values from scope, so they do not need to be passed in
       #  IN1 and sub-fields
       #  $Patient  
 
 # If the subscriber is SEL (self), then reference the patient
 subscriber_2:
-    condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr EQUALS SEL
+    condition: $relatedRelationshipStr EQUALS SEL || $relatedRelationshipStr EQUALS 01
     valueOf: datatype/Reference
     expressionType: resource
     specs: $Patient
     vars: 
-      relatedRelationshipStr: String, IN1.17     
+      relatedRelationshipStr: String, IN1.17 | IN2.72    
 
 subscriberId:  
    type: STRING
@@ -126,8 +126,8 @@ relationship:
    generateList: true
    condition: $coding NOT_NULL
    vars:
-      coding: SUBSCRIBER_RELATIONSHIP, IN1.17
-      text: String, IN1.17.2      
+      coding: SUBSCRIBER_RELATIONSHIP, IN1.17 | IN2.72
+      text: String, IN1.17.2 | IN2.72.2
 
 beneficiary:
     valueOf: datatype/Reference

--- a/src/main/resources/hl7/resource/RelatedPerson.yml
+++ b/src/main/resources/hl7/resource/RelatedPerson.yml
@@ -58,8 +58,8 @@ relationship:
    generateList: true
    condition: $coding NOT_NULL
    vars:
-      coding: POLICYHOLDER_RELATIONSHIP, IN1.17
-      text: String, IN1.17.2     
+      coding: POLICYHOLDER_RELATIONSHIP, IN1.17 | IN2.72
+      text: String, IN1.17.2 | IN2.72.2
 
 name:
    valueOf: datatype/HumanName

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -353,12 +353,19 @@ class SimpleDataValueResolverTest {
     @Test
     void testPolicyholderRelationship() {
 
-        // Check supported known input code
+        // Check supported known input code (from table 0063)
         SimpleCode coding = SimpleDataValueResolver.POLICYHOLDER_RELATIONSHIP.apply("PAR");
         assertThat(coding).isNotNull();
         assertThat(coding.getCode()).isEqualTo("PRN");
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v3-RoleCode");
         assertThat(coding.getDisplay()).isEqualTo("parent");
+
+        // Check supported known input code (from table 0344) REVERSES the relationship.  See notes in v2ToFhirMapping.
+        coding = SimpleDataValueResolver.POLICYHOLDER_RELATIONSHIP.apply("18"); // 18 is parent
+        assertThat(coding).isNotNull();
+        assertThat(coding.getCode()).isEqualTo("CHILD");
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v3-RoleCode");
+        assertThat(coding.getDisplay()).isEqualTo("child");
 
         // Check unsupported unknown input code
         // Because CGV has no mapping, we pass it without a system.
@@ -371,12 +378,19 @@ class SimpleDataValueResolverTest {
     @Test
     void testSubscriberRelationship() {
 
-        // Check supported known input code
+        // Check supported known input code (from table 0063) REVERSES the relationship.  See notes in v2ToFhirMapping.
         SimpleCode coding = SimpleDataValueResolver.SUBSCRIBER_RELATIONSHIP.apply("CHD");
         assertThat(coding).isNotNull();
         assertThat(coding.getCode()).isEqualTo("parent");
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/subscriber-relationship");
         assertThat(coding.getDisplay()).isEqualTo("Parent");
+
+        // Check supported known input code (from table 0344)
+        coding = SimpleDataValueResolver.SUBSCRIBER_RELATIONSHIP.apply("04"); // is child
+        assertThat(coding).isNotNull();
+        assertThat(coding.getCode()).isEqualTo("child");
+        assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/subscriber-relationship");
+        assertThat(coding.getDisplay()).isEqualTo("Child");
 
         // Check unsupported unknown input code
         // Because GOAT has no mapping, we pass it without a system.

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -589,7 +589,7 @@ class Hl7FinancialInsuranceTest {
                 //    IN1.16.1 to RelatedPerson Name .family
                 //    IN1.16.2 to RelatedPerson Name .given (first)
                 //    IN1.16.5 to RelatedPerson Name .prefix
-                // IN1.17 purposely empty to validate IN2.62 works as secondary
+                // IN1.17 purposely empty to validate IN2.72 works as secondary
                 // IN1.18 through IN1.35 NOT REFERENCED
                 + "|DoeFake^Judy^^^Rev.|||||||||||||||||||"
                 // IN1.36 to Identifier 4s
@@ -598,7 +598,7 @@ class Hl7FinancialInsuranceTest {
                 // IN2.1 through IN2.71 not used
                 + "IN2||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                 // IN2.72 to Coverage.relationship and RelatedPerson.relationship.  (Backup for IN1.17) Codes from table 0344
-                + "04|\n";
+                + "04|\n"; // 04 = Natural child
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -627,7 +627,7 @@ class Hl7FinancialInsuranceTest {
 
         // Expect one RelatedPerson
         List<Resource> relatedPersons = ResourceUtils.getResourceList(e, ResourceType.RelatedPerson);
-        assertThat(relatedPersons).hasSize(1); // From IN1.16 through IN1.19; IN1.43; INI.49 
+        assertThat(relatedPersons).hasSize(1); // From IN2.72 
         RelatedPerson related = (RelatedPerson) relatedPersons.get(0);
 
         assertThat(related.getName()).hasSize(1);
@@ -638,13 +638,13 @@ class Hl7FinancialInsuranceTest {
         // Check coverage relationship
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getRelationship(), "child",
                 "Child",
-                "http://terminology.hl7.org/CodeSystem/subscriber-relationship", null); // IN2.72
+                "http://terminology.hl7.org/CodeSystem/subscriber-relationship", null); // IN2.72 (04 = Natural child)
 
         // Check relatedPerson relationship
         assertThat(related.getRelationship()).hasSize(1);
         DatatypeUtils.checkCommonCodeableConceptAssertions(related.getRelationship().get(0), "PRN",
                 "parent",
-                "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null); // IN2.72
+                "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null); // IN2.72 (04 = Natural child)
 
         // Confirm the Coverage (subscriber) references the RelatedPerson
         assertThat(coverage.getSubscriber().getReference()).isEqualTo(related.getId());

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -103,6 +103,7 @@ class Hl7FinancialInsuranceTest {
                 // IN1.46 to Identifier 3
                 // IN1.47 through IN1.53 NOT REFERENCED
                 + "|MEMBER36||||||||||Value46|||||||\n";
+        // IN2.72 is purposely empty (backup to IN1.17) so no RelatedPerson is created.
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -256,7 +257,7 @@ class Hl7FinancialInsuranceTest {
     // Also test IN2.2 Social Security number
 
     void testInsuranceCoverageByRelatedFields(String messageType) throws IOException {
-        String hl7message = "MSH|^~\\&|||||20151008111200||"+messageType+"|MSGID000001|T|2.6|||||||||\n"
+        String hl7message = "MSH|^~\\&|||||20151008111200||" + messageType + "|MSGID000001|T|2.6|||||||||\n"
                 + "EVN||20210407191342||||||\n"
                 + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
                 + "PV1||I||||||||||||||||||||||||||||||||||||||||||\n"
@@ -298,7 +299,7 @@ class Hl7FinancialInsuranceTest {
                 // IN1.50 through IN1.53 NOT REFERENCED
                 + "|MEMBER36|||||||F|||Value46|||J494949^^^Large HMO^XX||||\n"
                 // IN2.2 to RelatedPerson.identifier (SSN)
-                // IN2.3 through IN1.62 not used
+                // IN2.3 through IN2.62 not used
                 + "IN2||777-88-9999||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                 // IN2.63 to RelatedPerson.telecom
                 //    IN2.63.1 to Organization Contact telecom .value (ONLY when XTN.5-XTN.7 are empty.  See rules in getFormattedTelecomNumberValue.)
@@ -352,8 +353,8 @@ class Hl7FinancialInsuranceTest {
         assertThat(related.getIdentifier().get(1).getValue()).isEqualTo("777-88-9999"); // IN2.2
         assertThat(related.getIdentifier().get(1).hasSystem()).isFalse(); // No system to assign
         DatatypeUtils.checkCommonCodeableConceptAssertions(related.getIdentifier().get(1).getType(), "SS",
-                "Social Security number", 
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);        
+                "Social Security number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Check RelatedPerson name. IN1.16 name is standard XPN, tested exhaustively in other tests.        
         assertThat(related.getName()).hasSize(1);
@@ -444,8 +445,10 @@ class Hl7FinancialInsuranceTest {
                 + "|MEMBER36||||||||||Value46|||||||\n";
 
         // TENANT prepend is passed through the options.  
-        ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint().withProperty("TENANT", "TenantId").build();        
-        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message, customOptionsWithTenant);
+        ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint()
+                .withProperty("TENANT", "TenantId").build();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message,
+                customOptionsWithTenant);
 
         List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
         assertThat(encounters).hasSize(1); // From PV1
@@ -552,6 +555,182 @@ class Hl7FinancialInsuranceTest {
 
         List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
         assertThat(coverages).hasSize(1); // From IN1 segment
+
+        // Confirm there are no unaccounted for resources
+        // Expected: Coverage, Organization, Patient, Encounter
+        assertThat(e).hasSize(4);
+    }
+
+    @Test
+    // Tests IN2.72 as backup IN1.17 coverage. Code '04' is child. A related person should be created.  
+    void testInsuranceCoverageFromIN2() throws IOException {
+        String hl7message = "MSH|^~\\&|||||20151008111200||ADT^A01^ADT_A01|MSGID000001|T|2.6|||||||||\n"
+                + "EVN||20210407191342||||||\n"
+                + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1||I||||||||||||||||||||||||||||||||||||||||||\n"
+                // FT1 added for completeness; required in specification, but not used (ignored) by templates
+                // FT1.4 is required transaction date (currently not used)
+                // FT1.6 is required transaction type (currently not used)
+                // FT1.7 is required transaction code (currently not used)
+                + "FT1||||20201231145045||CG|FAKE|||||||||||||||||||||||||||||||||||||\n"
+                // IN1 Segment is split and concatenated for easier understanding. (| precedes numbered field.)
+                // IN1.2.1, IN1.2.3 to Identifier 1
+                // IN1.2.4, IN1.2.6 to Identifier 2
+                + "IN1|1|Value1^^System3^Value4^^System6"
+                // Minimal Organization. Required for Payor, which is required.
+                // Organization deep test in testBasicInsuranceCoverageFields
+                // IN1.3 to Organization Identifier 
+                //    IN1.3.1 to Organization Identifier.value  
+                //    IN1.3.4 to Organization Identifier.system
+                // INI.4 to Organization Name (required to inflate organization)
+                // IN1.5 to 15 NOT REFERENCED (See test testBasicInsuranceCoverageFields)
+                + "|IdValue1^^^IdSystem4^^^^|Large Blue Organization|||||||||||"
+                // IN1.16 to RelatedPerson.name
+                //    IN1.16.1 to RelatedPerson Name .family
+                //    IN1.16.2 to RelatedPerson Name .given (first)
+                //    IN1.16.5 to RelatedPerson Name .prefix
+                // IN1.17 purposely empty to validate IN2.62 works as secondary
+                // IN1.18 through IN1.35 NOT REFERENCED
+                + "|DoeFake^Judy^^^Rev.|||||||||||||||||||"
+                // IN1.36 to Identifier 4s
+                // IN1.37 through IN1.53 NOT REFERENCED
+                + "|MEMBER36|||||||||||||||||\n"
+                // IN2.1 through IN2.71 not used
+                + "IN2||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                // IN2.72 to Coverage.relationship and RelatedPerson.relationship.  (Backup for IN1.17) Codes from table 0344
+                + "04|\n";
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).hasSize(1); // From PV1
+
+        List<Resource> patients = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patients).hasSize(1); // From PID
+        Patient patient = (Patient) patients.get(0);
+        String patientId = patient.getId();
+
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(1); // From Payor created by IN1
+
+        List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
+        assertThat(coverages).hasSize(1); // From IN1 segment
+        Coverage coverage = (Coverage) coverages.get(0);
+
+        // Confirm Coverage Identifiers
+        assertThat(coverage.getIdentifier()).hasSize(3);
+        // Coverage Identifiers deep check in testBasicInsuranceCoverageFields
+
+        // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
+        assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
+        assertThat(coverage.getPayorFirstRep().getReference()).isEqualTo(organizations.get(0).getId());
+
+        // Expect one RelatedPerson
+        List<Resource> relatedPersons = ResourceUtils.getResourceList(e, ResourceType.RelatedPerson);
+        assertThat(relatedPersons).hasSize(1); // From IN1.16 through IN1.19; IN1.43; INI.49 
+        RelatedPerson related = (RelatedPerson) relatedPersons.get(0);
+
+        assertThat(related.getName()).hasSize(1);
+        HumanName relatedName = related.getName().get(0);
+        // Simplified name test.  Deeper tests in other tests.
+        assertThat(relatedName.getText()).isEqualTo("Rev. Judy DoeFake"); // from IN1.16 aggregate
+
+        // Check coverage relationship
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getRelationship(), "child",
+                "Child",
+                "http://terminology.hl7.org/CodeSystem/subscriber-relationship", null); // IN2.72
+
+        // Check relatedPerson relationship
+        assertThat(related.getRelationship()).hasSize(1);
+        DatatypeUtils.checkCommonCodeableConceptAssertions(related.getRelationship().get(0), "PRN",
+                "parent",
+                "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null); // IN2.72
+
+        // Confirm the Coverage (subscriber) references the RelatedPerson
+        assertThat(coverage.getSubscriber().getReference()).isEqualTo(related.getId());
+        // Confirm the RelatedPerson references the Patient
+        assertThat(related.getPatient().getReference()).isEqualTo(patientId);
+
+        // Confirm there are no unaccounted for resources
+        // Expected: Coverage, Organization, Patient, Encounter, RelatedPerson
+        assertThat(e).hasSize(5);
+    }
+
+    @Test
+    // Tests IN2.72 as backup IN1.17 coverage. Case of self. Code '01' is self. No related person should be created.  
+    void testInsuranceCoverageFromIN2Self() throws IOException {
+
+        String hl7message = "MSH|^~\\&|||||20151008111200||DFT^P03^DFT_P03|MSGID000001|T|2.6|||||||||\n"
+                + "EVN||20210407191342||||||\n"
+                + "PID|||MR1^^^XYZ^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PV1||I||||||||||||||||||||||||||||||||||||||||||\n"
+                // FT1 added for completeness; required in specification, but not used (ignored) by templates
+                // FT1.4 is required transaction date (currently not used)
+                // FT1.6 is required transaction type (currently not used)
+                // FT1.7 is required transaction code (currently not used)
+                + "FT1||||20201231145045||CG|FAKE|||||||||||||||||||||||||||||||||||||\n"
+                // IN1 Segment is split and concatenated for easier understanding. (| precedes numbered field.)
+                // IN1.2.1, IN1.2.3 to Identifier 1
+                // IN1.2.4, IN1.2.6 to Identifier 2
+                + "IN1|1|Value1^^System3^Value4^^System6"
+                // Minimal Organization
+                // IN1.3 to Organization Identifier 
+                // INI.4 to Organization Name (required to inflate organization)
+                // IN1.5 to 15 NOT REFERENCED (Tested in testBasicInsuranceCoverageFields)
+                + "|IdValue1^^^IdSystem4^^^^|Large Blue Organization|||||||||||"
+                // IN1.16 empty because there is no related person (IN2.72 is self)
+                // IN1.17 empty to verify that IN2.72 works as backup for IN1.17
+                // IN1.18 through IN1.35 NOT REFERENCED
+                + "||||||||||||||||||||"
+                // IN1.36 to Identifier 4s
+                // IN1.37 through IN1.53 NOT REFERENCED
+                + "|MEMBER36|||||||||||||||||\n"
+                // IN2.1 through IN2.71 NOT REFERENCED
+                + "IN2||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+                // IN2.72 to Coverage.relationship and RelatedPerson.relationship.  (Backup for IN1.17) Codes from table 0344
+                // Code 01 (self) should create relationship of ONESELF, and reference to patient
+                + "01|\n";
+
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).hasSize(1); // From PV1
+
+        List<Resource> patients = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patients).hasSize(1); // From PID
+        Patient patient = (Patient) patients.get(0);
+        String patientId = patient.getId();
+
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(1); // From Payor created by IN1
+        Organization org = (Organization) organizations.get(0);
+
+        // Check organization Id's
+        assertThat(org.getIdentifier()).hasSize(1);
+        // Org identifiers checked deeply in other tests
+
+        List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
+        assertThat(coverages).hasSize(1); // From IN1 segment
+        Coverage coverage = (Coverage) coverages.get(0);
+
+        // Confirm Coverage Identifiers
+        assertThat(coverage.getIdentifier()).hasSize(3);
+        // Coverage Identifiers deep check in testBasicInsuranceCoverageFields
+
+        // Confirm Coverage Subscriber references to Patient
+        assertThat(coverage.getSubscriber().getReference()).isEqualTo(patientId);
+        // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
+        assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
+        assertThat(coverage.getPayorFirstRep().getReference()).isEqualTo(organizations.get(0).getId());
+
+        // Expect no RelatedPerson because IN2.72 was 01 (self)
+        List<Resource> relatedPersons = ResourceUtils.getResourceList(e, ResourceType.RelatedPerson);
+        assertThat(relatedPersons).isEmpty(); // No related person should be created because IN2.72 was 01 (self)
+
+        // Check coverage.relationship (from SubscriberRelationship mapping)
+        DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getRelationship(), "self",
+                "Self",
+                "http://terminology.hl7.org/CodeSystem/subscriber-relationship", null); // IN2.72
 
         // Confirm there are no unaccounted for resources
         // Expected: Coverage, Organization, Patient, Encounter


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

IN2.72 as backup relationship for IN1.17.
NOTE: special rules apply for interpreting the direction of the relationship as input and mapping to the direction of the relationship expected by the FHIR field.

Added detailed notes in v2ToFhirMapping.yml IMPORTANT NOTES ON RELATIONSHIP MAPPINGS