### PR TITLE
Check that configured resource paths are not null

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/resource/ResourceReader.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/resource/ResourceReader.java
@@ -80,17 +80,26 @@ public class ResourceReader {
    * @return The resource as a String
    */
   public String getResource(String resourcePath) {
-    Path resourceFolderFilePath = Paths.get(converterConfig.getResourceFolder(), resourcePath);
-    Path alternateResourceFolderFilePath = Paths.get(converterConfig.getAdditionalResourcesLocation(), resourcePath);
+    String resourceFolderName = converterConfig.getResourceFolder();
+    String additionalResourcesFolderName = converterConfig.getAdditionalResourcesLocation();
     String resource = null;
 
     try {
-      if (resourceFolderFilePath != null && resourceFolderFilePath.toFile().exists()) {
-        resource = loadFileResource(resourceFolderFilePath.toFile());
-      } 
-      if (resource == null && alternateResourceFolderFilePath != null && alternateResourceFolderFilePath.toFile().exists()) {
-        resource = loadFileResource(alternateResourceFolderFilePath.toFile());
-      } 
+      if (resourceFolderName != null) {
+        Path resourceFolderFilePath = Paths.get(resourceFolderName, resourcePath);
+        if (resourceFolderFilePath.toFile().exists()) {
+          resource = loadFileResource(resourceFolderFilePath.toFile());
+        }
+      }
+
+      if (resource == null && additionalResourcesFolderName != null) {
+        Path alternateResourceFolderFilePath = Paths.get(additionalResourcesFolderName, resourcePath);
+
+        if (alternateResourceFolderFilePath.toFile().exists()) {
+          resource = loadFileResource(alternateResourceFolderFilePath.toFile());
+        }
+      }
+
       if (resource == null) {
         resource = loadClassPathResource(resourcePath);
       }

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -2,3 +2,4 @@ base.path.resource=
 supported.hl7.messages=ADT_A01, ADT_A03, ADT_A08, ADT_A34, ADT_A40, DFT_P03, MDM_T02, MDM_T06, OML_O21, ORM_O01, OMP_O09, ORU_R01, PPR_PC1, RDE_O11, RDE_O25, VXU_V04
 default.zoneid=+08:00
 additional.conceptmap.file=
+additional.resources.location=


### PR DESCRIPTION
Previously, the `String` from the configuration would always be passed to `Paths.get`. On openjdk >=16 passing `null` to `Paths.get` throws a `NullPointerException` (see https://bugs.openjdk.java.net/browse/JDK-8254876), so this would occur if a configuration option was missing. `additional.resources.location` was not included in the default `config.properties`, so the `NullPointerException` was always being thrown.

This change moves the `null` checks before `Paths.get` is called. It also adds `additional.resources.location` to the `config.properties`, mostly as an example since it is not strictly necessary.

I'm not able to run the test suite with openjdk 17 for unrelated reasons, but I did confirm that if I build from this branch and use that as a dependency in my application I can run it successfully with openjdk 17.

Resolves https://github.com/LinuxForHealth/hl7v2-fhir-converter/issues/427