### PR TITLE
Use '-' in all ids for bad chars

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtils.java
@@ -284,7 +284,7 @@ public class Hl7RelatedGeneralUtils {
             // This replaces any special character (other than letters, numbers, dashes, or periods) with a period
             // Then lower-cases, and truncates to 64 characters.
             String stringValue = Hl7DataHandlerUtil.getStringValue(input).trim();
-            stringValue = stringValue.replaceAll("[^a-zA-Z0-9\\-\\.]", ".").toLowerCase();
+            stringValue = stringValue.replaceAll("[^a-zA-Z0-9\\-\\.]", "-").toLowerCase();
             return StringUtils.left(stringValue, 64);
         }
         return null;

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -361,9 +361,9 @@ class Hl7RelatedGeneralUtilsTest {
     void testGetFormatAsId() {
 
         // Inputs are any string
-        assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo.clinic");
+        assertThat(Hl7RelatedGeneralUtils.formatAsId("Mayo Clinic")).isEqualTo("mayo-clinic");
         assertThat(Hl7RelatedGeneralUtils.formatAsId("OMC")).isEqualTo("omc");
-        assertThat(Hl7RelatedGeneralUtils.formatAsId("   4 5 6  ")).isEqualTo("4.5.6");
+        assertThat(Hl7RelatedGeneralUtils.formatAsId("   4 5 6  ")).isEqualTo("4-5-6");
 
         // Edge cases (if these occur we might have name space collisions)
         // The input is trimmed so totally blank input becomes empty

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -162,7 +162,7 @@ class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/ssh.weymouth");
+        assertThat(providerString).isEqualTo("Organization/ssh-weymouth");
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
         assertThat(organizations).hasSize(1);
@@ -254,7 +254,7 @@ class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/toronto.east"); // Also verify underscore replacement for Utility.formatAsId
+        assertThat(providerString).isEqualTo("Organization/toronto-east"); // Also verify underscore replacement for Utility.formatAsId
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
         assertThat(organizations).hasSize(1);
@@ -288,7 +288,7 @@ class Hl7EncounterFHIRConversionTest {
         Reference serviceProvider = encounter.getServiceProvider();
         assertThat(serviceProvider).isNotNull();
         String providerString = serviceProvider.getReference();
-        assertThat(providerString).isEqualTo("Organization/ssh.weymouth.west.build-7.f");
+        assertThat(providerString).isEqualTo("Organization/ssh-weymouth-west-build-7.f");
 
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
         assertThat(organizations).hasSize(1);


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Small change as agreed to force all non-valid chars in id's to '-'.  (Instead of '.')

This does not merge Organization_ServiceProvider back into Organization.   That will be done in a future PR which will push all ID validate-ifying through the same process.

This is to correct failing tests in GT.
