### PR TITLE
Issue411 Support addtl Orgs IN2.25, 69

### DIFF
--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -120,9 +120,10 @@ status:
    constants:
      active: 'active'
 
-payor:
+payor_1:
    valueOf: resource/Organization
    expressionType: reference
+   generateList: true
    vars: 
        orgName: String, IN1.4.1
        orgIdValue: String, IN1.3.1
@@ -133,6 +134,32 @@ payor:
        orgAddressXAD: IN1.5
        orgContactXCN: IN1.6
        orgContactPointXTN: IN1.7
+       orgCompanyPlanCode: IN1.35
+
+payor_2:
+   valueOf: resource/Organization
+   expressionType: reference
+   generateList: true
+   vars: 
+       # NOTE FHIR does not require Organization.name, but we do
+       # for an unknown reason. This is documented in Issue #422
+       orgName: String, IN2.25.1
+       orgIdValue: String, IN2.25.1
+       orgIdSystem: String, IN2.25.4
+       orgIdTypeCode: String, IN2.25.5
+       orgIdStart: IN2.25.7
+       orgIdEnd: IN2.25.8
+
+payor_3:
+   valueOf: resource/Organization
+   expressionType: reference
+   generateList: true
+   vars: 
+       orgName: String, IN2.69.1
+       orgIdValue: String, IN2.69.10
+       orgIdSystem: String, IN2.69.6
+       orgIdTypeCode: String, IN2.69.7
+   
 
 # If the subscriber is not SEL (self), then create the related person
 subscriber_1:

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -12,7 +12,7 @@
 resourceType: Coverage
 id:
   type: STRING
-  valueOf: 'UUID.randomUUID()'
+  valueOf: "UUID.randomUUID()"
   expressionType: JEXL
 
 identifier_1:
@@ -39,7 +39,7 @@ identifier_2:
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "XV"
-    display: "Health Plan Identifier" 
+    display: "Health Plan Identifier"
 
 identifier_3:
   condition: $valueIn NOT_NULL
@@ -52,8 +52,8 @@ identifier_3:
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "XV"
-    display: "Health Plan Identifier" 
-    use: "old"    
+    display: "Health Plan Identifier"
+    use: "old"
 
 identifier_4:
   condition: $valueIn NOT_NULL
@@ -66,7 +66,7 @@ identifier_4:
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "MB"
-    display: "Member Number"      
+    display: "Member Number"
 
 identifier_5:
   condition: $valueIn NOT_NULL
@@ -74,12 +74,12 @@ identifier_5:
   generateList: true
   expressionType: resource
   vars:
-    valueIn: IN2.8 
+    valueIn: IN2.8
     # No systemCX set for this identifier
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "MA"
-    display: "Patient Medicaid number"       
+    display: "Patient Medicaid number"
 
 identifier_6:
   condition: $valueIn NOT_NULL
@@ -92,7 +92,7 @@ identifier_6:
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "MC"
-    display: "Patient's Medicare number"      
+    display: "Patient's Medicare number"
 
 identifier_7:
   condition: $valueIn NOT_NULL
@@ -105,123 +105,121 @@ identifier_7:
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "SN"
-    display: "Subscriber Number"                
+    display: "Subscriber Number"
 
-
-# Status is required, but it comes from a non-table 2 char ST 
+# Status is required, but it comes from a non-table 2 char ST
 # It MUST be one of: active | cancelled | draft | entered-in-error
 # For now, until we get a good mapping, assume all records are active
 status:
-   type: STRING
-   default: active
-   valueOf: $active
-   #   valueOf: IN1.45 value will come from IN1.45, but we don't yet have a mapping.
-   expressionType: HL7Spec
-   constants:
-     active: 'active'
+  type: STRING
+  default: active
+  valueOf: $active
+  #   valueOf: IN1.45 value will come from IN1.45, but we don't yet have a mapping.
+  expressionType: HL7Spec
+  constants:
+    active: "active"
 
 payor_1:
