### PR TITLE
Fix IN1.49 Pat.ident; add SrvPrv Org sys & tests

### DIFF
--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -253,3 +253,5 @@ serviceProvider:
   vars:
     orgName: String, PV2.23.1 | PV1.3.4.1
     orgIdValue: String, PV2.23.8 | PV1.3.4.1  # used for Id and Identifier
+  constants:   
+    orgIdSystem: 'extId'  # 'urn:id:' added by SystemCX processing

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -124,8 +124,8 @@ identifier_4:
       mrgIdentifier: MRG.1
 # Add the old MR # from the MRG segment
 
-# identifier_5a and _5b and _5c are three parts to complex logic
-# Only include IN1.49 as an identifier when the subscriber is not self AND a relatedPerson is created uses IN1.17
+# identifier_5a and _5b are two parts to complex logic
+# Only include IN1.49 as an identifier when the subscriber is not self AND a relatedPerson is created
 identifier_5a:
    condition: $valueIn NOT_NULL && $subscriberValue NOT_EQUALS SEL && $createRelatedPerson EQUALS TRUE
    valueOf: datatype/Identifier_var

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -124,8 +124,10 @@ identifier_4:
       mrgIdentifier: MRG.1
 # Add the old MR # from the MRG segment
 
-identifier_5:
-   condition: $valueIn NOT_NULL
+# identifier_5a and _5b and _5c are three parts to complex logic
+# Only include IN1.49 as an identifier when the subscriber is not self AND a relatedPerson is created uses IN1.17
+identifier_5a:
+   condition: $valueIn NOT_NULL && $subscriberValue NOT_EQUALS SEL && $createRelatedPerson EQUALS TRUE
    valueOf: datatype/Identifier_var
    generateList: true
    expressionType: resource
@@ -134,8 +136,26 @@ identifier_5:
       valueIn: String, IN1.49.1
       systemCX: IN1.49.4
       code: IN1.49.5
+      subscriberValue: String, IN1.17.1 # subscriber relationship
+      createRelatedPerson: RELATED_PERSON_NEEDED_IN117, IN1.17 
    constants:
       system: http://terminology.hl7.org/CodeSystem/v2-0203
+
+identifier_5b:
+   condition: $valueIn NOT_NULL && $valueIN117 NULL && $subscriberValue NOT_EQUALS 01 && $createRelatedPerson EQUALS TRUE
+   valueOf: datatype/Identifier_var
+   generateList: true
+   expressionType: resource
+   specs: IN1.49
+   vars:
+      valueIn: String, IN1.49.1
+      systemCX: IN1.49.4
+      code: IN1.49.5
+      subscriberValue: String, IN2.72 # subscriber relationship
+      createRelatedPerson: RELATED_PERSON_NEEDED_IN272, IN2.72
+      valueIN117: IN1.17.1
+   constants:
+      system: http://terminology.hl7.org/CodeSystem/v2-0203          
 
 # identifier_6a and _6b are two parts to complex logic
 # Only include when the subscriber is self, uses IN1.17

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7EncounterFHIRConversionTest.java
@@ -170,6 +170,9 @@ class Hl7EncounterFHIRConversionTest {
         Organization orgResource = ResourceUtils.getResourceOrganization(organizations.get(0), context);
         assertThat(orgResource.getId()).isEqualTo(providerString);
         assertThat(orgResource.getName()).isEqualTo("South Shore Hosptial Weymouth");
+        assertThat(orgResource.getIdentifier()).hasSize(1);
+        assertThat(orgResource.getIdentifierFirstRep().getValue()).hasToString("SSH_WEYMOUTH"); // PV2.23.1
+        assertThat(orgResource.getIdentifierFirstRep().getSystem()).hasToString("urn:id:extId"); // Because ID is name based
     }
 
     // Test for serviceProvider reference in messages with both PV1 and PV2 segments
@@ -216,6 +219,9 @@ class Hl7EncounterFHIRConversionTest {
         Organization orgResource = ResourceUtils.getResourceOrganization(organizations.get(0), context);
         assertThat(orgResource.getId()).isEqualTo(providerString);
         assertThat(orgResource.getName()).isEqualTo("South Shore Hosptial Weymouth");
+        assertThat(orgResource.getIdentifier()).hasSize(1);
+        assertThat(orgResource.getIdentifierFirstRep().getValue()).hasToString("Toronto"); // PV1.3.4.1
+        assertThat(orgResource.getIdentifierFirstRep().getSystem()).hasToString("urn:id:extId"); // Because ID is name based
     }
 
     // Test for serviceProvider reference in messages with PV1 segment and no PV2 segment
@@ -261,7 +267,10 @@ class Hl7EncounterFHIRConversionTest {
 
         Organization orgResource = ResourceUtils.getResourceOrganization(organizations.get(0), context);
         assertThat(orgResource.getId()).isEqualTo(providerString);
-        assertThat(orgResource.getName()).isEqualTo("Toronto East");
+        assertThat(orgResource.getName()).isEqualTo("Toronto East"); // PV1.3.4.1
+        assertThat(orgResource.getIdentifier()).hasSize(1);
+        assertThat(orgResource.getIdentifierFirstRep().getValue()).hasToString("Toronto East"); // PV1.3.4.1
+        assertThat(orgResource.getIdentifierFirstRep().getSystem()).hasToString("urn:id:extId"); // Because ID is name based
     }
 
     @Test
@@ -296,6 +305,9 @@ class Hl7EncounterFHIRConversionTest {
         Organization orgResource = ResourceUtils.getResourceOrganization(organizations.get(0), context);
         assertThat(orgResource.getId()).isEqualTo(providerString);
         assertThat(orgResource.getName()).isEqualTo("South Shore Hosptial Weymouth");
+        assertThat(orgResource.getIdentifier()).hasSize(1);
+        assertThat(orgResource.getIdentifierFirstRep().getValue()).hasToString("SSH*WEYMOUTH WEST_BUILD-7.F"); // PV2.23.1
+        assertThat(orgResource.getIdentifierFirstRep().getSystem()).hasToString("urn:id:extId"); // Because ID is name based
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Fixes problem where system was not provided for ServiceProvider Organization identifier.  Adds tests so this is found in the future.

Fixes problem where IN1.49 was incorrectly used as a Patient identifier when the relationship was not self, but no RelatedPerson created.  