### PR TITLE
Addtl support to patient.idnt IN2.2,6,8

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -69,6 +69,7 @@ public enum SimpleDataTypeMapper {
   POLICYHOLDER_RELATIONSHIP(SimpleDataValueResolver.POLICYHOLDER_RELATIONSHIP),
   SUBSCRIBER_RELATIONSHIP(SimpleDataValueResolver.SUBSCRIBER_RELATIONSHIP),
   RELATED_PERSON_NEEDED(SimpleDataValueResolver.RELATED_PERSON_NEEDED),
+  SUBSCRIBER_IS_SELF(SimpleDataValueResolver.SUBSCRIBER_IS_SELF),
   UNIT_SYSTEM(SimpleDataValueResolver.UNIT_SYSTEM),
   ENCOUNTER_MODE_ARRIVAL_DISPLAY(SimpleDataValueResolver.ENCOUNTER_MODE_ARRIVAL_DISPLAY);
 

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -385,6 +385,12 @@ public class SimpleDataValueResolver {
         return getFHIRCode(val, "RelatedPersonNeeded");
     };
 
+    // Maps from IN1.17 or IN2.72 to a boolean string TRUE if the subscriber is equivalent to SELF
+    public static final ValueExtractor<Object, String> SUBSCRIBER_IS_SELF = (Object value) -> {
+        String val = Hl7DataHandlerUtil.getStringValue(value);
+        return getFHIRCode(val, "SubscriberIsSelf");
+    };
+
     public static final ValueExtractor<Object, SimpleCode> MARITAL_STATUS = (Object value) -> {
         String val = Hl7DataHandlerUtil.getStringValue(value);
         String text = Hl7DataHandlerUtil.getOriginalDisplayText(value);

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -546,3 +546,12 @@ RelatedPersonNeeded:
   17: TRUE # Minor dependent of a minor dependant input (grandchild dependent) : Grandparent
   18: TRUE # Parent : Child 
   19: TRUE # Grandparent : Grandchild 
+
+# Indicates whether the input code maps to SELF by returning TRUE.
+# FALSE and no match are equivalent.
+# Only matching codes listed because all other codes fail.
+SubscriberIsSelf:
+# Codes from IN1.17 (values from table 0063) 
+  SEL: TRUE
+# Codes from IN2.72 (values from table 0344)
+  01: TRUE  # Patient is insured : no relatedPerson

--- a/src/main/resources/hl7/message/ADT_A01.yml
+++ b/src/main/resources/hl7/message/ADT_A01.yml
@@ -22,6 +22,8 @@ resources:
       additionalSegments:
              - PD1
              - MSH
+             - INSURANCE.IN1
+             - INSURANCE.IN2
 
     - resourceName: Encounter
       segment: PV1

--- a/src/main/resources/hl7/message/ADT_A03.yml
+++ b/src/main/resources/hl7/message/ADT_A03.yml
@@ -22,6 +22,8 @@ resources:
       additionalSegments:
              - PD1
              - MSH
+             - INSURANCE.IN1
+             - INSURANCE.IN2
 
 
     - resourceName: Encounter

--- a/src/main/resources/hl7/message/ADT_A04.yml
+++ b/src/main/resources/hl7/message/ADT_A04.yml
@@ -22,6 +22,8 @@ resources:
     additionalSegments:
       - PD1
       - MSH
+      - INSURANCE.IN1
+      - INSURANCE.IN2      
 
 
   - resourceName: Encounter

--- a/src/main/resources/hl7/message/ADT_A08.yml
+++ b/src/main/resources/hl7/message/ADT_A08.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -22,6 +22,8 @@ resources:
       additionalSegments:
         - PD1
         - MSH
+        - INSURANCE.IN1
+        - INSURANCE.IN2        
 
     - resourceName: Encounter
       segment: PV1

--- a/src/main/resources/hl7/message/ADT_A28.yml
+++ b/src/main/resources/hl7/message/ADT_A28.yml
@@ -20,8 +20,10 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PD1
-             - MSH
+            - PD1
+            - MSH
+            - INSURANCE.IN1
+            - INSURANCE.IN2             
 
     - resourceName: Encounter
       segment: PV1

--- a/src/main/resources/hl7/message/ADT_A31.yml
+++ b/src/main/resources/hl7/message/ADT_A31.yml
@@ -20,8 +20,10 @@ resources:
       repeats: false
       isReferenced: true
       additionalSegments:
-             - PD1
-             - MSH
+            - PD1
+            - MSH
+            - INSURANCE.IN1
+            - INSURANCE.IN2 
 
     - resourceName: Encounter
       segment: PV1

--- a/src/main/resources/hl7/message/DFT_P03.yml
+++ b/src/main/resources/hl7/message/DFT_P03.yml
@@ -26,6 +26,7 @@ resources:
       - PD1
       - MSH
       - INSURANCE.IN1
+      - INSURANCE.IN2
 
   - resourceName: Encounter
     segment: PV1

--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -172,12 +172,12 @@ subscriber_1:
 # If the subscriber is SEL (self), do not create a relatedPerson, but reference the patient
 # NOT_NULL check is not needed because we have positive values and condition will not fire without them
 subscriber_2:
-  condition: $relatedRelationshipStr EQUALS SEL || $relatedRelationshipStr EQUALS 01
+  condition: $subscriberIsSelf EQUALS TRUE
   valueOf: datatype/Reference
   expressionType: resource
   specs: $Patient
   vars:
-    relatedRelationshipStr: String, IN1.17 | IN2.72
+    subscriberIsSelf: SUBSCRIBER_IS_SELF, IN1.17 | IN2.72 # subscriber relationship
 
 subscriberId:
   type: STRING

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,14 +19,30 @@ identifier_1:
    vars:
       assignerSystem: String, PID.3.4
 
-# Gets the SSN from PID.19, formats and adds it as an ID
-identifier_2:
-   condition: $valueIn NOT_NULL
+# When the Coverage.subscriber is not self (or is empty) use PID.19 for SSN identifier
+identifier_2a:
+   condition: $valueIn NOT_NULL && $subscriberIsSelf NOT_EQUALS TRUE
    valueOf: datatype/Identifier_var
    generateList: true
    expressionType: resource
    vars:
-      valueIn: String, PID.19
+      valueIn: String, PID.19 # subscriber SSN
+      subscriberIsSelf: SUBSCRIBER_IS_SELF, IN1.17 | IN2.72 # subscriber relationship
+   constants:
+      system: http://terminology.hl7.org/CodeSystem/v2-0203
+      code: SS
+      display: Social Security number
+# There is no text for PID.19
+
+# When the Coverage.subscriber is self use PID.19 / IN2.2 for SSN identifier
+identifier_2b:
+   condition: $valueIn NOT_NULL && $subscriberIsSelf EQUALS TRUE
+   valueOf: datatype/Identifier_var
+   generateList: true
+   expressionType: resource
+   vars:
+      valueIn: String, PID.19 | IN2.2 # subscriber SSN
+      subscriberIsSelf: SUBSCRIBER_IS_SELF, IN1.17 | IN2.72  # subscriber relationship
    constants:
       system: http://terminology.hl7.org/CodeSystem/v2-0203
       code: SS
@@ -71,6 +87,47 @@ identifier_5:
       code: IN1.49.5
    constants:
       system: http://terminology.hl7.org/CodeSystem/v2-0203
+
+# only include when the subscriber is self
+identifier_6:
+  condition: $valueIn NOT_NULL && $subscriberIsSelf EQUALS TRUE
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.61 | IN1.36
+    subscriberIsSelf: SUBSCRIBER_IS_SELF, IN1.17 | IN2.72  # subscriber relationship
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MB"
+    display: "Member Number"
+
+identifier_7:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.8
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MA"
+    display: "Patient Medicaid number"
+
+identifier_8:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.6
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MC"
+    display: "Patient's Medicare number"
 
 name:
    valueOf: datatype/HumanName
@@ -187,7 +244,7 @@ generalPractitioner:
    specs: PD1.4
    vars:
       practitionerVal: PD1.4
-      
+
 extension:
    generateList: true
    expressionType: nested

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -19,7 +19,8 @@ identifier_1:
    vars:
       assignerSystem: String, PID.3.4
 
-# When the Coverage.subscriber is not self (or is empty) use PID.19 for SSN identifier
+# NOTE: indentifier_2a and indentifier_2b can be combined when complex boolean conditions supported
+# When the Coverage.subscriber is not self use PID.19 for SSN identifier
 identifier_2a:
    condition: $valueIn NOT_NULL && $subscriberIsSelf NOT_EQUALS TRUE
    valueOf: datatype/Identifier_var
@@ -34,8 +35,23 @@ identifier_2a:
       display: Social Security number
 # There is no text for PID.19
 
-# When the Coverage.subscriber is self use PID.19 / IN2.2 for SSN identifier
+# When the Coverage.subscriber is null use PID.19 for SSN identifier
 identifier_2b:
+   condition: $valueIn NOT_NULL && $subscriberIsSelf NULL
+   valueOf: datatype/Identifier_var
+   generateList: true
+   expressionType: resource
+   vars:
+      valueIn: String, PID.19 # subscriber SSN
+      subscriberIsSelf: SUBSCRIBER_IS_SELF, IN1.17 | IN2.72 # subscriber relationship
+   constants:
+      system: http://terminology.hl7.org/CodeSystem/v2-0203
+      code: SS
+      display: Social Security number
+# There is no text for PID.19
+
+# When the Coverage.subscriber is self use PID.19 / IN2.2 for SSN identifier
+identifier_2c:
    condition: $valueIn NOT_NULL && $subscriberIsSelf EQUALS TRUE
    valueOf: datatype/Identifier_var
    generateList: true

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -103,7 +103,7 @@ class Hl7FinancialInsuranceTest {
                 // IN1.36 also to subscriberId
                 // IN1.46 to third XV Coverage.identifier
                 // IN1.49 to PatientCoverage.identifier
-                + "|MEMBER36||||||||||Value46|||PatientId49.1^^^System49.4^TypeCode49.5||||\n"
+                + "|MEMBER36||||||||||Value46|||PatientId49.1^^^System49.4^XX||||\n"
                 // IN2.6 is purposely empty so will not create an MC Coverage.identifier
                 // IN2.8 is purposely empty so will not create an MA Coverage.identifier
                 // IN2.25 to new PayorId Organization
@@ -131,7 +131,7 @@ class Hl7FinancialInsuranceTest {
         patientIdentifier = patient.getIdentifier().get(1);
         assertThat(patientIdentifier.getValue()).isEqualTo("PatientId49.1"); // IN1.49.1 
         assertThat(patientIdentifier.getSystem()).isEqualTo("urn:id:System49.4"); // IN1.49.4
-        DatatypeUtils.checkCommonCodeableConceptAssertions(patientIdentifier.getType(), "TypeCode49.5", null,
+        DatatypeUtils.checkCommonCodeableConceptAssertions(patientIdentifier.getType(), "XX", null,
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null); // IN1.49.5        
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -598,14 +598,14 @@ class Hl7FinancialInsuranceTest {
         DatatypeUtils.checkCommonCodeableConceptAssertions(patientIdentifier.getType(), "MR", "Medical record number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null); // PID.3.5
         patientIdentifier = patient.getIdentifier().get(1);
-        assertThat(patientIdentifier.getValue()).isEqualTo("SSN123456"); // IN2.2
-        assertThat(patientIdentifier.hasSystem()).isFalse(); // No system for SSN
-        DatatypeUtils.checkCommonCodeableConceptAssertions(patientIdentifier.getType(), "SS", "Social Security number",
-                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
-        patientIdentifier = patient.getIdentifier().get(2);
         assertThat(patientIdentifier.getValue()).isEqualTo("MEMBER36"); // IN1.36 backup to IN2.61, active because subscriber is SELF
         assertThat(patientIdentifier.hasSystem()).isFalse(); // No system for MB
         DatatypeUtils.checkCommonCodeableConceptAssertions(patientIdentifier.getType(), "MB", "Member Number",
+                "http://terminology.hl7.org/CodeSystem/v2-0203", null);
+        patientIdentifier = patient.getIdentifier().get(2);
+        assertThat(patientIdentifier.getValue()).isEqualTo("SSN123456"); // IN2.2
+        assertThat(patientIdentifier.hasSystem()).isFalse(); // No system for SSN
+        DatatypeUtils.checkCommonCodeableConceptAssertions(patientIdentifier.getType(), "SS", "Social Security number",
                 "http://terminology.hl7.org/CodeSystem/v2-0203", null);
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>


if subscriber=self, use IN2.2 as fallback to populate SSN patient identifier if PID-19 is empty

IN2.6 to Patient.identifier.type.coding.code=MC

IN2.8 to Patient.identifier.type.coding.code=MA

If subscriber=self, use IN2-61 for Patient.identifier.type.coding.code=MB, fallback to IN1-36:

Created SUBSCRIBER_IS_SELF check.

Added IN1, IN2 to sibling ADT_xxx messages.  (We are checking ADT_A01)