-   valueOf: resource/Organization
-   expressionType: reference
-   generateList: true
-   vars: 
-       orgName: String, IN1.4.1
-       orgIdValue: String, IN1.3.1
-       orgIdSystem: String, IN1.3.4
-       orgIdTypeCode: String, IN1.3.5
-       orgIdStart: IN1.3.7
-       orgIdEnd: IN1.3.8
-       orgAddressXAD: IN1.5
-       orgContactXCN: IN1.6
-       orgContactPointXTN: IN1.7
-       orgCompanyPlanCode: IN1.35
+  valueOf: resource/Organization
+  expressionType: reference
+  generateList: true
+  vars:
+    orgName: String, IN1.4.1
+    orgIdValue: String, IN1.3.1
+    orgIdSystem: String, IN1.3.4
+    orgIdTypeCode: String, IN1.3.5
+    orgIdStart: IN1.3.7
+    orgIdEnd: IN1.3.8
+    orgAddressXAD: IN1.5
+    orgContactXCN: IN1.6
+    orgContactPointXTN: IN1.7
+    orgCompanyPlanCode: IN1.35
 
 payor_2:
-   valueOf: resource/Organization
-   expressionType: reference
-   generateList: true
-   vars: 
-       # NOTE FHIR does not require Organization.name, but we do
-       # for an unknown reason. This is documented in Issue #422
-       orgName: String, IN2.25.1
-       orgIdValue: String, IN2.25.1
-       orgIdSystem: String, IN2.25.4
-       orgIdTypeCode: String, IN2.25.5
-       orgIdStart: IN2.25.7
-       orgIdEnd: IN2.25.8
+  valueOf: resource/Organization
+  expressionType: reference
+  generateList: true
+  vars:
+    # NOTE FHIR does not require Organization.name, but we do
+    # for an unknown reason. This is documented in Issue #422
+    orgName: String, IN2.25.1
+    orgIdValue: String, IN2.25.1
+    orgIdSystem: String, IN2.25.4
+    orgIdTypeCode: String, IN2.25.5
+    orgIdStart: IN2.25.7
+    orgIdEnd: IN2.25.8
 
 policyHolder:
-   valueOf: resource/Organization
-   expressionType: reference
-   vars: 
-       orgName: String, IN2.69.1
-       orgIdValue: String, IN2.69.10
-       orgIdSystem: String, IN2.69.6
-       orgIdTypeCode: String, IN2.69.7
-   
+  valueOf: resource/Organization
+  expressionType: reference
+  vars:
+    orgName: String, IN2.69.1
+    orgIdValue: String, IN2.69.10
+    orgIdSystem: String, IN2.69.6
+    orgIdTypeCode: String, IN2.69.7
 
 # If the subscriber is not SEL (self), then create the related person
 subscriber_1:
-   condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr NOT_EQUALS SEL && $relatedRelationshipStr NOT_EQUALS 01
-   valueOf: resource/RelatedPerson
-   expressionType: reference
-   vars: 
-      relatedRelationshipStr: String, IN1.17 | IN2.72  
-      # Related person gets many values from scope, so they do not need to be passed in
-      #  IN1 and sub-fields
-      #  $Patient  
+  condition: $relatedRelationshipStr NOT_NULL && $relatedRelationshipStr NOT_EQUALS SEL && $relatedRelationshipStr NOT_EQUALS 01
+  valueOf: resource/RelatedPerson
+  expressionType: reference
+  vars:
+    relatedRelationshipStr: String, IN1.17 | IN2.72
+    # Related person gets many values from scope, so they do not need to be passed in
+    #  IN1 and sub-fields
+    #  $Patient
 
 # If the subscriber is SEL (self), then reference the patient
 # NOT_NULL check is not needed because we have values here, and NOT_NULL is otherwise caught by logic of subscriber_1
 subscriber_2:
-    condition: $relatedRelationshipStr EQUALS SEL || $relatedRelationshipStr EQUALS 01
-    valueOf: datatype/Reference
-    expressionType: resource
-    specs: $Patient
-    vars: 
-      relatedRelationshipStr: String, IN1.17 | IN2.72    
+  condition: $relatedRelationshipStr EQUALS SEL || $relatedRelationshipStr EQUALS 01
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Patient
+  vars:
+    relatedRelationshipStr: String, IN1.17 | IN2.72
 
-subscriberId:  
-   type: STRING
-   valueOf: IN1.36
-   expressionType: HL7Spec
+subscriberId:
+  type: STRING
+  valueOf: IN1.36
+  expressionType: HL7Spec
 
 # Relationship may be SEL (self)
 relationship:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   generateList: true
