### PR TITLE
Add type.system 203 when IN2.69.7 code known

### DIFF
--- a/src/main/resources/hl7/resource/Coverage.yml
+++ b/src/main/resources/hl7/resource/Coverage.yml
@@ -156,7 +156,8 @@ policyHolder:
     orgName: String, IN2.69.1
     orgIdValue: String, IN2.69.10 # used for Id and Identifier
     orgIdSystem: String, IN2.69.6
-    orgIdTypeCode: String, IN2.69.7
+    # Using coding does intelligent system lookup, field knows its table is 0203
+    orgIdTypeCoding: CODING_SYSTEM_V2_IS_USER_DEFINED_TABLE, IN2.69.7 
 
 # If the subscriber from IN1.17 is in the list of relationship codes needing a relatedPerson, create one
 subscriber_1a:

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -53,6 +53,7 @@ identifier_2a:
     start: $orgIdStart
     end: $orgIdEnd
     code: $orgIdTypeCode
+    coding: $orgIdTypeCoding # $coding takes priority over $code
 
 # Used by IN1/Coverage (Insurance) organizations, which have a more complex identifier
 # This handles case when $TENANT is passed at run time
@@ -67,10 +68,13 @@ identifier_2b:
     start: $orgIdStart
     end: $orgIdEnd
     code: $orgIdTypeCode
+    coding: $orgIdTypeCoding  # $coding takes priority over $code
   constants:
     period: "." # period is constant used between concatention in $valueIn
 
+# Must check for empty valueIn because coding could be set
 identifier_3:
+  condition: $valueIn NOT_NULL
   valueOf: datatype/Identifier_var
   generateList: true
   expressionType: resource


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Fixes gap where we want the Organization.identifier.type to have the system.  
Because IN2.69.7 code is _assumed_ to be a v2-0203 value, we look it up. 
If it's found, we show code, display, and system
If not found in lookup, we show only code.