### PR TITLE
Replace not-valid chars in IDs

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -14,7 +14,7 @@ public enum SimpleDataTypeMapper {
   INTEGER(SimpleDataValueResolver.INTEGER),
   STRING(SimpleDataValueResolver.STRING),
   STRING_ALL(SimpleDataValueResolver.STRING_ALL),
-  LOWER_CASE_STRING(SimpleDataValueResolver.LOWER_CASE_STRING),
+  VALID_ID(SimpleDataValueResolver.VALID_ID),
   FLOAT(SimpleDataValueResolver.FLOAT),
   BASE64_BINARY(SimpleDataValueResolver.BASE64_BINARY),
 

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -90,10 +90,11 @@ public class SimpleDataValueResolver {
         return Hl7DataHandlerUtil.getStringValue(value, true);
     };
 
-    public static final ValueExtractor<Object, String> LOWER_CASE_STRING = (Object value) -> {
+    public static final ValueExtractor<Object, String> VALID_ID = (Object value) -> {
         String strValue = Hl7DataHandlerUtil.getStringValue(value);
         if (strValue != null) {
-            return strValue.toLowerCase();
+            strValue = strValue.toLowerCase();
+            return strValue.replaceAll("[^a-zA-Z0-9.]", "-");
         } 
         return null;
     };

--- a/src/main/resources/hl7/resource/Organization.yml
+++ b/src/main/resources/hl7/resource/Organization.yml
@@ -16,14 +16,14 @@ id_1:
 # $orgIdValue must be passed in to control which IN1 / IN2 is used, and prevent bleed
 id_2:
   condition: $orgIdValue NOT_NULL && $TENANT NULL
-  type: LOWER_CASE_STRING
+  type: VALID_ID
   valueOf: $orgIdValue
 
 # When there is IN1 / IN2 record and there IS a TENANT
 # $orgIdValue must be passed in to control which IN1 / IN2 is used, and prevent bleed
 id_3:
   condition: $orgIdValue NOT_NULL && $TENANT NOT_NULL
-  type: LOWER_CASE_STRING
+  type: VALID_ID
   valueOf: $orgIdWithTenantPrefix
   vars: 
     orgIdWithTenantPrefix: $TENANT + $period + $orgIdValue

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -206,6 +206,17 @@ class SimpleDataValueResolverTest {
     }
 
     @Test
+    // Tests VALID_ID
+    void testConvertToValidId() {
+        assertThat(SimpleDataValueResolver.VALID_ID.apply("A B C")).isEqualTo("a-b-c");
+        assertThat(SimpleDataValueResolver.VALID_ID.apply("A-B-C")).isEqualTo("a-b-c");
+        assertThat(SimpleDataValueResolver.VALID_ID.apply("A/B/C")).isEqualTo("a-b-c");
+        assertThat(SimpleDataValueResolver.VALID_ID.apply("Å-B-C")).isEqualTo("--b-c");
+        assertThat(SimpleDataValueResolver.VALID_ID.apply("A_B,C")).isEqualTo("a-b-c");
+        assertThat(SimpleDataValueResolver.VALID_ID.apply("A.B.C")).isEqualTo("a.b.c");
+    }
+
+    @Test
     void get_race_value_valid() throws DataTypeException {
         CWE cwe = new CWE(null);
         cwe.getCwe3_NameOfCodingSystem().setValue("HL70005");

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -211,7 +211,6 @@ class SimpleDataValueResolverTest {
         assertThat(SimpleDataValueResolver.VALID_ID.apply("A B C")).isEqualTo("a-b-c");
         assertThat(SimpleDataValueResolver.VALID_ID.apply("A-B-C")).isEqualTo("a-b-c");
         assertThat(SimpleDataValueResolver.VALID_ID.apply("A/B/C")).isEqualTo("a-b-c");
-        assertThat(SimpleDataValueResolver.VALID_ID.apply("Å-B-C")).isEqualTo("--b-c");
         assertThat(SimpleDataValueResolver.VALID_ID.apply("A_B,C")).isEqualTo("a-b-c");
         assertThat(SimpleDataValueResolver.VALID_ID.apply("A.B.C")).isEqualTo("a.b.c");
     }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Small change which ensures that not-valid characters are removed (replaced with "-") for IDs.  Tests