-   condition: $coding NOT_NULL
-   vars:
-      coding: SUBSCRIBER_RELATIONSHIP, IN1.17 | IN2.72
-      text: String, IN1.17.2 | IN2.72.2
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  generateList: true
+  condition: $coding NOT_NULL
+  vars:
+    coding: SUBSCRIBER_RELATIONSHIP, IN1.17 | IN2.72
+    text: String, IN1.17.2 | IN2.72.2
 
 beneficiary:
-    valueOf: datatype/Reference
-    expressionType: resource
-    specs: $Patient
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Patient
 
 class_1:
-   valueOf: secondary/Class
-   generateList: true
-   expressionType: resource
-   vars: 
-      classValue: String, IN1.8
+  valueOf: secondary/Class
+  generateList: true
+  expressionType: resource
+  vars:
+    classValue: String, IN1.8
 
 class_2:
-   valueOf: secondary/Class
-   generateList: true
-   expressionType: resource
-   specs: IN1.9
+  valueOf: secondary/Class
+  generateList: true
+  expressionType: resource
+  specs: IN1.9
 
 period:
-    valueOf: datatype/Period
-    expressionType: resource
-    vars:
-       start: IN1.12
-       end: IN1.13
+  valueOf: datatype/Period
+  expressionType: resource
+  vars:
+    start: IN1.12
+    end: IN1.13
 
 order:
-   type: INTEGER
-   valueOf: IN1.22 | IN1.1
-   expressionType: HL7Spec
+  type: INTEGER
+  valueOf: IN1.22 | IN1.1
+  expressionType: HL7Spec

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -150,10 +150,9 @@ payor_2:
        orgIdStart: IN2.25.7
        orgIdEnd: IN2.25.8
 
-payor_3:
+policyHolder:
    valueOf: resource/Organization
    expressionType: reference
-   generateList: true
    vars: 
        orgName: String, IN2.69.1
        orgIdValue: String, IN2.69.10

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -45,14 +45,28 @@ identifier_2b:
       code: $orgIdTypeCode  
    constants:
       period: '.'                 
+
+identifier_3:
+   valueOf: datatype/Identifier_var
+   generateList: true  
+   expressionType: resource
+   vars:
+      valueIn: $orgCompanyPlanCode
+      # No CXsystem
+      # No code
+
 name_v1:
    type: STRING
    condition: $idValue NULL
    valueOf: CWE.2 | XON.1 | $orgName
+   # NOTE FHIR does not require Organization.name, but we do
+   # for an unkown reason. This is documented in Issue #422
+   # When this is fixed, remove payor_2: orgName: String, IN2.25.1
    required: true
    expressionType: HL7Spec
    vars:
       idValue: CWE.1 | XON.10 | XON.3 
+
 name_v2:
    type: STRING
    condition: $idValue NOT_NULL
@@ -60,6 +74,7 @@ name_v2:
    expressionType: HL7Spec
    vars:
       idValue: CWE.1 | XON.10 | XON.3
+      
 alias:
    type: STRING
    valueOf: CWE.5

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -54,7 +54,7 @@ identifier_3:
   generateList: true
   expressionType: resource
   vars:
-    valueIn: $orgCompanyPlanCode
+    valueIn: $orgCompanyPlanCode   # IN1.35 passed in from Coverage
     # No CXsystem
     # No code
 

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -5,96 +5,99 @@
 #
 resourceType: Organization
 id:
-   type: STRING
-   valueOf: UUID.randomUUID()
-   expressionType: JEXL
-# Used by most organizations   
+  type: STRING
+  valueOf: UUID.randomUUID()
+  expressionType: JEXL
+
+# Used by most organizations
 identifier_1:
-   condition: $orgIdValue NULL
-   valueOf: datatype/Identifier_Gen
-   generateList: true  
-   expressionType: resource
-   vars:
-      id: CWE.1 | XON.10 | XON.3
-      system: CWE.3 
+  condition: $orgIdValue NULL
+  valueOf: datatype/Identifier_Gen
+  generateList: true
+  expressionType: resource
+  vars:
+    id: CWE.1 | XON.10 | XON.3
+    system: CWE.3
+
 # Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier
-# This handles case when no $TENANT value is available        
+# This handles case when no $TENANT value is available
 identifier_2a:
-   condition: $orgIdValue NOT_NULL && $TENANT NULL
-   valueOf: datatype/Identifier_var
-   generateList: true  
-   expressionType: resource
-   vars:
-      valueIn: $orgIdValue
-      systemCX: $orgIdSystem
-      start: $orgIdStart
-      end: $orgIdEnd
-      code: $orgIdTypeCode
+  condition: $orgIdValue NOT_NULL && $TENANT NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: $orgIdValue
+    systemCX: $orgIdSystem
+    start: $orgIdStart
+    end: $orgIdEnd
+    code: $orgIdTypeCode
+
 # Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier
-# This handles case when $TENANT is passed at run time          
+# This handles case when $TENANT is passed at run time
 identifier_2b:
-   condition: $orgIdValue NOT_NULL && $TENANT NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true  
-   expressionType: resource
-   vars:
-      valueIn: $TENANT + $period + $orgIdValue
-      systemCX: $orgIdSystem
-      start: $orgIdStart
-      end: $orgIdEnd
-      code: $orgIdTypeCode  
-   constants:
-      period: '.'                 
+  condition: $orgIdValue NOT_NULL && $TENANT NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: $TENANT + $period + $orgIdValue
+    systemCX: $orgIdSystem
+    start: $orgIdStart
+    end: $orgIdEnd
+    code: $orgIdTypeCode
+  constants:
+    period: "." # period is constant used between concatention in $valueIn
 
 identifier_3:
-   valueOf: datatype/Identifier_var
-   generateList: true  
-   expressionType: resource
-   vars:
-      valueIn: $orgCompanyPlanCode
-      # No CXsystem
-      # No code
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: $orgCompanyPlanCode
+    # No CXsystem
+    # No code
 
 name_v1:
-   type: STRING
-   condition: $idValue NULL
-   valueOf: CWE.2 | XON.1 | $orgName
-   # NOTE FHIR does not require Organization.name, but we do
-   # for an unkown reason. This is documented in Issue #422
-   # When this is fixed, remove payor_2: orgName: String, IN2.25.1
-   required: true
-   expressionType: HL7Spec
-   vars:
-      idValue: CWE.1 | XON.10 | XON.3 
+  type: STRING
+  condition: $idValue NULL
+  valueOf: CWE.2 | XON.1 | $orgName
+  # NOTE FHIR does not require Organization.name, but we do
+  # for an unkown reason. This is documented in Issue #422
+  # When this is fixed, remove payor_2: orgName: String, IN2.25.1
+  required: true
+  expressionType: HL7Spec
+  vars:
+    idValue: CWE.1 | XON.10 | XON.3
 
 name_v2:
-   type: STRING
-   condition: $idValue NOT_NULL
-   valueOf: CWE.2 | XON.1
-   expressionType: HL7Spec
-   vars:
-      idValue: CWE.1 | XON.10 | XON.3
-      
+  type: STRING
+  condition: $idValue NOT_NULL
+  valueOf: CWE.2 | XON.1
+  expressionType: HL7Spec
+  vars:
+    idValue: CWE.1 | XON.10 | XON.3
+
 alias:
-   type: STRING
-   valueOf: CWE.5
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: CWE.5
+  expressionType: HL7Spec
 
 address:
-   valueOf: datatype/Address
-   generateList: true
-   expressionType: resource
-   specs: $orgAddressXAD  
+  valueOf: datatype/Address
+  generateList: true
+  expressionType: resource
+  specs: $orgAddressXAD
 
-contact: 
-   valueOf: secondary/Contact
-   generateList: true
-   expressionType: resource
-   specs: $orgContactXCN
-   vars:
-      # May be provided to create a purpose in the Contact element
-      code: $orgContactPurposeCode
-      system_code: $orgContactPurposeSystemCode
-      display: $orgContactPurposeDisplay
-      text: $orgContactPurposeText
-      contactPointXTN: $orgContactPointXTN
+contact:
+  valueOf: secondary/Contact
+  generateList: true
+  expressionType: resource
+  specs: $orgContactXCN
+  vars:
+    # May be provided to create a purpose in the Contact element
+    code: $orgContactPurposeCode
+    system_code: $orgContactPurposeSystemCode
+    display: $orgContactPurposeDisplay
+    text: $orgContactPurposeText
+    contactPointXTN: $orgContactPointXTN

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -99,7 +99,7 @@ class Hl7FinancialInsuranceTest {
                 // IN1.23 through IN1.34 NOT REFERENCED                
                 // IN1.35 to Organization.identifier
                 + "|20201231145045|20211231145045|||||||||5|||||||||||||COMPANYPLANCODE35"
-                // IN1.36 to Identifier 4 - MB
+                // IN1.36 to Identifier MB and Identifier SN
                 // IN1.36 also to subscriberId
                 // IN1.46 to Identifier XV 3
                 // IN1.47 through IN1.53 NOT REFERENCED
@@ -109,10 +109,9 @@ class Hl7FinancialInsuranceTest {
                 // IN2.25 to new PayorId Organization
                 // IN2.61 is purposely empty (primary to IN1.36) so IN1.36 will be used as the MB identifier
                 + "IN2|||||||||||||||||||||||||IdValue25.1^^^IdSystem25.4^IdType25.5^^20201231145045^20211231145045|||||||||||||||||||||||||||||||||||||||||||"
-                // IN2.69 to new Insured Organization Name and ID
+                // IN2.69 to new PolicyHolder Organization Name and ID
                 // IN2.72 is purposely empty (backup to IN1.17) so no RelatedPerson is created.
                 + "|Name69.1^^^^^IdSystem69.6^XX^^^IdValue69.10||\n";
-
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -125,11 +124,11 @@ class Hl7FinancialInsuranceTest {
         String patientId = patient.getId();
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
-        assertThat(organizations).hasSize(3); // From IN1.3 creates Payor, IN2.25 to new PayorId Organization, IN2.69 creates new Insured Organization Name
+        assertThat(organizations).hasSize(3); // From IN1.3 creates Payor, IN2.25 to new PayorId Organization, IN2.69 creates new PolicyHolder Organization Name
         Organization org = (Organization) organizations.get(0);
 
         // Check Payor Organization Id's
-        String organizationId = org.getId();
+        String payorOrganizationId = org.getId();
         assertThat(org.getName()).isEqualTo("Large Blue Organization"); // IN1.4
         assertThat(org.getIdentifier()).hasSize(2);
         Identifier orgId0 = org.getIdentifier().get(0);
@@ -174,17 +173,9 @@ class Hl7FinancialInsuranceTest {
         assertThat(contactPoint.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN1.7.14
         assertThat(contactPoint.getRank()).isEqualTo(1); // IN1.7.18
 
-        // Check Insured Organization Name and ID Organization from IN2.69
-        org = (Organization) organizations.get(1);
-        assertThat(org.getName()).isEqualTo("Name69.1"); // IN2.69.1
-        assertThat(org.getIdentifier()).hasSize(1);
-        orgId0 = org.getIdentifier().get(0);
-        assertThat(orgId0.getValue()).isEqualTo("IdValue69.10"); // IN2.69.10
-        assertThat(orgId0.getSystem()).isEqualTo("urn:id:IdSystem69.6"); // IN2.69.6
-        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "XX", null, null, null); // IN2.69.7
-
         // Check PayorId Organization from IN2.25 
-        org = (Organization) organizations.get(2);
+        org = (Organization) organizations.get(1);
+        String payorOrganizationIdIn25 = org.getId();
         assertThat(org.getName()).isEqualTo("IdValue25.1"); // IN2.25.1
         assertThat(org.getIdentifier()).hasSize(1);
         orgId0 = org.getIdentifier().get(0);
@@ -194,12 +185,22 @@ class Hl7FinancialInsuranceTest {
         assertThat(orgId0.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN2.25.8
         DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "IdType25.5", null, null, null); // IN2.25.5
 
+        // Check PolicyHolder Organization Name and ID Organization from IN2.69
+        org = (Organization) organizations.get(2);
+        String policyHolderOrganizationId = org.getId();
+        assertThat(org.getName()).isEqualTo("Name69.1"); // IN2.69.1
+        assertThat(org.getIdentifier()).hasSize(1);
+        orgId0 = org.getIdentifier().get(0);
+        assertThat(orgId0.getValue()).isEqualTo("IdValue69.10"); // IN2.69.10
+        assertThat(orgId0.getSystem()).isEqualTo("urn:id:IdSystem69.6"); // IN2.69.6
+        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "XX", null, null, null); // IN2.69.7
+
         List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
         assertThat(coverages).hasSize(1); // From IN1 segment
         Coverage coverage = (Coverage) coverages.get(0);
 
         // Confirm Coverage Identifiers - Order matches order of identifier_X in Coverage.yml
-        assertThat(coverage.getIdentifier()).hasSize(5);  // XV, XV, XV, MB, SN; but not MA (IN2.8) nor MC (IN2.6)
+        assertThat(coverage.getIdentifier()).hasSize(5); // XV, XV, XV, MB, SN; but not MA (IN2.8) nor MC (IN2.6)
         assertThat(coverage.getIdentifier().get(0).getValue()).isEqualTo("Value1"); // IN1.2.1
         assertThat(coverage.getIdentifier().get(0).getSystem()).isEqualTo("urn:id:System3"); // IN1.2.3
         assertThat(coverage.getIdentifier().get(0).getUse()).isNull(); // No use, here
@@ -228,8 +229,8 @@ class Hl7FinancialInsuranceTest {
         assertThat(coverage.getIdentifier().get(4).getSystem()).isNull(); // No system, here
         assertThat(coverage.getIdentifier().get(4).getUse()).isNull(); // No use, here
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(4).getType(), "SN",
-                "Subscriber Number" ,
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);         
+                "Subscriber Number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Confirm SubscriberId
         assertThat(coverage.getSubscriberId()).isEqualTo("MEMBER36"); // IN1.36
@@ -237,9 +238,14 @@ class Hl7FinancialInsuranceTest {
         // Confirm coverage.Order
         assertThat(coverage.getOrder()).isEqualTo(5); // IN1.22 takes priority over IN1.1
 
-        // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
+        // Confirm Coverage Beneficiary references to Patient, and Payor references correct Organizations
         assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
-        assertThat(coverage.getPayorFirstRep().getReference()).isEqualTo(organizationId);
+        assertThat(coverage.getPayor()).hasSize(2); // One for each payorOrganization
+        assertThat(coverage.getPayor().get(0).getReference()).isEqualTo(payorOrganizationId);
+        assertThat(coverage.getPayor().get(1).getReference()).isEqualTo(payorOrganizationIdIn25);
+        // Confirm policyHolder references correct organization
+        assertThat(coverage.getPolicyHolder().getReference()).isEqualTo(policyHolderOrganizationId);
+
         // Only one Coverage Class expected.  (getClass_ is correct name for method)
         assertThat(coverage.getClass_()).hasSize(3);
         checkCoverageClassExistsWithCorrectValueAndName(coverage.getClass_(), "UA34567", null); // IN1.8  Only has value
@@ -389,31 +395,31 @@ class Hl7FinancialInsuranceTest {
         assertThat(coverage.getIdentifier().get(2).getUseElement().getCode()).hasToString("old"); // Use is enumeration "old"
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(2).getType(), "XV",
                 "Health Plan Identifier",
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null); 
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
         assertThat(coverage.getIdentifier().get(3).getValue()).isEqualTo("MEMBER61"); // IN2.61 takes priority over IN1.36
         assertThat(coverage.getIdentifier().get(3).getSystem()).isNull(); // No system, here
         assertThat(coverage.getIdentifier().get(3).getUse()).isNull(); // No use, here
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(3).getType(), "MB",
                 "Member Number",
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);  
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
         assertThat(coverage.getIdentifier().get(4).getValue()).isEqualTo("MEDICAID08"); // IN2.8
         assertThat(coverage.getIdentifier().get(4).getSystem()).isNull(); // No system, here
         assertThat(coverage.getIdentifier().get(4).getUse()).isNull(); // No use, here
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(4).getType(), "MA",
-                "Patient Medicaid number" ,
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null); 
+                "Patient Medicaid number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
         assertThat(coverage.getIdentifier().get(5).getValue()).isEqualTo("MEDICARE06"); // IN2.6
         assertThat(coverage.getIdentifier().get(5).getSystem()).isNull(); // No system, here
         assertThat(coverage.getIdentifier().get(5).getUse()).isNull(); // No use, here
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(5).getType(), "MC",
-                "Patient's Medicare number" ,
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);  
+                "Patient's Medicare number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
         assertThat(coverage.getIdentifier().get(6).getValue()).isEqualTo("MEMBER36"); // IN1.36
         assertThat(coverage.getIdentifier().get(6).getSystem()).isNull(); // No system, here
         assertThat(coverage.getIdentifier().get(6).getUse()).isNull(); // No use, here
         DatatypeUtils.checkCommonCodeableConceptAssertions(coverage.getIdentifier().get(6).getType(), "SN",
-                "Subscriber Number" ,
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);                       
+                "Subscriber Number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
         assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
@@ -531,10 +537,9 @@ class Hl7FinancialInsuranceTest {
                 // IN2.25 to new PayorId Organization
                 // IN2.61 is purposely empty (primary to IN1.36) so IN1.36 will be used as the MB identifier
                 + "IN2|||||||||||||||||||||||||IdValue25.1^^^IdSystem25.4^IdType25.5^^20201231145045^20211231145045|||||||||||||||||||||||||||||||||||||||||||"
-                // IN2.69 to new Insured Organization Name and ID
+                // IN2.69 to new PolicyHolder Organization Name and ID
                 // IN2.72 is purposely empty (backup to IN1.17) so no RelatedPerson is created.
                 + "|Name69.1^^^^^IdSystem69.6^XX^^^IdValue69.10||\n";
-
 
         // TENANT prepend is passed through the options.  
         ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint()
@@ -551,8 +556,9 @@ class Hl7FinancialInsuranceTest {
         String patientId = patient.getId();
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
-        assertThat(organizations).hasSize(3); // From Payor created by IN1, PayorId Organization (IN2.25), and Insured Organization Name (IN2.69)
+        assertThat(organizations).hasSize(3); // From Payor created by IN1, PayorId Organization (IN2.25), and PolcyHolder Organization Name (IN2.69)
         Organization org = (Organization) organizations.get(0);
+        String payorOrganizationId = org.getId();
 
         // Check organization Id's
         assertThat(org.getName()).isEqualTo("Large Blue Organization"); // IN1.4
@@ -563,25 +569,27 @@ class Hl7FinancialInsuranceTest {
         assertThat(orgId0.hasPeriod()).isFalse(); // IN1.3.7 & IN1.3.7 empty
         assertThat(orgId0.hasType()).isFalse(); // IN1.3.5 empty
 
-        // Check Insured Organization Name and ID Organization from IN2.69
-        org = (Organization) organizations.get(1);
-        assertThat(org.getName()).isEqualTo("Name69.1"); // IN2.69.1
-        assertThat(org.getIdentifier()).hasSize(1);
-        orgId0 = org.getIdentifier().get(0);
-        assertThat(orgId0.getValue()).isEqualTo("TenantId.IdValue69.10"); // IN2.69.10
-        assertThat(orgId0.getSystem()).isEqualTo("urn:id:IdSystem69.6"); // IN2.69.6
-        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "XX", null, null, null); // IN2.69.7
-
         // Check PayorId Organization from IN2.25 
-        org = (Organization) organizations.get(2);
+        org = (Organization) organizations.get(1);
+        String payorOrganizationIdIn25 = org.getId();
         assertThat(org.getName()).isEqualTo("IdValue25.1"); // IN2.25.1
         assertThat(org.getIdentifier()).hasSize(1);
         orgId0 = org.getIdentifier().get(0);
-        assertThat(orgId0.getValue()).isEqualTo("TenantId.IdValue25.1"); // IN2.25.1
+        assertThat(orgId0.getValue()).isEqualTo("TenantId.IdValue25.1"); // IN2.25.1 w/TENANT. prepend
         assertThat(orgId0.getSystem()).isEqualTo("urn:id:IdSystem25.4"); // IN2.25.4
         assertThat(orgId0.getPeriod().getStartElement().toString()).containsPattern("2020-12-31T14:50:45"); // IN2.25.7
         assertThat(orgId0.getPeriod().getEndElement().toString()).containsPattern("2021-12-31T14:50:45"); // IN2.25.8
-        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "IdType25.5", null, null, null); // // IN2.25.5
+        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "IdType25.5", null, null, null); // IN2.25.5
+
+        // Check PolicyHolder Organization Name and ID Organization from IN2.69
+        org = (Organization) organizations.get(2);
+        String policyHolderOrganizationId = org.getId();
+        assertThat(org.getName()).isEqualTo("Name69.1"); // IN2.69.1
+        assertThat(org.getIdentifier()).hasSize(1);
+        orgId0 = org.getIdentifier().get(0);
+        assertThat(orgId0.getValue()).isEqualTo("TenantId.IdValue69.10"); // IN2.69.10 w/TENANT. prepend
+        assertThat(orgId0.getSystem()).isEqualTo("urn:id:IdSystem69.6"); // IN2.69.6
+        DatatypeUtils.checkCommonCodeableConceptAssertions(orgId0.getType(), "XX", null, null, null); // IN2.69.7
 
         List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
         assertThat(coverages).hasSize(1); // From IN1 segment
@@ -593,9 +601,13 @@ class Hl7FinancialInsuranceTest {
 
         // Confirm Coverage Subscriber references to Patient
         assertThat(coverage.getSubscriber().getReference()).isEqualTo(patientId);
-        // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
+        // Confirm Coverage Beneficiary references to Patient, and Payors references correct Organizations
         assertThat(coverage.getBeneficiary().getReference()).isEqualTo(patientId);
-        assertThat(coverage.getPayorFirstRep().getReference()).isEqualTo(organizations.get(0).getId());
+        assertThat(coverage.getPayor()).hasSize(2); // One for each payorOrganization
+        assertThat(coverage.getPayor().get(0).getReference()).isEqualTo(payorOrganizationId);
+        assertThat(coverage.getPayor().get(1).getReference()).isEqualTo(payorOrganizationIdIn25);
+        // Confirm policyHolder references correct organization
+        assertThat(coverage.getPolicyHolder().getReference()).isEqualTo(policyHolderOrganizationId);
 
         // Expect no RelatedPerson because IN1.17 was self
         List<Resource> relatedPersons = ResourceUtils.getResourceList(e, ResourceType.RelatedPerson);
@@ -732,7 +744,7 @@ class Hl7FinancialInsuranceTest {
         Coverage coverage = (Coverage) coverages.get(0);
 
         // Confirm Coverage Identifiers
-        assertThat(coverage.getIdentifier()).hasSize(4);  // XV, XV, MB, SN
+        assertThat(coverage.getIdentifier()).hasSize(4); // XV, XV, MB, SN
         // Coverage Identifiers deep check in testBasicInsuranceCoverageFields
 
         // Confirm Coverage Beneficiary references to Patient, and Payor references to Organization
@@ -797,7 +809,7 @@ class Hl7FinancialInsuranceTest {
                 // IN1.17 empty to verify that IN2.72 works as backup for IN1.17
                 // IN1.18 through IN1.35 NOT REFERENCED
                 + "||||||||||||||||||||"
-                // IN1.36 to Identifier 4 (MB) and Identifier 7 (SN)
+                // IN1.36 to Identifier MB and Identifier SN
                 // IN1.37 through IN1.53 NOT REFERENCED
                 + "|MEMBER36|||||||||||||||||\n"
                 // IN2.1 through IN2.71 NOT REFERENCED
@@ -829,7 +841,7 @@ class Hl7FinancialInsuranceTest {
         Coverage coverage = (Coverage) coverages.get(0);
 
         // Confirm Coverage Identifiers
-        assertThat(coverage.getIdentifier()).hasSize(4);  // XV, XV, MB, SN
+        assertThat(coverage.getIdentifier()).hasSize(4); // XV, XV, MB, SN
         // Coverage Identifiers deep check in testBasicInsuranceCoverageFields
 
         // Confirm Coverage Subscriber references to Patient


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

1. IN1.35 to Organization.identifier. This identifier will have a value only, no system or type. (PR A)


2. Coverage.payor create a separate Organization from IN2.25
     - IN2.25.1 is used to set Organization.id.
           - If a tenant is set, the id value should be <tenant>.<IN2-25.1>
           - If a tenant is not set, the id value will be just IN2-25.1
    - Organization.identifier using
       ```
       .1 identifier.value
       .4 identifier.system (urn:id:25.4)
       .5 identifier.type.code
       .7 identifier.period.start
       .8 identifier.period.end
      ```
    - Organization.name using IN2.25.1 identifier.value. **BJC: current code requires a name. L4H Converter Issue 422 will remove this requirement in the future.**


3. Coverage.policyHolder create a separate Organization from IN2.69
    - IN2.69.10 is used to set Organization.id.
         - If a tenant is set, the id value should be <tenant>.<IN2-69.10>
         - If a tenant is not set, the id value will be just IN2-69.10
    - Organization.identifier using
       ```
       .10 identifier.value
       .6 identifier.system (urn:id:69.6)
       .7 identifier.type.code
      ```
     - IN2.69.1 is used to set Organization.name
 