### PR TITLE
#442 Thread-safe context ZoneId dateTime handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The converter allows passing of certain parameters at run time through the optio
  
 | Parameter Name           | Description                                                                                                                                                                       | Example Call on Options Creation                    |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| ZoneIdText     | ZoneId override for the ISO 8601 timezone offset. Overrides default.zoneid in config.properties. Requires a valid ZoneId text value, which is converted to a java.time.ZoneId.            | options.withZoneIdText("+07:00")      |
+| ZoneIdText     | ZoneId override for the ISO 8601 timezone offset. Overrides default.zoneid in config.properties. Requires a valid ZoneId text value, which is converted to a java.time.ZoneId.            | options.withZoneIdText("+07:00")   options.withZoneIdText("America/Chicago")   |
 | Property (Key/Value)  | A string property expressed as a key / value pair.  Properties become available as variables to the templates.  A property `TENANT` with value `myTenantId` is utilized in templates as `$TENANT`.             | options.withProperty("TENANT","myTenantId")      |
 
 

--- a/TECHNIQUES.md
+++ b/TECHNIQUES.md
@@ -98,6 +98,24 @@ public static String getAddressDistrict(String patientCountyPid12, String addres
         return returnDistrict;
     }
 ```
+
+## Time
+
+Time conversion and formatting utilities are available, but they must be called in a thread-safe way.  The time ZoneId may be specified as a default in `config.properties` value `default.zoneid=+08:00` or passed in via runtime context using `.withZoneIdText("-05:00")`.  The value of the input `ZoneIdText` is available as the system variable `$ZONEID` and should be used in all time conversions where a time zone is needed. `GeneralUtils.dateTimeWithZoneId` takes an input HL7 time value field and converts it using the ZoneIdText of the current context.  The timezone should not be stored by any static method, accessing the ZoneIdText via the system variable makes the time processing threadsafe.
+```yaml
+time:
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: NTE.6 | NTE.7
+```
+The rules for determining a time zone for a date time value are:
+1. If a DateTime from HL7 contains it's own ZoneId in the DateTime, use it.
+1. If it has no ZoneId, and the context ZoneIdText is set, use that.
+1. If it has no ZoneId, and no context ZoneIdText, but there is a config ZoneId, use that.
+1. If it has no ZoneId, and no context ZoneIdText, and no config ZoneId, use the local timezone (whichis the ZoneId of the server where the process is running).
+
 ## YAML Hints
 
 Hints about the ways syntax and references work in the YAML files

--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -174,9 +174,11 @@ subject:
     specs: $Patient
 
 onsetDateTime:
-     type: DATE_TIME
-     valueOf: PRB.16
-     expressionType: HL7Spec
+    type: STRING
+    valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+    expressionType: JEXL
+    vars: 
+        dateTimeIn: PRB.16
 
 stage:
    valueOf: secondary/Stage

--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -245,6 +245,12 @@ Specification represents the base value for a expression. There are two types of
 * SimpleSpecification  -- Represents simple specification that can be extracted from context values. Example: specs: $Patient. Note BASE_VALUE is reserved for base value provided to an expression during evaluation. Do not use or name variable as BASE_VALUE.
 * HL7Specification -- Represents specification for extracting values from HL7 message.
 
+#### Reserved Variable Names
+You may name your variables anything, with the exception of the following, which are reserved for system use.
+* **BASE_VALUE** - base value provided to an expression during evaluation.
+* **TENANT** - convention for id of the tenant, when passed in at run-time.
+* **ZONEID** - zoneId if passed in at run-time; usually set to the tenant zoneId.  
+
 ##### HL7Specification
 
 HL7Specification represents expression that helps to identify the value to extracted from the HL7 message.<br>

--- a/src/main/java/io/github/linuxforhealth/core/config/ConverterConfiguration.java
+++ b/src/main/java/io/github/linuxforhealth/core/config/ConverterConfiguration.java
@@ -138,17 +138,6 @@ public class ConverterConfiguration {
     return zoneId;
   }
 
-  // Allow override of the ZoneId used for TimeZone operations
-  public void setZoneId(String zoneText) {
-    try {
-      zoneId = ZoneId.of(zoneText);
-    } catch (DateTimeException e) {
-      LOGGER.warn("Cannot create ZoneId");
-      LOGGER.debug("Cannot create ZoneId from :" + zoneText, e);
-      // Leave zoneId as it was.
-    }
-  }
-
   public String getAdditionalConceptmapFile() {
     return additionalConceptmapFile;
   }

--- a/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
+++ b/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
@@ -33,6 +33,7 @@ public class FHIRContext {
     private static FhirValidator validator;
     private boolean validateResource;
     private HashMap<String, String> properties;
+    private String zoneIdText;
 
     /**
      * Constructor for FHIRContext
@@ -42,11 +43,12 @@ public class FHIRContext {
      * @param properties Run-time properties in a Map of Key / Value String pairs
      * 
      */
-    public FHIRContext(boolean isPrettyPrint, boolean validateResource, Map<String,String> properties) {
+    public FHIRContext(boolean isPrettyPrint, boolean validateResource, Map<String,String> properties, String zoneIdText) {
         parser = CTX.newJsonParser();
         parser.setPrettyPrint(isPrettyPrint);
         this.validateResource = validateResource;
         this.properties = (HashMap<String, String>) properties;
+        this.zoneIdText = zoneIdText;
 
     }
 
@@ -58,11 +60,11 @@ public class FHIRContext {
      * 
      */
     public FHIRContext(boolean isPrettyPrint, boolean validateResource) {
-        this(isPrettyPrint, validateResource, new HashMap<>());
+        this(isPrettyPrint, validateResource, new HashMap<>(),null);
     }
 
     public FHIRContext() {
-        this(Constants.DEFAULT_PRETTY_PRINT, false, new HashMap<>());
+        this(Constants.DEFAULT_PRETTY_PRINT, false, new HashMap<>(),null);
     }
 
     public IParser getParser() {
@@ -80,6 +82,10 @@ public class FHIRContext {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public String getZoneIdText() {
+        return zoneIdText;
     }
 
     public String encodeResourceToString(Bundle bundle){

--- a/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
 import ca.uhn.hl7v2.util.Hl7InputStreamMessageStringIterator;
-import io.github.linuxforhealth.core.config.ConverterConfiguration;
 import io.github.linuxforhealth.core.terminology.TerminologyLookup;
 import io.github.linuxforhealth.core.terminology.UrlLookup;
 import io.github.linuxforhealth.fhir.FHIRContext;
@@ -139,10 +138,6 @@ public class HL7ToFHIRConverter {
             engine = getMessageEngine(options);
         }
 
-        // If zoneIdText has been provide via run properties, it overrides the default and any value from the config file.
-        if (options.getZoneIdText()!=null) {
-            ConverterConfiguration.getInstance().setZoneId(options.getZoneIdText());
-        }
 
         Message hl7message = getHl7Message(hl7MessageData);
         if (hl7message != null) {
@@ -160,7 +155,7 @@ public class HL7ToFHIRConverter {
 
     private HL7MessageEngine getMessageEngine(ConverterOptions options){
         Preconditions.checkArgument(options != null, "options cannot be null.");
-        FHIRContext context = new FHIRContext(options.isPrettyPrint(), options.isValidateResource(), options.getProperties());
+        FHIRContext context = new FHIRContext(options.isPrettyPrint(), options.isValidateResource(), options.getProperties(), options.getZoneIdText());
 
         return new HL7MessageEngine(context, options.getBundleType());
     }

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataTypeMapper.java
@@ -20,14 +20,10 @@ public enum SimpleDataTypeMapper {
 
   URI(SimpleDataValueResolver.URI_VAL),
   URL(SimpleDataValueResolver.STRING),
-  INSTANT(SimpleDataValueResolver.INSTANT),
 
   DATE(SimpleDataValueResolver.DATE),
 
-  DATE_TIME(SimpleDataValueResolver.DATE_TIME),
-  //TIME(SimpleDataValueResolver.TIME_TYPE),
   ID(SimpleDataValueResolver.STRING),
-  //MARKDOWN(SimpleDataValueResolver.STRING),
   UNSIGNEDINT(SimpleDataValueResolver.INTEGER),
   POSITIVEINT(SimpleDataValueResolver.INTEGER),
   UUID(SimpleDataValueResolver.UUID_VAL),
@@ -41,7 +37,6 @@ public enum SimpleDataTypeMapper {
   SYSTEM_ID(SimpleDataValueResolver.SYSTEM_ID),
   DOSE_SYSTEM(SimpleDataValueResolver.DOSE_SYSTEM),
   DOSE_VALUE(SimpleDataValueResolver.DOSE_VALUE),
-  PV1_DURATION_LENGTH(SimpleDataValueResolver.PV1_DURATION_LENGTH),
 
   ALLERGY_INTOLERANCE_CATEGORY(SimpleDataValueResolver.ALLERGY_INTOLERANCE_CATEGORY_CODE_FHIR),
   ALLERGY_INTOLERANCE_CRITICALITY(

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -14,15 +14,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.Temporal;
-import java.time.temporal.UnsupportedTemporalTypeException;
-
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
 import ca.uhn.hl7v2.model.v26.datatype.PPN;
 import ca.uhn.hl7v2.model.v26.datatype.XCN;
-import ca.uhn.hl7v2.model.v26.segment.PV1;
-import ca.uhn.hl7v2.model.v26.datatype.DTM;
 
 import ca.uhn.hl7v2.model.Varies;
 import org.apache.commons.lang3.BooleanUtils;
@@ -74,13 +68,6 @@ public class SimpleDataValueResolver {
         return null;
     };
 
-    public static final ValueExtractor<Object, String> DATE_TIME = (Object value) -> {
-        String val = Hl7DataHandlerUtil.getStringValue(value);
-        if (val != null) {
-            return DateUtil.formatToDateTimeWithZone(val);
-        }
-        return null;
-    };
 
     public static final ValueExtractor<Object, String> STRING = (Object value) -> {
         return Hl7DataHandlerUtil.getStringValue(value);
@@ -96,46 +83,6 @@ public class SimpleDataValueResolver {
             strValue = strValue.toLowerCase();
             return strValue.replaceAll("[^a-zA-Z0-9.]", "-");
         } 
-        return null;
-    };
-
-    public static final ValueExtractor<Object, String> INSTANT = (Object value) -> {
-        String val = Hl7DataHandlerUtil.getStringValue(value);
-        if (val != null) {
-            return DateUtil.formatToZonedDateTime(val);
-        }
-        return null;
-    };
-
-    // Special extractor only for use with PV1 records.
-    // Extract the admit and discharge time and calculate duration length.
-    // Returns null if for any reason the data is not usable, which
-    // allows use of secondary values or to stop display.
-    public static final ValueExtractor<Object, String> PV1_DURATION_LENGTH = (Object value) -> {
-        if (value instanceof PV1) {
-            PV1 pv1 = (PV1) value;
-            DTM start = pv1.getAdmitDateTime();
-            DTM end = pv1.getDischargeDateTime();
-
-            try {
-                String sdate1 = Hl7DataHandlerUtil.getStringValue(start);
-                String sdate2 = Hl7DataHandlerUtil.getStringValue(end);
-                if (sdate1 != null && sdate2 != null) {
-                    Temporal date1 = DateUtil.getTemporal(DateUtil.formatToDateTimeWithZone(sdate1));
-                    Temporal date2 = DateUtil.getTemporal(DateUtil.formatToDateTimeWithZone(sdate2));
-                    LOGGER.info("computing temporal dates");
-                    LOGGER.debug("temporal dates start: {} , end: {} ", date1, date2);
-                    if (date1 != null && date2 != null) {
-                        return String.valueOf(ChronoUnit.MINUTES.between(date1, date2));
-                    }
-                }
-            } catch (UnsupportedTemporalTypeException e) {
-                LOGGER.warn("Cannot evaluate time difference.");
-                LOGGER.debug("Cannot evaluate time difference for start: {} , end: {} reason {} ", start, end,
-                        e.getMessage());
-                return null;
-            }
-        }
         return null;
     };
 

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -103,6 +103,10 @@ public class HL7MessageEngine implements MessageEngine {
         for (Map.Entry<String,String> entry : getFHIRContext().getProperties().entrySet()){
             localContextValues.put(entry.getKey(), new SimpleEvaluationResult<String>(entry.getValue()));
         }
+        // Add the ZoneId runtime property to localContextVariables
+        // If it is not passed in (null), use "" (empty) to satisfy parser null checks in .yml parsing
+        String zoneIdText =  getFHIRContext().getZoneIdText() != null ? getFHIRContext().getZoneIdText() : "";
+        localContextValues.put("ZONEID", new SimpleEvaluationResult<String>(zoneIdText));
  
         List<ResourceResult> resourceResultsWithEvalLater = new ArrayList<>();
         for (FHIRResourceTemplate genericTemplate : resources) {

--- a/src/main/resources/hl7/datatype/Annotation.yml
+++ b/src/main/resources/hl7/datatype/Annotation.yml
@@ -1,23 +1,27 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 # When annotationText is a concatenation of multiple NTE records, the first NTE.5 is used
 # to create the practitioner reference.  Other NTE.5's are ignored.
 authorReference:
-   condition: $performer NOT_NULL
-   valueOf: resource/Practitioner
-   expressionType: reference
-   specs: NTE.5
-   vars:
-      performer: NTE.5
+  condition: $performer NOT_NULL
+  valueOf: resource/Practitioner
+  expressionType: reference
+  specs: NTE.5
+  vars:
+    performer: NTE.5
+ 
 time:
-   type: DATE_TIME
-   valueOf: NTE.6 | NTE.7
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: NTE.6 | NTE.7
+
 text:
-   type: STRING
-   valueOf: $annotationText | NTE.3
-   required: true
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: $annotationText | NTE.3
+  required: true
+  expressionType: HL7Spec

--- a/src/main/resources/hl7/datatype/Attachment.yml
+++ b/src/main/resources/hl7/datatype/Attachment.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -9,18 +9,18 @@
 # From the spec: The contentType element SHALL always be populated when an Attachment contains data.  Identifies the type of the data in the attachment,
 # as a mime type.  Common mime types are available at https://terminology.hl7.org/2.1.0/CodeSystem-v2-0834.html
 contentType:
-    type: STRING
-    valueOf: $mime
+  type: STRING
+  valueOf: $mime
 
 # From the spec: The human language of the content. The value can be any valid value according to BCP 47.
 language:
-    type: STRING
-    valueOf: $language
+  type: STRING
+  valueOf: $language
 
 # From the spec: The actual data of the attachment - a sequence of bytes, base64 encoded.
 data:
-    type: BASE64_BINARY
-    valueOf: $data
+  type: BASE64_BINARY
+  valueOf: $data
 
 # The hl7v2-fhir-converter will not set the url field.  Since the converter is returning only json (not creating any files)
 # and putting information in the data field, the uri field will not be set.  If desired, the user could set the url field
@@ -39,10 +39,13 @@ data:
 
 # From the spec: A label or set of text to display in place of the data.
 title:
-    type: STRING
-    valueOf: $title
+  type: STRING
+  valueOf: $title
 
 # From the spec: The date that the attachment was first created.
 creation:
-    type: DATE_TIME
-    valueOf: $date
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: $date

--- a/src/main/resources/hl7/datatype/Period.yml
+++ b/src/main/resources/hl7/datatype/Period.yml
@@ -1,13 +1,19 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-start: 
-     type: DATE_TIME
-     valueOf: $start
-      
+start:
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: $start
+
 end:
-   type: DATE_TIME
-   valueOf: $end
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: $end

--- a/src/main/resources/hl7/extension/ExtensionMeta.yml
+++ b/src/main/resources/hl7/extension/ExtensionMeta.yml
@@ -1,73 +1,79 @@
+#
+# (C) Copyright IBM Corp. 2021, 2022
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 extension_1:
-   generateList: true
-   valueOf: extension/Extension
-   expressionType: resource
-   vars:
-      value: String, MSH.3
-   constants:
-      KEY_NAME_SUFFIX: String
-      urlValue: process-client-id
+  generateList: true
+  valueOf: extension/Extension
+  expressionType: resource
+  vars:
+    value: String, MSH.3
+  constants:
+    KEY_NAME_SUFFIX: String
+    urlValue: process-client-id
 
 extension_2:
-   generateList: true
-   valueOf: extension/Extension
-   expressionType: resource
-   vars:
-      value: String, MSH.12.1
-   constants:
-      KEY_NAME_SUFFIX: String
-      urlValue: source-data-model-version
+  generateList: true
+  valueOf: extension/Extension
+  expressionType: resource
+  vars:
+    value: String, MSH.12.1
+  constants:
+    KEY_NAME_SUFFIX: String
+    urlValue: source-data-model-version
 
 extension_3:
-   generateList: true
-   valueOf: extension/Extension
-   expressionType: resource
-   vars:
-      value: String, MSH.10
-   constants:
-      KEY_NAME_SUFFIX: String
-      urlValue: source-record-id
+  generateList: true
+  valueOf: extension/Extension
+  expressionType: resource
+  vars:
+    value: String, MSH.10
+  constants:
+    KEY_NAME_SUFFIX: String
+    urlValue: source-record-id
 
 extension_4:
-   generateList: true
-   valueOf: extension/Extension
-   expressionType: resource
-   vars:
-      value: DATE_TIME, MSH.7
-   constants:
-      KEY_NAME_SUFFIX: DateTime
-      urlValue: source-event-timestamp
+  generateList: true
+  valueOf: extension/Extension
+  expressionType: resource
+  vars:
+    value: MSH.7, GeneralUtils.dateTimeWithZoneId(value,ZONEID)
+  constants:
+    KEY_NAME_SUFFIX: DateTime
+    urlValue: source-event-timestamp
 
 extension_5:
-   generateList: true
-   expressionType: nested
-   expressionsMap:
-      url:
-         type: SYSTEM_URL
-         value: 'source-record-type'
-      valueCodeableConcept:
-         valueOf: datatype/CodeableConcept_var
-         expressionType: resource
-         vars:
-            system: SYSTEM_URL, $system_code
-            code: String, MSH.9.1
-            display: $NULL
-         constants:
-            system_code: 'source-record-type-system'
+  generateList: true
+  expressionType: nested
+  expressionsMap:
+    url:
+      type: SYSTEM_URL
+      value: "source-record-type"
+    valueCodeableConcept:
+      valueOf: datatype/CodeableConcept_var
+      expressionType: resource
+      vars:
+        system: SYSTEM_URL, $system_code
+        code: String, MSH.9.1
+        display: $NULL
+      constants:
+        system_code: "source-record-type-system"
 
 extension_6:
-   generateList: true
-   expressionType: nested
-   expressionsMap:
-      url:
-         type: SYSTEM_URL
-         value: 'source-event-trigger'
-      valueCodeableConcept:
-         valueOf: datatype/CodeableConcept_var
-         expressionType: resource
-         vars:
-            system: SYSTEM_URL, $system_code
-            code: String, MSH.9.2
-            display: $NULL
-         constants:
-            system_code: 'source-event-trigger-system'
+  generateList: true
+  expressionType: nested
+  expressionsMap:
+    url:
+      type: SYSTEM_URL
+      value: "source-event-trigger"
+    valueCodeableConcept:
+      valueOf: datatype/CodeableConcept_var
+      expressionType: resource
+      vars:
+        system: SYSTEM_URL, $system_code
+        code: String, MSH.9.2
+        display: $NULL
+      constants:
+        system_code: "source-event-trigger-system"

--- a/src/main/resources/hl7/resource/AllergyIntolerance.yml
+++ b/src/main/resources/hl7/resource/AllergyIntolerance.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -7,7 +7,7 @@
 resourceType: AllergyIntolerance
 id:
   type: STRING
-  valueOf: 'UUID.randomUUID()'
+  valueOf: "UUID.randomUUID()"
   expressionType: JEXL
 
 identifier:
@@ -21,51 +21,53 @@ identifier:
     sys: "urn:id:extID"
 
 clinicalStatus:
-   valueOf: datatype/CodeableConcept_var
-   generateList: true
-   expressionType: resource
-   constants:
-      system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical'
-      code: 'active'
-      display: 'Active'
-    
-verificationStatus: 
-   valueOf: datatype/CodeableConcept_var
-   generateList: true
-   expressionType: resource
-   constants:
-      system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification'
-      code: 'confirmed'
-      display: 'Confirmed'
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"
+    code: "active"
+    display: "Active"
+
+verificationStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification"
+    code: "confirmed"
+    display: "Confirmed"
 
 category:
-    type: ALLERGY_INTOLERANCE_CATEGORY
-    generateList: true
-    valueOf: AL1.2
-    expressionType: HL7Spec
-    
+  type: ALLERGY_INTOLERANCE_CATEGORY
+  generateList: true
+  valueOf: AL1.2
+  expressionType: HL7Spec
+
 criticality:
-    type: ALLERGY_INTOLERANCE_CRITICALITY 
-    valueOf: AL1.4
-    expressionType: HL7Spec
-    
+  type: ALLERGY_INTOLERANCE_CRITICALITY
+  valueOf: AL1.4
+  expressionType: HL7Spec
+
 code:
-   valueOf: datatype/CodeableConcept
-   generateList: true
-   expressionType: resource
-   specs: AL1.3
+  valueOf: datatype/CodeableConcept
+  generateList: true
+  expressionType: resource
+  specs: AL1.3
 
 onsetDateTime:
-   type: DATE_TIME
-   valueOf: AL1.6
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: AL1.6
 
 patient:
-    valueOf: datatype/Reference
-    expressionType: resource
-    specs: $Patient
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Patient
 
 reaction:
-    valueOf: secondary/Reaction
-    expressionType: resource
-    specs: AL1.5
+  valueOf: secondary/Reaction
+  expressionType: resource
+  specs: AL1.5

--- a/src/main/resources/hl7/resource/Condition.yml
+++ b/src/main/resources/hl7/resource/Condition.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -126,27 +126,25 @@ asserter:
      asserterVal: DG1.16
 
 recordedDate:
-   type: DATE_TIME
-   valueOf: DG1.19 | PRB.2
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+  expressionType: JEXL
+  vars: 
+    dateTimeIn: DG1.19 | PRB.2      
 
 abatementDateTime:
-  type: DATE_TIME
-  valueOf: PRB.9
-  expressionType: HL7Spec
-
-verificationStatus:
-  valueOf: datatype/CodeableConcept
-  generateList: true
-  expressionType: resource
-  specs: PRB.13
-  vars:
-    code: PRB.13
+  type: STRING
+  valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+  expressionType: JEXL
+  vars: 
+    dateTimeIn: PRB.9 
 
 onsetDateTime:
-  type: DATE_TIME
-  valueOf: PRB.16 | DG1.5
-  expressionType: HL7Spec
+  type: STRING
+  valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+  expressionType: JEXL
+  vars: 
+    dateTimeIn: PRB.16 | DG1.5    
 
 onsetString:
   condition: $onsetDateTime NULL
@@ -156,12 +154,12 @@ onsetString:
   vars:
     onsetDateTime: PRB.16  #DG1.5 not referenced for onsetDateTime as there is currently not a fallback DG1 segment to use for a onset string
 
-extension_1:
+extension:
    generateList: true
    valueOf: extension/Extension
    expressionType: resource
    vars:
-      value: DATE_TIME, PRB.7
+      value: PRB.7, GeneralUtils.dateTimeWithZoneId(value,ZONEID)  
    constants:
       KEY_NAME_SUFFIX: DateTime
       urlValue: condition-assertedDate

--- a/src/main/resources/hl7/resource/DiagnosticReport.yml
+++ b/src/main/resources/hl7/resource/DiagnosticReport.yml
@@ -1,153 +1,156 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 resourceType: DiagnosticReport
 id:
-   type: STRING
-   valueOf: 'UUID.randomUUID()'
-   expressionType: JEXL
+  type: STRING
+  valueOf: "UUID.randomUUID()"
+  expressionType: JEXL
 
 identifier_1:
-   valueOf: datatype/Identifier
-   generateList: true
-   expressionType: resource
-   vars:
-      value: MSH.7
-      system: SYSTEM_URL, $sys
-   constants:
-      sys: "urn:id:extID"
+  valueOf: datatype/Identifier
+  generateList: true
+  expressionType: resource
+  vars:
+    value: MSH.7
+    system: SYSTEM_URL, $sys
+  constants:
+    sys: "urn:id:extID"
 
 identifier_2:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   expressionType: resource
-   vars:
-      valueIn: ORC.3.1 | OBR.3.1
-      systemCX: ORC.3.2 | OBR.3.2
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "FILL"
-      display: "Filler Identifier"
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: ORC.3.1 | OBR.3.1
+    systemCX: ORC.3.2 | OBR.3.2
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "FILL"
+    display: "Filler Identifier"
 
 identifier_3:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   expressionType: resource
-   vars:
-      valueIn: ORC.2.1 | OBR.2.1
-      systemCX: ORC.2.2 | OBR.2.2
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "PLAC"
-      display: "Placer Identifier"
-   
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: ORC.2.1 | OBR.2.1
+    systemCX: ORC.2.2 | OBR.2.2
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "PLAC"
+    display: "Placer Identifier"
+
 status:
-   type: DIAGNOSTIC_REPORT_STATUS
-   valueOf: OBR.25
-   expressionType: HL7Spec
+  type: DIAGNOSTIC_REPORT_STATUS
+  valueOf: OBR.25
+  expressionType: HL7Spec
 
 category:
-   valueOf: datatype/CodeableConcept
-   generateList: true
-   expressionType: resource
-   specs: OBR.24
-   vars:
-      code: OBR.24
-      
+  valueOf: datatype/CodeableConcept
+  generateList: true
+  expressionType: resource
+  specs: OBR.24
+  vars:
+    code: OBR.24
+
 code:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: OBR.4
-   required: true
-   vars:
-      code: OBR.4
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: OBR.4
+  required: true
+  vars:
+    code: OBR.4
 
 encounter:
-   valueOf: datatype/Reference
-   expressionType: resource
-   specs: $Encounter
-   
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Encounter
+
 subject:
-   valueOf: datatype/Reference
-   expressionType: resource
-   specs: $Patient
-   
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Patient
+
 effectiveDateTime:
-   condition: $start NOT_NULL && $end NULL
-   type: DATE_TIME
-   valueOf: OBR.7
-   expressionType: HL7Spec
-   vars:
-      start: OBR.7
-      end: OBR.8
+  condition: $start NOT_NULL && $end NULL
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: OBR.7
+    start: OBR.7
+    end: OBR.8
 
 effectivePeriod:
-   valueOf: datatype/Period
-   condition: $start NOT_NULL && $end NOT_NULL
-   expressionType: resource
-   vars:
-      start: OBR.7
-      end: OBR.8
+  valueOf: datatype/Period
+  condition: $start NOT_NULL && $end NOT_NULL
+  expressionType: resource
+  vars:
+    start: OBR.7
+    end: OBR.8
 
 issued:
-   type: INSTANT
-   valueOf: OBR.22
-   expressionType: HL7Spec
-   
+  type: STRING
+  valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+  expressionType: JEXL
+  vars: 
+    dateTimeIn: OBR.22  
+
 resultsInterpreter:
-   condition: $interpreter NOT_NULL
-   valueOf: resource/Practitioner
-   generateList: true
-   expressionType: reference
-   specs: OBR.32.1
-   vars:
-      interpreter: OBR.32.1
+  condition: $interpreter NOT_NULL
+  valueOf: resource/Practitioner
+  generateList: true
+  expressionType: reference
+  specs: OBR.32.1
+  vars:
+    interpreter: OBR.32.1
 
 basedOn:
-   condition: $basedOnORCOBR NOT_NULL
-   valueOf: resource/ServiceRequest
-   generateList: true
-   expressionType: reference
-   specs: ORC | OBR
-   vars:
-      basedOnORCOBR: ORC | OBR     
+  condition: $basedOnORCOBR NOT_NULL
+  valueOf: resource/ServiceRequest
+  generateList: true
+  expressionType: reference
+  specs: ORC | OBR
+  vars:
+    basedOnORCOBR: ORC | OBR
 
 specimen:
-   valueOf: datatype/Reference
-   generateList: true
-   expressionType: resource
-   specs: $Specimen
-   useGroup: true
+  valueOf: datatype/Reference
+  generateList: true
+  expressionType: resource
+  specs: $Specimen
+  useGroup: true
 
 result:
-   valueOf: datatype/Reference
-   generateList: true
-   expressionType: resource
-   specs: $Observation
-   useGroup: true
+  valueOf: datatype/Reference
+  generateList: true
+  expressionType: resource
+  specs: $Observation
+  useGroup: true
 
 presentedForm:
-   valueOf: datatype/Attachment
-   expressionType: resource
-   # This merges all the OBX lines together when the message has only type 'TX' (obx2). 
-   # Messages with mixed types of OBX segments will not have a presentedForm attachment created.
-   condition: $obx2 EQUALS TX
-   vars:
-      # This concatenates all OBX-5 lines together (the asterisk) and preserves blank lines (the ampersand).  Multiple lines are concatenated with a tilde.
-      data: OBX.5 *&, GeneralUtils.concatenateWithChar(data, '\n')
-      title: OBR.4.2
-      date: OBX.14
-      mime: $code
-      language: $code2
-      obx2: STRING, OBX.2
-   constants:
-      system: 'http://terminology.hl7.org/CodeSystem/v2-0834'
-      code: 'text/plain'
-      display: 'Text data'
-      system2: 'http://hl7.org/fhir/ValueSet/all-languages'
-      code2: 'en'
-      display2: 'English'
+  valueOf: datatype/Attachment
+  expressionType: resource
+  # This merges all the OBX lines together when the message has only type 'TX' (obx2).
+  # Messages with mixed types of OBX segments will not have a presentedForm attachment created.
+  condition: $obx2 EQUALS TX
+  vars:
+    # This concatenates all OBX-5 lines together (the asterisk) and preserves blank lines (the ampersand).  Multiple lines are concatenated with a tilde.
+    data: OBX.5 *&, GeneralUtils.concatenateWithChar(data, '\n')
+    title: OBR.4.2
+    date: OBX.14
+    mime: $code
+    language: $code2
+    obx2: STRING, OBX.2
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0834"
+    code: "text/plain"
+    display: "Text data"
+    system2: "http://hl7.org/fhir/ValueSet/all-languages"
+    code2: "en"
+    display2: "English"

--- a/src/main/resources/hl7/resource/DocumentReference.yml
+++ b/src/main/resources/hl7/resource/DocumentReference.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -186,9 +186,11 @@ subject:
    specs: $Patient
 
 date:
-   type: INSTANT
-   valueOf: TXA.6 
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+  expressionType: JEXL
+  vars: 
+    dateTimeIn: TXA.6
 
 author:
    condition: $hasValue NOT_NULL

--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -249,6 +249,7 @@ serviceProvider:
   condition: $orgIdValue NOT_NULL
   valueOf: resource/Organization
   expressionType: reference
+  generateList: true
   vars:
     orgName: String, PV2.23.1 | PV1.3.4.1
     orgIdValue: String, PV2.23.8 | PV1.3.4.1  # used for Id and Identifier

--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -249,7 +249,6 @@ serviceProvider:
   condition: $orgIdValue NOT_NULL
   valueOf: resource/Organization
   expressionType: reference
-  generateList: true
   vars:
     orgName: String, PV2.23.1 | PV1.3.4.1
     orgIdValue: String, PV2.23.8 | PV1.3.4.1  # used for Id and Identifier

--- a/src/main/resources/hl7/resource/Encounter.yml
+++ b/src/main/resources/hl7/resource/Encounter.yml
@@ -83,7 +83,7 @@ length:
     expressionType: resource
     vars: 
       pv2time: STRING, PV2.11
-      pv1length: PV1_DURATION_LENGTH, PV1
+      pv1length: PV1, GeneralUtils.pv1DurationLength(pv1length,ZONEID)
 
 reasonCode_1:
     valueOf: datatype/CodeableConcept

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -1,201 +1,234 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 resourceType: Immunization
 id:
-   type: STRING
-   valueOf: UUID.randomUUID()
-   expressionType: JEXL
+  type: STRING
+  valueOf: UUID.randomUUID()
+  expressionType: JEXL
 
 identifier:
-   valueOf: datatype/Identifier
-   generateList: true
-   expressionType: resource
-   vars:
-      system: SYSTEM_URL, $sys
-      value: BUILD_IDENTIFIER_FROM_CWE, RXA.5
-   constants:
-      sys: "urn:id:extID"
+  valueOf: datatype/Identifier
+  generateList: true
+  expressionType: resource
+  vars:
+    system: SYSTEM_URL, $sys
+    value: BUILD_IDENTIFIER_FROM_CWE, RXA.5
+  constants:
+    sys: "urn:id:extID"
+
 status:
-   valueOf: "GeneralUtils.getImmunizationStatus(rxa18,rxa20,orc5)"
-   expressionType: JEXL
-   vars:
-      rxa18: RXA.18
-      rxa20: RXA.20
-      orc5: ORC.5
+  valueOf: "GeneralUtils.getImmunizationStatus(rxa18,rxa20,orc5)"
+  expressionType: JEXL
+  vars:
+    rxa18: RXA.18
+    rxa20: RXA.20
+    orc5: ORC.5
+
 statusReason_1:
-   condition: $rxa18 NOT_NULL
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: RXA.18
-   vars:
-      rxa18: RXA.18
+  condition: $rxa18 NOT_NULL
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: RXA.18
+  vars:
+    rxa18: RXA.18
+
 statusReason_2:
-   valueOf: datatype/CodeableConcept_var
-   expressionType: resource
-   condition: $rxa18 NULL && $statCode EQUALS RE
-   vars:
-      rxa18: RXA.18
-      statCode: STRING, RXA.20
-   constants:
-      code: "PATOBJ"
-      display: "Patient Refusal"
-      system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+  valueOf: datatype/CodeableConcept_var
+  expressionType: resource
+  condition: $rxa18 NULL && $statCode EQUALS RE
+  vars:
+    rxa18: RXA.18
+    statCode: STRING, RXA.20
+  constants:
+    code: "PATOBJ"
+    display: "Patient Refusal"
+    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+
 statusReason_3:
-   valueOf: datatype/CodeableConcept_var
-   expressionType: resource
-   condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 30945-0
-   vars:
-      rxa18: RXA.18
-      rxa20: RXA.20
-      obx31: String, OBX.3.1
-   constants:
-      code: "MEDPREC"
-      display: "medical precaution"
-      system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+  valueOf: datatype/CodeableConcept_var
+  expressionType: resource
+  condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 30945-0
+  vars:
+    rxa18: RXA.18
+    rxa20: RXA.20
+    obx31: String, OBX.3.1
+  constants:
+    code: "MEDPREC"
+    display: "medical precaution"
+    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+
 statusReason_4:
-   valueOf: datatype/CodeableConcept_var
-   expressionType: resource
-   condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 59784-9
-   vars:
-      rxa18: RXA.18
-      rxa20: RXA.20
-      obx31: String, OBX.3.1
-   constants:
-      code: "IMMUNE"
-      display: "immunity"
-      system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+  valueOf: datatype/CodeableConcept_var
+  expressionType: resource
+  condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 59784-9
+  vars:
+    rxa18: RXA.18
+    rxa20: RXA.20
+    obx31: String, OBX.3.1
+  constants:
+    code: "IMMUNE"
+    display: "immunity"
+    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+
 vaccineCode_1:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: RXA.5
-   vars:
-      code: RXA.5
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: RXA.5
+  vars:
+    code: RXA.5
+
 vaccineCode_2:
-   condition: $obx31 EQUALS 30956-7 && $rxa5 NULL
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: OBX.5
-   vars:
-      rxa5: RXA.5
-      obx31: String, OBX.3.1
+  condition: $obx31 EQUALS 30956-7 && $rxa5 NULL
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: OBX.5
+  vars:
+    rxa5: RXA.5
+    obx31: String, OBX.3.1
+
 patient:
-   valueOf: datatype/Reference
-   required: true
-   expressionType: resource
-   specs: $Patient
+  valueOf: datatype/Reference
+  required: true
+  expressionType: resource
+  specs: $Patient
+
 encounter:
-   valueOf: datatype/Reference
-   expressionType: resource
-   specs: $Encounter
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Encounter
+
 occurrenceDateTime:
-   required: true
-   type: DATE_TIME
-   valueOf: RXA.3
-   expressionType: HL7Spec
+  required: true
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: RXA.3
+
 primarySource:
-   value: true
-   condition: $rxa9 NOT_NULL
-   vars:
-      rxa9: RXA.9
+  value: true
+  condition: $rxa9 NOT_NULL
+  vars:
+    rxa9: RXA.9
+
 reportOrigin:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: RXA.9
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: RXA.9
+
 manufacturer:
-   condition: $rxa17 NOT_NULL
-   valueOf: resource/Organization
-   expressionType: reference
-   specs: RXA.17
-   vars: 
-      rxa17: RXA.17
+  condition: $rxa17 NOT_NULL
+  valueOf: resource/Organization
+  expressionType: reference
+  specs: RXA.17
+  vars:
+    rxa17: RXA.17
+
 lotNumber:
-   type: STRING
-   valueOf: RXA.15
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: RXA.15
+  expressionType: HL7Spec
+
 expirationDate:
-   type: DATE_TIME
-   valueOf: RXA.16
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: RXA.16
+
 site:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: RXR.2
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: RXR.2
+
 route:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: RXR.1
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: RXR.1
+
 doseQuantity:
-   condition: $value NOT_NULL
-   valueOf: datatype/Quantity
-   expressionType: resource
-   specs: RXA.6 | RXA.7
-   vars:
-      value: DOSE_VALUE, RXA.6
-      unit: RXA.7.1
-      code: RXA.7.1
-      sys: DOSE_SYSTEM, RXA.7.3
+  condition: $value NOT_NULL
+  valueOf: datatype/Quantity
+  expressionType: resource
+  specs: RXA.6 | RXA.7
+  vars:
+    value: DOSE_VALUE, RXA.6
+    unit: RXA.7.1
+    code: RXA.7.1
+    sys: DOSE_SYSTEM, RXA.7.3
+
 performer_1:
-   valueOf: secondary/Performer
-   generateList: true
-   expressionType: resource
-   vars:
-      orderingProvider: ORC.12
+  valueOf: secondary/Performer
+  generateList: true
+  expressionType: resource
+  vars:
+    orderingProvider: ORC.12
+
 performer_2:
-   valueOf: secondary/Performer
-   generateList: true
-   expressionType: resource
-   vars:
-      administeringProvider: RXA.10
+  valueOf: secondary/Performer
+  generateList: true
+  expressionType: resource
+  vars:
+    administeringProvider: RXA.10
+
 note:
-   valueOf: datatype/Annotation
-   expressionType: resource
-   condition: $obx3 EQUALS 48767-8
-   specs: OBX
-   vars:
-      obx3: STRING, OBX.3.1
-      annotationText: STRING, OBX.5
+  valueOf: datatype/Annotation
+  expressionType: resource
+  condition: $obx3 EQUALS 48767-8
+  specs: OBX
+  vars:
+    obx3: STRING, OBX.3.1
+    annotationText: STRING, OBX.5
+
 reasonReference:
-   valueOf: datatype/Reference
-   expressionType: resource
-   generateList: true
-   specs: $Observation
-   useGroup: true
+  valueOf: datatype/Reference
+  expressionType: resource
+  generateList: true
+  specs: $Observation
+  useGroup: true
+
 isSubpotent:
-   value: true
-   condition: $rxa20 EQUALS PA
-   vars:
-      rxa20: String, RXA.20
+  value: true
+  condition: $rxa20 EQUALS PA
+  vars:
+    rxa20: String, RXA.20
+
 programEligibility:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   condition: $obx3 EQUALS 64994-7
-   specs: OBX.5
-   vars:
-      obx3: String, OBX.3.1
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  condition: $obx3 EQUALS 64994-7
+  specs: OBX.5
+  vars:
+    obx3: String, OBX.3.1
+    
 fundingSource:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   condition: $obx3 EQUALS 30963-3
-   specs: OBX.5
-   vars:
-      obx3: String, OBX.3.1
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  condition: $obx3 EQUALS 30963-3
+  specs: OBX.5
+  vars:
+    obx3: String, OBX.3.1
 
 reasonCode:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: RXA.19
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: RXA.19
+
 recorded:
-   type: DATE_TIME
-   valueOf: RXA.22 | ORC.9
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: RXA.22 | ORC.9
+
 reaction:
-   condition: $obx31 EQUALS 31044-1
-   valueOf: secondary/ImmunizationReaction
-   generateList: true
-   expressionType: resource
-   specs: OBX
-   vars:
-      obx31: String, OBX.3.1
+  condition: $obx31 EQUALS 31044-1
+  valueOf: secondary/ImmunizationReaction
+  generateList: true
+  expressionType: resource
+  specs: OBX
+  vars:
+    obx31: String, OBX.3.1

--- a/src/main/resources/hl7/resource/MedicationAdministration.yml
+++ b/src/main/resources/hl7/resource/MedicationAdministration.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -34,7 +34,7 @@ identifier_2:
 
 status:
   type: MEDREQ_STATUS
-  valueOf:  RXA.20
+  valueOf: RXA.20
   expressionType: HL7Spec
 
 medicationCodeableConcept:
@@ -48,9 +48,11 @@ medicationReference:
   specs: $Medication
 
 effectiveDateTime:
-  type: DATE_TIME
-  valueOf: RXA.3 | RXA.4
-  expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: RXA.3 | RXA.4
 
 effectivePeriod:
   valueOf: datatype/Period

--- a/src/main/resources/hl7/resource/MedicationRequest.yml
+++ b/src/main/resources/hl7/resource/MedicationRequest.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -128,11 +128,11 @@ medicationCodeableConcept_4:
     rxE: RXE.31
 
 authoredOn:
-  type: DATE_TIME
-  valueOf: $val
-  expressionType: HL7Spec
-  vars:
-    val: RXE.32 | ORC.9
+  type: STRING
+  valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
+  expressionType: JEXL
+  vars: 
+    dateTimeIn: RXE.32 | ORC.9  
 
 reasonCode:
   valueOf: datatype/CodeableConcept

--- a/src/main/resources/hl7/resource/Observation.yml
+++ b/src/main/resources/hl7/resource/Observation.yml
@@ -1,15 +1,14 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 #Observation resource
 ---
-
 resourceType: Observation
 id:
   type: STRING
-  valueOf: 'UUID.randomUUID()'
+  valueOf: "UUID.randomUUID()"
   expressionType: JEXL
 
 identifier_1: #joins filler | placer | MSH.7 with whatever gets returned from BUILD_FROM_CWE. that magic happens in identifier_Observation
@@ -20,16 +19,16 @@ identifier_1: #joins filler | placer | MSH.7 with whatever gets returned from BU
     obx3: BUILD_IDENTIFIER_FROM_CWE, OBX.3
     fillpla: STRING, ORC.3.1 | OBR.3.1 | ORC.2.1 | OBR.2.1 | MSH.7
   constants:
-      sys: "urn:id:extID"
-      joinChar: '-'
+    sys: "urn:id:extID"
+    joinChar: "-"
 identifier_2:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   expressionType: resource
-   vars:
-      valueIn: OBX.21.1
-      systemCX: OBX.21.2
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: OBX.21.1
+    systemCX: OBX.21.2
 identifier_3:
   condition: $id NOT_NULL
   valueOf: datatype/Identifier_Observation
@@ -40,12 +39,12 @@ identifier_3:
     fillpla: STRING, ORC.3.1 | OBR.3.1 | ORC.2.1 | OBR.2.1 | MSH.7
   constants:
     sys: "urn:id:extID"
-    joinChar: '-'
+    joinChar: "-"
 status:
-   type: OBSERVATION_STATUS
-   default: unknown
-   valueOf: OBX.11
-   expressionType: HL7Spec
+  type: OBSERVATION_STATUS
+  default: unknown
+  valueOf: OBX.11
+  expressionType: HL7Spec
 
 # When OBX's are missing or TX based, we don't want to create an Observation.
 # When TX, because content is already appended to an associated DiagnosticReport or DocumentReference
@@ -53,226 +52,231 @@ status:
 # 'code' is set 'required: true' to cause all or nothing creation logic
 # The expression is nested and values are passed to the nested so that BOTH values control the 'all or nothing'
 code:
-   expressionType: nested
-   required: true
-   vars:
-     obx3: OBX.3
-     obx2: STRING, OBX.2
-   expressions:
-   -  condition: $obx3 NOT_NULL && $obx2 NOT_EQUALS_STRING TX
+  expressionType: nested
+  required: true
+  vars:
+    obx3: OBX.3
+    obx2: STRING, OBX.2
+  expressions:
+    - condition: $obx3 NOT_NULL && $obx2 NOT_EQUALS_STRING TX
       valueOf: datatype/CodeableConcept
       expressionType: resource
       specs: $obx3
 
 subject:
-    valueOf: datatype/Reference
-    expressionType: resource
-    specs: $Patient
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Patient
 
 encounter:
-    valueOf: datatype/Reference
-    expressionType: resource
-    specs: $Encounter
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Encounter
 
 effectiveDateTime:
-     type: DATE_TIME
-     valueOf: OBX.14 | OBX.19
-     expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: OBX.14 | OBX.19
 
 issued:
-     type: DATE_TIME
-     valueOf: OBR.22 | OBX.19
-     expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: OBR.22 | OBX.19
 
 valueString:
-    condition: $obx2 EQUALS ST
-    type: STRING_ALL
-    valueOf: OBX.5
-    expressionType: HL7Spec
-    vars:
-      obx2: STRING, OBX.2
+  condition: $obx2 EQUALS ST
+  type: STRING_ALL
+  valueOf: OBX.5
+  expressionType: HL7Spec
+  vars:
+    obx2: STRING, OBX.2
 
 valueQuantity_1:
-    valueOf: datatype/Quantity
-    expressionType: resource
-    condition: $obx2 EQUALS NM
-    vars:
-      value: OBX.5
-      unit: OBX.6.1
-      code: OBX.6.1
-      obx2: STRING, OBX.2
-      resolvedSystem: SYSTEM_URL, OBX.6.3
+  valueOf: datatype/Quantity
+  expressionType: resource
+  condition: $obx2 EQUALS NM
+  vars:
+    value: OBX.5
+    unit: OBX.6.1
+    code: OBX.6.1
+    obx2: STRING, OBX.2
+    resolvedSystem: SYSTEM_URL, OBX.6.3
 
 valueQuantity_2:
-    valueOf: datatype/Quantity
-    expressionType: resource
-    condition: $obx2 EQUALS SN && $separator NULL
-    vars:
-      value: OBX.5.2
-      unit: OBX.6.1
-      code: OBX.6.1
-      comparator: OBX.5.1
-      obx2: STRING, OBX.2
-      separator: STRING, OBX.5.3
-      resolvedSystem: SYSTEM_URL, OBX.6.3
+  valueOf: datatype/Quantity
+  expressionType: resource
+  condition: $obx2 EQUALS SN && $separator NULL
+  vars:
+    value: OBX.5.2
+    unit: OBX.6.1
+    code: OBX.6.1
+    comparator: OBX.5.1
+    obx2: STRING, OBX.2
+    separator: STRING, OBX.5.3
+    resolvedSystem: SYSTEM_URL, OBX.6.3
 
 valueQuantity_3:
-    valueOf: datatype/Quantity
-    expressionType: resource
-    condition: $obx2 EQUALS SN && $separator NOT_NULL && $separator NOT_EQUALS ':' && $separator NOT_EQUALS '/'
-    vars:
-      value: OBX.5.2
-      unit: OBX.6.1
-      code: OBX.6.1
-      comparator: OBX.5.1
-      obx2: STRING, OBX.2
-      separator: STRING, OBX.5.3
-      resolvedSystem: SYSTEM_URL, OBX.6.3
+  valueOf: datatype/Quantity
+  expressionType: resource
+  condition: $obx2 EQUALS SN && $separator NOT_NULL && $separator NOT_EQUALS ':' && $separator NOT_EQUALS '/'
+  vars:
+    value: OBX.5.2
+    unit: OBX.6.1
+    code: OBX.6.1
+    comparator: OBX.5.1
+    obx2: STRING, OBX.2
+    separator: STRING, OBX.5.3
+    resolvedSystem: SYSTEM_URL, OBX.6.3
 
 valueCodeableConcept:
-     condition:  $obx2 EQUALS  CF || $obx2 EQUALS CNE || $obx2 EQUALS CWE || $obx2 EQUALS CE
-     valueOf: datatype/CodeableConcept
-     generateList: true
-     expressionType: resource
-     specs: OBX.5
-     vars:
-       obx2: STRING, OBX.2
+  condition: $obx2 EQUALS  CF || $obx2 EQUALS CNE || $obx2 EQUALS CWE || $obx2 EQUALS CE
+  valueOf: datatype/CodeableConcept
+  generateList: true
+  expressionType: resource
+  specs: OBX.5
+  vars:
+    obx2: STRING, OBX.2
 
 valuePeriod:
-   condition: $obx2 EQUALS DR
-   valueOf: datatype/Period
-   expressionType: resource
-   vars:
-     code: OBX.5
-     obx2: STRING, OBX.2
+  condition: $obx2 EQUALS DR
+  valueOf: datatype/Period
+  expressionType: resource
+  vars:
+    code: OBX.5
+    obx2: STRING, OBX.2
 
 valueDateTime:
-   condition: $obx2 EQUALS DT || $obx2 EQUALS DTM
-   type: DATE_TIME
-   valueOf: OBX.5
-   expressionType: HL7Spec
-   vars:
-     obx2: STRING, OBX.2
+  condition: $obx2 EQUALS DT || $obx2 EQUALS DTM
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: OBX.5
+    obx2: STRING, OBX.2
 
 valueTime:
-   condition: $obx2 EQUALS TM
-   type: TIME
-   valueOf: OBX.5
-   expressionType: HL7Spec
-   vars:
-     obx2: STRING, OBX.2
+  condition: $obx2 EQUALS TM
+  type: TIME
+  valueOf: OBX.5
+  expressionType: HL7Spec
+  vars:
+    obx2: STRING, OBX.2
 
 valueRatio_1:
-   condition: $obx2 EQUALS SN && $separator NOT_NULL && $separator EQUALS ':'
-   valueOf: datatype/Ratio
-   expressionType: resource
-   specs: OBX.5
-   vars:
-     numerator: SN.2
-     denominator: SN.4
-     obx2: STRING, OBX.2
-     separator: STRING, SN.3
+  condition: $obx2 EQUALS SN && $separator NOT_NULL && $separator EQUALS ':'
+  valueOf: datatype/Ratio
+  expressionType: resource
+  specs: OBX.5
+  vars:
+    numerator: SN.2
+    denominator: SN.4
+    obx2: STRING, OBX.2
+    separator: STRING, SN.3
 
 valueRatio_2:
-   condition: $obx2 EQUALS SN && $separator NOT_NULL && $separator EQUALS '/'
-   valueOf: datatype/Ratio
-   expressionType: resource
-   specs: OBX.5
-   vars:
-     numerator: SN.2
-     denominator: SN.4
-     obx2: STRING, OBX.2
-     separator: STRING, SN.3
+  condition: $obx2 EQUALS SN && $separator NOT_NULL && $separator EQUALS '/'
+  valueOf: datatype/Ratio
+  expressionType: resource
+  specs: OBX.5
+  vars:
+    numerator: SN.2
+    denominator: SN.4
+    obx2: STRING, OBX.2
+    separator: STRING, SN.3
 
 interpretation:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: OBX.8
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: OBX.8
 
 note_1:
-   valueOf: datatype/Annotation
-   expressionType: resource
-   condition: $obx3 EQUALS 48767-8
-   specs: OBX
-   vars:
-      obx3: STRING, OBX.3.1
-      annotationText: STRING, OBX.5
+  valueOf: datatype/Annotation
+  expressionType: resource
+  condition: $obx3 EQUALS 48767-8
+  specs: OBX
+  vars:
+    obx3: STRING, OBX.3.1
+    annotationText: STRING, OBX.5
 
 note_2:
-   valueOf: datatype/Annotation
-   condition: $annotationText NOT_NULL
-   expressionType: resource
-   vars:
-      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')
+  valueOf: datatype/Annotation
+  condition: $annotationText NOT_NULL
+  expressionType: resource
+  vars:
+    annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')
 
 bodySite:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: OBX.20
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: OBX.20
 
 method:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: OBX.17
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: OBX.17
 
 referenceRange:
-   valueOf: secondary/ReferenceRange
-   condition: $textValue NOT_NULL
-   generateList: true
-   expressionType: resource
-   specs: OBX.7
-   vars:
-     low:  OBX.7, GeneralUtils.extractLow(low)
-     high: OBX.7, GeneralUtils.extractHigh(high)
-     appliestoValue: OBX.10
-     textValue: OBX.7
-     typeValue: OBX.10
-     unit: OBX.6
+  valueOf: secondary/ReferenceRange
+  condition: $textValue NOT_NULL
+  generateList: true
+  expressionType: resource
+  specs: OBX.7
+  vars:
+    low: OBX.7, GeneralUtils.extractLow(low)
+    high: OBX.7, GeneralUtils.extractHigh(high)
+    appliestoValue: OBX.10
+    textValue: OBX.7
+    typeValue: OBX.10
+    unit: OBX.6
 
 performer_1:
-   condition: $performerValue NOT_NULL
-   valueOf: resource/Practitioner
-   generateList: true
-   expressionType: reference
-   specs: OBX.16
-   vars:
-     performerValue: OBX.16
+  condition: $performerValue NOT_NULL
+  valueOf: resource/Practitioner
+  generateList: true
+  expressionType: reference
+  specs: OBX.16
+  vars:
+    performerValue: OBX.16
 
 performer_2:
-   condition: $performerValue2 NOT_NULL
-   valueOf: resource/Organization
-   generateList: true
-   expressionType: reference
-   specs: OBX.23
-   vars:
-     performerValue2: OBX.23
-     orgAddressXAD: OBX.24
-     orgContactXCN: OBX.25
-   constants:  
-     # Observation Organization needs an ADMIN purpose
-     orgContactPurposeCode: 'ADMIN'
-     orgContactPurposeSystemCode: 'contactentity-type'
-     orgContactPurposeDisplay: 'Administrative'
-     orgContactPurposeText: 'Organization Medical Director'
+  condition: $performerValue2 NOT_NULL
+  valueOf: resource/Organization
+  generateList: true
+  expressionType: reference
+  specs: OBX.23
+  vars:
+    performerValue2: OBX.23
+    orgAddressXAD: OBX.24
+    orgContactXCN: OBX.25
+  constants:
+    # Observation Organization needs an ADMIN purpose
+    orgContactPurposeCode: "ADMIN"
+    orgContactPurposeSystemCode: "contactentity-type"
+    orgContactPurposeDisplay: "Administrative"
+    orgContactPurposeText: "Organization Medical Director"
 
 device:
-   condition: $deviceValue NOT_NULL
-   valueOf: resource/Device
-   generateList: true
-   expressionType: reference
-   specs: OBX.18
-   vars:
-     deviceValue: OBX.18
+  condition: $deviceValue NOT_NULL
+  valueOf: resource/Device
+  generateList: true
+  expressionType: reference
+  specs: OBX.18
+  vars:
+    deviceValue: OBX.18
 
 category:
-   condition: $specimen NOT_NULL
-   valueOf: datatype/CodeableConcept_var
-   generateList: true
-   expressionType: resource
-   vars:
-      system: SYSTEM_URL, $system_code
-      specimen: SPM.4
-   constants:
-      code: 'laboratory'
-      system_code: 'observation-category'
-      display: 'Laboratory'
+  condition: $specimen NOT_NULL
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  vars:
+    system: SYSTEM_URL, $system_code
+    specimen: SPM.4
+  constants:
+    code: "laboratory"
+    system_code: "observation-category"
+    display: "Laboratory"

--- a/src/main/resources/hl7/resource/Patient.yml
+++ b/src/main/resources/hl7/resource/Patient.yml
@@ -7,17 +7,17 @@ resourceType: Patient
 # Represents data that needs to be extracted for a Patient Resource in FHIR
 # reference: https://www.hl7.org/fhir/patient.html
 id:
-   type: STRING
-   valueOf: UUID.randomUUID()
-   expressionType: JEXL
+  type: STRING
+  valueOf: UUID.randomUUID()
+  expressionType: JEXL
 
 identifier_1:
-   valueOf: datatype/Identifier_SystemID
-   generateList: true
-   expressionType: resource
-   specs: PID.3
-   vars:
-      assignerSystem: String, PID.3.4
+  valueOf: datatype/Identifier_SystemID
+  generateList: true
+  expressionType: resource
+  specs: PID.3
+  vars:
+    assignerSystem: String, PID.3.4
 
 # When the Coverage.subscriber from IN1.17 is NOT self use PID.19 for SSN identifier
 identifier_2a:
@@ -99,63 +99,63 @@ identifier_2e:
 # There is no text for PID.19
 
 identifier_3:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-# There is no authority for PID.19
-   expressionType: resource
-# Gets the Driver's license from PID.20, formats and adds it as an ID
-   vars:
-      valueIn: String, PID.20.1
-   constants:
-      system: http://terminology.hl7.org/CodeSystem/v2-0203
-      code: DL
-      display: Driver's license number
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  # There is no authority for PID.19
+  expressionType: resource
+  # Gets the Driver's license from PID.20, formats and adds it as an ID
+  vars:
+    valueIn: String, PID.20.1
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: DL
+    display: Driver's license number
 # There is no text for PID.20
 
 identifier_4:
-   condition: $mrgIdentifier NOT_NULL
-   valueOf: datatype/Identifier_SystemID
-   generateList: true
-   expressionType: resource
-   specs: MRG.1
-   constants:
-      use: old
-      mrgIdentifier: MRG.1
+  condition: $mrgIdentifier NOT_NULL
+  valueOf: datatype/Identifier_SystemID
+  generateList: true
+  expressionType: resource
+  specs: MRG.1
+  constants:
+    use: old
+    mrgIdentifier: MRG.1
 # Add the old MR # from the MRG segment
 
 # identifier_5a and _5b are two parts to complex logic
 # Only include IN1.49 as an identifier when the subscriber is not self AND a relatedPerson is created
 identifier_5a:
-   condition: $valueIn NOT_NULL && $subscriberValue NOT_EQUALS SEL && $createRelatedPerson EQUALS TRUE
-   valueOf: datatype/Identifier_var
-   generateList: true
-   expressionType: resource
-   specs: IN1.49
-   vars:
-      valueIn: String, IN1.49.1
-      systemCX: IN1.49.4
-      code: IN1.49.5
-      subscriberValue: String, IN1.17.1 # subscriber relationship
-      createRelatedPerson: RELATED_PERSON_NEEDED_IN117, IN1.17 
-   constants:
-      system: http://terminology.hl7.org/CodeSystem/v2-0203
+  condition: $valueIn NOT_NULL && $subscriberValue NOT_EQUALS SEL && $createRelatedPerson EQUALS TRUE
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  specs: IN1.49
+  vars:
+    valueIn: String, IN1.49.1
+    systemCX: IN1.49.4
+    code: IN1.49.5
+    subscriberValue: String, IN1.17.1 # subscriber relationship
+    createRelatedPerson: RELATED_PERSON_NEEDED_IN117, IN1.17
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
 
 identifier_5b:
-   condition: $valueIn NOT_NULL && $valueIN117 NULL && $subscriberValue NOT_EQUALS 01 && $createRelatedPerson EQUALS TRUE
-   valueOf: datatype/Identifier_var
-   generateList: true
-   expressionType: resource
-   specs: IN1.49
-   vars:
-      valueIn: String, IN1.49.1
-      systemCX: IN1.49.4
-      code: IN1.49.5
-      subscriberValue: String, IN2.72 # subscriber relationship
-      createRelatedPerson: RELATED_PERSON_NEEDED_IN272, IN2.72
-      valueIN117: IN1.17.1
-   constants:
-      system: http://terminology.hl7.org/CodeSystem/v2-0203          
+  condition: $valueIn NOT_NULL && $valueIN117 NULL && $subscriberValue NOT_EQUALS 01 && $createRelatedPerson EQUALS TRUE
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  specs: IN1.49
+  vars:
+    valueIn: String, IN1.49.1
+    systemCX: IN1.49.4
+    code: IN1.49.5
+    subscriberValue: String, IN2.72 # subscriber relationship
+    createRelatedPerson: RELATED_PERSON_NEEDED_IN272, IN2.72
+    valueIN117: IN1.17.1
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
 
 # identifier_6a and _6b are two parts to complex logic
 # Only include when the subscriber is self, uses IN1.17
@@ -166,7 +166,7 @@ identifier_6a:
   expressionType: resource
   vars:
     valueIn: IN2.61 | IN1.36
-    valueIN117: String, IN1.17.1  # subscriber relationship
+    valueIN117: String, IN1.17.1 # subscriber relationship
     # No systemCX set for this identifier
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
@@ -174,7 +174,7 @@ identifier_6a:
     display: "Member Number"
 
 # Only include when the subscriber is self
-# IN2.72 only gets used if IN1.17 priority is empty (see identifier_6a) 
+# IN2.72 only gets used if IN1.17 priority is empty (see identifier_6a)
 identifier_6b:
   condition: $valueIn NOT_NULL && $valueIN117 NULL && $valueIN272 EQUALS 01
   valueOf: datatype/Identifier_var
@@ -183,7 +183,7 @@ identifier_6b:
   vars:
     valueIn: IN2.61 | IN1.36
     valueIN117: IN1.17.1
-    valueIN272: String, IN2.72  # subscriber relationship
+    valueIN272: String, IN2.72 # subscriber relationship
     # No systemCX set for this identifier
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
@@ -217,192 +217,191 @@ identifier_8:
     display: "Patient's Medicare number"
 
 name:
-   valueOf: datatype/HumanName
-   generateList: true
-   expressionType: resource
-   specs: PID.5
+  valueOf: datatype/HumanName
+  generateList: true
+  expressionType: resource
+  specs: PID.5
 
 gender:
-   type: ADMINISTRATIVE_GENDER
-   valueOf: PID.8
-   expressionType: HL7Spec
+  type: ADMINISTRATIVE_GENDER
+  valueOf: PID.8
+  expressionType: HL7Spec
 
 address:
-   valueOf: datatype/Address
-   generateList: true
-   expressionType: resource
-   specs: PID.11
-   vars:
-        # Used in Address to create district for patient address
-        # In future, they could be processed in a DataValueResolver. 
-        distPatientCounty: String, PID.12
-        distAddressCountyParish: String, PID.11.9
-        distPatient: PID
+  valueOf: datatype/Address
+  generateList: true
+  expressionType: resource
+  specs: PID.11
+  vars:
+    # Used in Address to create district for patient address
+    # In future, they could be processed in a DataValueResolver.
+    distPatientCounty: String, PID.12
+    distAddressCountyParish: String, PID.11.9
+    distPatient: PID
 
 telecom_1:
-   condition: $pid14 NOT_NULL
-   valueOf: datatype/ContactPoint
-   generateList: true
-   expressionType: resource
-   specs: PID.14
-   vars:
-      pid14: PID.14
-   constants:
-      use: work
+  condition: $pid14 NOT_NULL
+  valueOf: datatype/ContactPoint
+  generateList: true
+  expressionType: resource
+  specs: PID.14
+  vars:
+    pid14: PID.14
+  constants:
+    use: work
 
 telecom_2:
-   condition: $pid13 NOT_NULL
-   valueOf: datatype/ContactPoint
-   generateList: true
-   expressionType: resource
-   specs: PID.13
-   vars:
-      pid13: PID.13
-   constants:
-      use: home
+  condition: $pid13 NOT_NULL
+  valueOf: datatype/ContactPoint
+  generateList: true
+  expressionType: resource
+  specs: PID.13
+  vars:
+    pid13: PID.13
+  constants:
+    use: home
 
 # The yaml is processed in reverse order, therefore
 # Put the PID.13 last in yaml so it is first to be processed
 birthDate:
-   type: DATE
-   valueOf: PID.7
-   expressionType: HL7Spec
+  type: DATE
+  valueOf: PID.7
+  expressionType: HL7Spec
 
 multipleBirthBoolean_1:
-   condition: $multBool NOT_NULL && $multInt NULL
-   type: BOOLEAN
-   valueOf: PID.24
-   expressionType: HL7Spec
-   vars:
-      multBool: PID.24
-      multInt: PID.25
+  condition: $multBool NOT_NULL && $multInt NULL
+  type: BOOLEAN
+  valueOf: PID.24
+  expressionType: HL7Spec
+  vars:
+    multBool: PID.24
+    multInt: PID.25
 
 multipleBirthBoolean_2:
-   condition: $multBool EQUALS N
-   type: BOOLEAN
-   valueOf: PID.24
-   expressionType: HL7Spec
-   vars:
-      multBool: String, PID.24
-      multInt: PID.25
+  condition: $multBool EQUALS N
+  type: BOOLEAN
+  valueOf: PID.24
+  expressionType: HL7Spec
+  vars:
+    multBool: String, PID.24
+    multInt: PID.25
 
 multipleBirthInteger_1:
-   condition: $multBool NULL && $multInt NOT_NULL
-   type: INTEGER
-   valueOf: PID.25
-   expressionType: HL7Spec
-   vars:
-      multBool: String, PID.24
-      multInt: PID.25
+  condition: $multBool NULL && $multInt NOT_NULL
+  type: INTEGER
+  valueOf: PID.25
+  expressionType: HL7Spec
+  vars:
+    multBool: String, PID.24
+    multInt: PID.25
 
 multipleBirthInteger_2:
-   condition: $multBool EQUALS Y && $multInt NOT_NULL
-   type: INTEGER
-   valueOf: PID.25
-   expressionType: HL7Spec
-   vars:
-      multBool: String, PID.24
-      multInt: PID.25
+  condition: $multBool EQUALS Y && $multInt NOT_NULL
+  type: INTEGER
+  valueOf: PID.25
+  expressionType: HL7Spec
+  vars:
+    multBool: String, PID.24
+    multInt: PID.25
 
 deceasedBoolean:
-   condition: $deceasedBool NOT_NULL && $deceasedDateTime NULL
-   type: BOOLEAN
-   valueOf: PID.30
-   expressionType: HL7Spec
-   vars:
-      deceasedBool: PID.30
-      deceasedDateTime: PID.29
+  condition: $deceasedBool NOT_NULL && $deceasedDateTime NULL
+  type: BOOLEAN
+  valueOf: PID.30
+  expressionType: HL7Spec
+  vars:
+    deceasedBool: PID.30
+    deceasedDateTime: PID.29
 
 deceasedDateTime:
-   condition: $deceasedDateTime NOT_NULL
-   type: DATE_TIME
-   valueOf: PID.29
-   expressionType: HL7Spec
-   vars:
-      deceasedDateTime: PID.29
+  condition: $dateTimeIn NOT_NULL
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: PID.29
 
 maritalStatus:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   condition: $coding NOT_NULL
-   vars:
-      coding: MARITAL_STATUS, PID.16
-      text: String, PID.16.2
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  condition: $coding NOT_NULL
+  vars:
+    coding: MARITAL_STATUS, PID.16
+    text: String, PID.16.2
 
 generalPractitioner:
-   condition: $practitionerVal NOT_NULL
-   valueOf: resource/Practitioner
-   generateList: true
-   expressionType: reference
-   specs: PD1.4
-   vars:
-      practitionerVal: PD1.4
+  condition: $practitionerVal NOT_NULL
+  valueOf: resource/Practitioner
+  generateList: true
+  expressionType: reference
+  specs: PD1.4
+  vars:
+    practitionerVal: PD1.4
 
 extension:
-   generateList: true
-   expressionType: nested
-   expressions:
-   -  condition: $value NOT_NULL
+  generateList: true
+  expressionType: nested
+  expressions:
+    - condition: $value NOT_NULL
       valueOf: extension/Extension
       expressionType: resource
       vars:
-         value: String, PID.6.1
+        value: String, PID.6.1
       constants:
-         KEY_NAME_SUFFIX: String
-         urlValue: mothersMaidenName
+        KEY_NAME_SUFFIX: String
+        urlValue: mothersMaidenName
 
-   -  expressionType: nested
+    - expressionType: nested
       expressionsMap:
-         url:
-            type: SYSTEM_URL
-            value: 'religion'
-         valueCodeableConcept:
-            valueOf: datatype/CodeableConcept
-            expressionType: resource
-            condition: $coding NOT_NULL
-            vars:
-               coding: RELIGIOUS_AFFILIATION_CC, PID.17
-               text: String, PID.17.2
+        url:
+          type: SYSTEM_URL
+          value: "religion"
+        valueCodeableConcept:
+          valueOf: datatype/CodeableConcept
+          expressionType: resource
+          condition: $coding NOT_NULL
+          vars:
+            coding: RELIGIOUS_AFFILIATION_CC, PID.17
+            text: String, PID.17.2
 
-   -  expressionType: nested
+    - expressionType: nested
       specs: PID.10
       generateList: true
       expressionsMap:
-         url:
-            type: SYSTEM_URL
-            value: 'race'
-         valueCodeableConcept:
-            valueOf: datatype/CodeableConcept
-            expressionType: resource
-            specs: CWE
+        url:
+          type: SYSTEM_URL
+          value: "race"
+        valueCodeableConcept:
+          valueOf: datatype/CodeableConcept
+          expressionType: resource
+          specs: CWE
 
 communication:
-   condition: $language NOT_NULL
-   valueOf: secondary/Communication
-   expressionType: resource
-   vars:
-      language: PID.15
+  condition: $language NOT_NULL
+  valueOf: secondary/Communication
+  expressionType: resource
+  vars:
+    language: PID.15
 
 active:
-   condition: $mrgSegment NOT_NULL
-   type: BOOLEAN  
-   valueOf: true
-   vars: 
-      mrgSegment: MRG
+  condition: $mrgSegment NOT_NULL
+  type: BOOLEAN
+  valueOf: true
+  vars:
+    mrgSegment: MRG
 
 link:
-   generateList: true
-   evaluateLater: true
-   expressionType: nested
-   condition: $mrgSegment NOT_NULL
-   vars: 
-      mrgSegment: MRG
-   expressionsMap:
-      type:
-        type: STRING
-        valueOf: 'replaces'
-      other:
-        required: true
-        valueOf: resource/PatientMRG
-        expressionType: reference
-
+  generateList: true
+  evaluateLater: true
+  expressionType: nested
+  condition: $mrgSegment NOT_NULL
+  vars:
+    mrgSegment: MRG
+  expressionsMap:
+    type:
+      type: STRING
+      valueOf: "replaces"
+    other:
+      required: true
+      valueOf: resource/PatientMRG
+      expressionType: reference

--- a/src/main/resources/hl7/resource/ServiceRequest.yml
+++ b/src/main/resources/hl7/resource/ServiceRequest.yml
@@ -1,153 +1,157 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 resourceType: ServiceRequest
 id:
-   type: STRING
-   valueOf: 'UUID.randomUUID()'
-   expressionType: JEXL
-   
-identifier_1:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   expressionType: resource
-   vars:
-      valueIn: PV1.19.1 | PID.18.1 | MSH.7
-      systemCX: PV1.19.4 | PID.18.4
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "VN"
-      display: "Visit number"
+  type: STRING
+  valueOf: "UUID.randomUUID()"
+  expressionType: JEXL
 
-# The logic for Filler appears it should be:     
+identifier_1:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: PV1.19.1 | PID.18.1 | MSH.7
+    systemCX: PV1.19.4 | PID.18.4
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "VN"
+    display: "Visit number"
+
+# The logic for Filler appears it should be:
 #  valueIn: ORC.3.1 | OBR.3.1
-#  systemCX: ORC.3.2 | OBR.3.2    
+#  systemCX: ORC.3.2 | OBR.3.2
 # But if ORC.3.1 has a value and ORC.3.2 is empty but OBR.3.2 has a value,
 # it results in mismatched code and system values.
 # The code below forces the value and the system to be of the same pair.
 # Similar settings for Placer.
 
 identifier_2a:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   useGroup: true
-   expressionType: resource
-   vars:
-      valueIn: ORC.3.1
-      systemCX: ORC.3.2
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "FILL"
-      display: "Filler Identifier"
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  useGroup: true
+  expressionType: resource
+  vars:
+    valueIn: ORC.3.1
+    systemCX: ORC.3.2
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "FILL"
+    display: "Filler Identifier"
 
 identifier_2b:
-   condition: $valueInORC NULL && $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   useGroup: true
-   expressionType: resource
-   vars:
-      valueIn: OBR.3.1
-      systemCX: OBR.3.2
-      valueInORC: ORC.3.1
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "FILL"
-      display: "Filler Identifier"      
+  condition: $valueInORC NULL && $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  useGroup: true
+  expressionType: resource
+  vars:
+    valueIn: OBR.3.1
+    systemCX: OBR.3.2
+    valueInORC: ORC.3.1
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "FILL"
+    display: "Filler Identifier"
 
 identifier_3a:
-   condition: $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   useGroup: true
-   expressionType: resource
-   vars:
-      valueIn: ORC.2.1
-      systemCX: ORC.2.2 
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "PLAC"
-      display: "Placer Identifier"
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  useGroup: true
+  expressionType: resource
+  vars:
+    valueIn: ORC.2.1
+    systemCX: ORC.2.2
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "PLAC"
+    display: "Placer Identifier"
 
 identifier_3b:
-   condition:  $valueInORC NULL && $valueIn NOT_NULL
-   valueOf: datatype/Identifier_var
-   generateList: true
-   useGroup: true
-   expressionType: resource
-   vars:
-      valueIn: OBR.2.1
-      systemCX: OBR.2.2
-      valueInORC: ORC.2.1
-   constants:
-      system: "http://terminology.hl7.org/CodeSystem/v2-0203"
-      code: "PLAC"
-      display: "Placer Identifier"      
+  condition: $valueInORC NULL && $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  useGroup: true
+  expressionType: resource
+  vars:
+    valueIn: OBR.2.1
+    systemCX: OBR.2.2
+    valueInORC: ORC.2.1
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "PLAC"
+    display: "Placer Identifier"
 
 status:
-   type: SERVICE_REQUEST_STATUS
-   default: "unknown"
-   valueOf: ORC.5
-   expressionType: HL7Spec   
+  type: SERVICE_REQUEST_STATUS
+  default: "unknown"
+  valueOf: ORC.5
+  expressionType: HL7Spec
 
 intent:
-   type: STRING
-   valueOf: $default
-   expressionType: HL7Spec
-   constants:
-      default: "order"
+  type: STRING
+  valueOf: $default
+  expressionType: HL7Spec
+  constants:
+    default: "order"
 
 subject:
-   valueOf: datatype/Reference
-   expressionType: resource
-   specs: $Patient
+  valueOf: datatype/Reference
+  expressionType: resource
+  specs: $Patient
 
 # Requisition was removed because PGN does not currently validate with HAPI HL7 parser using system http://terminology.hl7.org/CodeSystem/v2-0203.
 # The only known possible alternative system: http://terminology.hl7.org/2.1.0/CodeSystem/v2-0203 fails to validate with HAPI FHIR validator.
 
 authoredOn:
-   type: DATE_TIME
-   valueOf: ORC.9 | OBR.6
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: ORC.9 | OBR.6
 
-occurrenceDateTime:   
-   type: DATE_TIME
-   valueOf: ORC.15 | OBR.7 | OBR.27.4
-   expressionType: HL7Spec
+occurrenceDateTime:
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: ORC.15 | OBR.7 | OBR.27.4
 
 requester:
-   condition: $request NOT_NULL 
-   valueOf: resource/Practitioner
-   expressionType: reference
-   specs: ORC.12 | OBR.16
-   vars:
-      request: ORC.12 | OBR.16
-      referenceDisplay: PERSON_DISPLAY_NAME, ORC.12 | OBR.16
+  condition: $request NOT_NULL
+  valueOf: resource/Practitioner
+  expressionType: reference
+  specs: ORC.12 | OBR.16
+  vars:
+    request: ORC.12 | OBR.16
+    referenceDisplay: PERSON_DISPLAY_NAME, ORC.12 | OBR.16
 
 reasonCode:
-   condition: $reasonCWE NOT_NULL 
-   valueOf: datatype/CodeableConcept
-   generateList: true
-   expressionType: resource
-   specs: OBR.31 | ORC.16  
-   vars:
-      reasonCWE: OBR.31 | ORC.16      
+  condition: $reasonCWE NOT_NULL
+  valueOf: datatype/CodeableConcept
+  generateList: true
+  expressionType: resource
+  specs: OBR.31 | ORC.16
+  vars:
+    reasonCWE: OBR.31 | ORC.16
 
 code:
-   condition: $codeCWE NOT_NULL 
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: OBR.4
-   vars:
-      codeCWE: OBR.4 
+  condition: $codeCWE NOT_NULL
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: OBR.4
+  vars:
+    codeCWE: OBR.4
 
 note:
-   valueOf: datatype/Annotation
-   condition: $annotationText NOT_NULL
-   expressionType: resource
-   vars:
-      annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')            
+  valueOf: datatype/Annotation
+  condition: $annotationText NOT_NULL
+  expressionType: resource
+  vars:
+    annotationText: NTE.3 *&, GeneralUtils.concatenateWithChar(annotationText, '  \n')

--- a/src/main/resources/hl7/resource/Specimen.yml
+++ b/src/main/resources/hl7/resource/Specimen.yml
@@ -1,54 +1,55 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 resourceType: Specimen
 id:
-   type: STRING
-   valueOf: 'UUID.randomUUID()'
-   expressionType: JEXL
-   
+  type: STRING
+  valueOf: "UUID.randomUUID()"
+  expressionType: JEXL
+
 identifier:
-   valueOf: datatype/Identifier
-   generateList: true
-   expressionType: resource
-   specs: SPM.2.1 | SPM.2.2
-   
+  valueOf: datatype/Identifier
+  generateList: true
+  expressionType: resource
+  specs: SPM.2.1 | SPM.2.2
+
 status:
-   type: SPECIMEN_STATUS
-   valueOf: SPM.20
-   expressionType: HL7Spec
+  type: SPECIMEN_STATUS
+  valueOf: SPM.20
+  expressionType: HL7Spec
 
 type:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: SPM.4 | SPM.5
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: SPM.4 | SPM.5
 
 receivedTime:
-   type: DATE_TIME
-   valueOf: SPM.18
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: SPM.18
 
 collection:
-   valueOf: secondary/collection
-   expressionType: resource
+  valueOf: secondary/collection
+  expressionType: resource
 
 processing:
-   valueOf: secondary/processing
-   expressionType: resource
+  valueOf: secondary/processing
+  expressionType: resource
 
 condition:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: SPM.24
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: SPM.24
 
 note:
-   valueOf: datatype/Annotation
-   expressionType: resource
-   condition: $obx3 EQUALS 48767-8
-   specs: OBX
-   vars:
-      obx3: STRING, OBX.3.1
-      annotationText: STRING, OBX.5
-
+  valueOf: datatype/Annotation
+  expressionType: resource
+  condition: $obx3 EQUALS 48767-8
+  specs: OBX
+  vars:
+    obx3: STRING, OBX.3.1
+    annotationText: STRING, OBX.5

--- a/src/main/resources/hl7/secondary/ImmunizationReaction.yml
+++ b/src/main/resources/hl7/secondary/ImmunizationReaction.yml
@@ -1,16 +1,17 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
 detail:
-   valueOf: resource/Observation_ImmunizationReaction
-   expressionType: reference
-   specs: OBX.5
+  valueOf: resource/Observation_ImmunizationReaction
+  expressionType: reference
+  specs: OBX.5
 
 date:
-   type: DATE_TIME
-   valueOf: OBX.14
-   expressionType: HL7Spec
-
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: OBX.14

--- a/src/main/resources/hl7/secondary/collection.yml
+++ b/src/main/resources/hl7/secondary/collection.yml
@@ -1,23 +1,28 @@
 #
-# (C) Copyright Mubashir Kazia. 2021
+# (C) Copyright Mubashir Kazia. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 collectedDateTime:
-   type: DATE_TIME
-   valueOf: SPM.17
-   expressionType: HL7Spec
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: SPM.17
+
 quantity:
-   valueOf: datatype/Quantity
-   expressionType: resource
-   vars:
-     value: SPM.12.1
-     unit: SPM.12.2
+  valueOf: datatype/Quantity
+  expressionType: resource
+  vars:
+    value: SPM.12.1
+    unit: SPM.12.2
+
 method:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: SPM.7
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: SPM.7
+
 bodySite:
-   valueOf: datatype/CodeableConcept
-   expressionType: resource
-   specs: SPM.8
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  specs: SPM.8

--- a/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
+++ b/src/test/java/io/github/linuxforhealth/core/config/ConverterConfigurationTest.java
@@ -80,15 +80,6 @@ class ConverterConfigurationTest {
         assertThat(theConvConfig.getAdditionalConceptmapFile())
                 .isEqualTo("src/test/resources/additional_conceptmap.yml");
         assertThat(theConvConfig.getAdditionalResourcesLocation()).isEqualTo("src/test/resources/additional_resources");
-
-        // Test that ZoneId can be overridden
-        assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+08:00"); // Double check value before the set (previouly checked line 79)
-        theConvConfig.setZoneId("+07:00");
-        assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+07:00");
-
-        // Test that a BAD ZoneId does not override and does not change existing value
-        theConvConfig.setZoneId("BAD_ZONE_ID");
-        assertThat(theConvConfig.getZoneId().getId()).isEqualTo("+07:00");
     }
 
     private void writeProperties(File configFile) throws FileNotFoundException, IOException {

--- a/src/test/java/io/github/linuxforhealth/hl7/data/DateUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/DateUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -51,62 +51,88 @@ class DateUtilTest {
 
     @Test
     void simple_datetime() {
-        String ld = DateUtil.formatToDateTimeWithZone("2008");
+        String ld = DateUtil.formatToDateTimeWithZone("2008","");
+        assertThat(ld).isEqualTo("2008");
+        ld = DateUtil.formatToDateTimeWithZone("2008","America/Chicago");
         assertThat(ld).isEqualTo("2008");
     }
 
     @Test
     void simple_datetime_month() {
-        String ld = DateUtil.formatToDateTimeWithZone("200809");
+        String ld = DateUtil.formatToDateTimeWithZone("200809","");
+        assertThat(ld).isEqualTo("2008-09");
+        ld = DateUtil.formatToDateTimeWithZone("200809","America/Chicago");
         assertThat(ld).isEqualTo("2008-09");
     }
 
     @Test
-    void simple_dateime_month_day() {
-        String ld = DateUtil.formatToDateTimeWithZone("20080926");
+    void simple_datetime_month_day() {
+        String ld = DateUtil.formatToDateTimeWithZone("20080926","");
+        assertThat(ld).isEqualTo("2008-09-26");
+        ld = DateUtil.formatToDateTimeWithZone("20080926","America/Chicago");
         assertThat(ld).isEqualTo("2008-09-26");
     }
 
     @Test
     void simple_datetime_month_day_hour() {
-        String ld = DateUtil.formatToDateTimeWithZone("2008092609");
+        String ld = DateUtil.formatToDateTimeWithZone("2008092609","");
         assertThat(ld).isEqualTo("2008-09-26T09:00:00+08:00");
+        ld = DateUtil.formatToDateTimeWithZone("2008092609","-07:00");
+        assertThat(ld).isEqualTo("2008-09-26T09:00:00-07:00");
+        ld = DateUtil.formatToDateTimeWithZone("2008092609","America/Chicago");
+        assertThat(ld).isEqualTo("2008-09-26T09:00:00-05:00");
     }
 
     @Test
     void simple_datetime_month_day_zone() {
-        String ld = DateUtil.formatToDateTimeWithZone("200711040132-0400");
+        // When ZoneId is part of dateTime input, no ZoneId adjustment
+        String ld = DateUtil.formatToDateTimeWithZone("200711040132-0400","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:00-04:00");
+        ld = DateUtil.formatToDateTimeWithZone("200711040132-0400","America/Chicago");
+        assertThat(ld).isEqualTo("2007-11-04T01:32:00-04:00"); 
     }
 
     @Test
     void simple_datetime_month_day_milliseconds_zone() {
-        String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3+0900");
+        // When ZoneId is part of dateTime input, no ZoneId adjustment
+        String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3+0900","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+09:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34+0900");
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34+0900","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.34+09:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345+0900");
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345+0900","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.345+09:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456+0900");
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456+0900","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3456+09:00");
     }
 
     @Test
     void simple_datetime_month_day_milliseconds_no_zone() {
-        String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3");
+        String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+08:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34");
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.34+08:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345");
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.345+08:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456");
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456","");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3456+08:00");
+
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3","+03:00");
+        assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+03:00");
+
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34","+03:00");
+        assertThat(ld).isEqualTo("2007-11-04T01:32:06.34+03:00");
+
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345","+03:00");
+        assertThat(ld).isEqualTo("2007-11-04T01:32:06.345+03:00");
+
+        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456","+03:00");
+        assertThat(ld).isEqualTo("2007-11-04T01:32:06.3456+03:00");
     }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/DateUtilTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/DateUtilTest.java
@@ -51,7 +51,7 @@ class DateUtilTest {
 
     @Test
     void simple_datetime() {
-        String ld = DateUtil.formatToDateTimeWithZone("2008","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("2008");
         assertThat(ld).isEqualTo("2008");
         ld = DateUtil.formatToDateTimeWithZone("2008","America/Chicago");
         assertThat(ld).isEqualTo("2008");
@@ -59,7 +59,7 @@ class DateUtilTest {
 
     @Test
     void simple_datetime_month() {
-        String ld = DateUtil.formatToDateTimeWithZone("200809","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("200809");
         assertThat(ld).isEqualTo("2008-09");
         ld = DateUtil.formatToDateTimeWithZone("200809","America/Chicago");
         assertThat(ld).isEqualTo("2008-09");
@@ -67,7 +67,7 @@ class DateUtilTest {
 
     @Test
     void simple_datetime_month_day() {
-        String ld = DateUtil.formatToDateTimeWithZone("20080926","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("20080926");
         assertThat(ld).isEqualTo("2008-09-26");
         ld = DateUtil.formatToDateTimeWithZone("20080926","America/Chicago");
         assertThat(ld).isEqualTo("2008-09-26");
@@ -75,7 +75,7 @@ class DateUtilTest {
 
     @Test
     void simple_datetime_month_day_hour() {
-        String ld = DateUtil.formatToDateTimeWithZone("2008092609","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("2008092609");
         assertThat(ld).isEqualTo("2008-09-26T09:00:00+08:00");
         ld = DateUtil.formatToDateTimeWithZone("2008092609","-07:00");
         assertThat(ld).isEqualTo("2008-09-26T09:00:00-07:00");
@@ -86,7 +86,7 @@ class DateUtilTest {
     @Test
     void simple_datetime_month_day_zone() {
         // When ZoneId is part of dateTime input, no ZoneId adjustment
-        String ld = DateUtil.formatToDateTimeWithZone("200711040132-0400","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("200711040132-0400");
         assertThat(ld).isEqualTo("2007-11-04T01:32:00-04:00");
         ld = DateUtil.formatToDateTimeWithZone("200711040132-0400","America/Chicago");
         assertThat(ld).isEqualTo("2007-11-04T01:32:00-04:00"); 
@@ -95,31 +95,31 @@ class DateUtilTest {
     @Test
     void simple_datetime_month_day_milliseconds_zone() {
         // When ZoneId is part of dateTime input, no ZoneId adjustment
-        String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3+0900","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.3+0900");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+09:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34+0900","");
+        ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.34+0900");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.34+09:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345+0900","");
+        ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.345+0900");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.345+09:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456+0900","");
+        ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.3456+0900");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3456+09:00");
     }
 
     @Test
     void simple_datetime_month_day_milliseconds_no_zone() {
-        String ld = DateUtil.formatToDateTimeWithZone("20071104013206.3","");
+        String ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.3");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3+08:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.34","");
+        ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.34");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.34+08:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.345","");
+        ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.345");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.345+08:00");
 
-        ld = DateUtil.formatToDateTimeWithZone("20071104013206.3456","");
+        ld = DateUtil.formatToDateTimeWithDefaultZone("20071104013206.3456");
         assertThat(ld).isEqualTo("2007-11-04T01:32:06.3456+08:00");
 
         ld = DateUtil.formatToDateTimeWithZone("20071104013206.3","+03:00");

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -368,25 +368,22 @@ class Hl7RelatedGeneralUtilsTest {
 
     @Test
     void getPV1DurationLength() throws DataTypeException {
-        // Get a PV1
-        ORU_R01 message = new ORU_R01();
-        ORU_R01_PATIENT_RESULT patientResult = message.getPATIENT_RESULT();
-        ORU_R01_PATIENT patient = patientResult.getPATIENT();
-        ORU_R01_VISIT visit = patient.getVISIT();
-        PV1 pv1 = visit.getPV1();
 
         ArrayList<String> timeZoneIds = Lists.newArrayList("", "+03:00", "Europe/Paris");
-        // String timeZoneId = "+03:00";
 
         for (String timeZoneId : timeZoneIds) {
+            // Get a PV1
+            ORU_R01 message = new ORU_R01();
+            ORU_R01_PATIENT_RESULT patientResult = message.getPATIENT_RESULT();
+            ORU_R01_PATIENT patient = patientResult.getPATIENT();
+            ORU_R01_VISIT visit = patient.getVISIT();
+            PV1 pv1 = visit.getPV1();
+
             // Admit and Discharge are not yet set; they are still empty
-            pv1.getAdmitDateTime().setValue("");
-            pv1.getDischargeDateTime().setValue("");
             assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isNull();
 
             // Admit set, but Discharge not yet set
             pv1.getAdmitDateTime().setValue("20161013154626");
-            pv1.getDischargeDateTime().setValue("");
             assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isNull();
 
             // Admit and Discharge set to valid values

--- a/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/Hl7RelatedGeneralUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,11 +9,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import com.google.common.collect.Lists;
 
 import org.hl7.fhir.r4.model.codesystems.EncounterStatus;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ca.uhn.hl7v2.model.DataTypeException;
+import ca.uhn.hl7v2.model.v26.group.ORU_R01_PATIENT;
+import ca.uhn.hl7v2.model.v26.group.ORU_R01_PATIENT_RESULT;
+import ca.uhn.hl7v2.model.v26.group.ORU_R01_VISIT;
+import ca.uhn.hl7v2.model.v26.message.ORU_R01;
+import ca.uhn.hl7v2.model.v26.segment.PV1;
+import io.github.linuxforhealth.hl7.data.date.DateUtil;
 
 class Hl7RelatedGeneralUtilsTest {
 
@@ -356,4 +365,66 @@ class Hl7RelatedGeneralUtilsTest {
         assertThat(Hl7RelatedGeneralUtils.getFormattedTelecomNumberValue("111", "", "", "4444444", "", "112"))
                 .isEqualTo("444 4444"); // Same rule without extension
     }
+
+    @Test
+    void getPV1DurationLength() throws DataTypeException {
+        // Get a PV1
+        ORU_R01 message = new ORU_R01();
+        ORU_R01_PATIENT_RESULT patientResult = message.getPATIENT_RESULT();
+        ORU_R01_PATIENT patient = patientResult.getPATIENT();
+        ORU_R01_VISIT visit = patient.getVISIT();
+        PV1 pv1 = visit.getPV1();
+
+        ArrayList<String> timeZoneIds = Lists.newArrayList("", "+03:00", "Europe/Paris");
+        // String timeZoneId = "+03:00";
+
+        for (String timeZoneId : timeZoneIds) {
+            // Admit and Discharge are not yet set; they are still empty
+            pv1.getAdmitDateTime().setValue("");
+            pv1.getDischargeDateTime().setValue("");
+            assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isNull();
+
+            // Admit set, but Discharge not yet set
+            pv1.getAdmitDateTime().setValue("20161013154626");
+            pv1.getDischargeDateTime().setValue("");
+            assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isNull();
+
+            // Admit and Discharge set to valid values
+            pv1.getAdmitDateTime().setValue("20161013154626");
+            pv1.getDischargeDateTime().setValue("20161013164626");
+            assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isEqualTo("60");
+
+            // Admit and Discharge set to valid values less that one minute apart
+            pv1.getAdmitDateTime().setValue("20161013154626");
+            pv1.getDischargeDateTime().setValue("20161013154628");
+            assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isEqualTo("0");
+
+            // Admit and Discharge set to insufficient detail values (have no minutes) return null
+            pv1.getAdmitDateTime().setValue("20161013");
+            pv1.getDischargeDateTime().setValue("20161013");
+            assertThat(Hl7RelatedGeneralUtils.pv1DurationLength(pv1, timeZoneId)).isNull();
+
+            // Other input types, such as a string, are not valid and null is returned
+            assertThat(Hl7RelatedGeneralUtils.pv1DurationLength("A string", timeZoneId)).isNull();
+        }
+
+    }
+
+    @Test
+    void get_datetime_value_valid() {
+        String gen = "20110613122406";
+        assertThat(Hl7RelatedGeneralUtils.dateTimeWithZoneId(gen,"")).isNotNull();
+        assertThat(Hl7RelatedGeneralUtils.dateTimeWithZoneId(gen,"")).isEqualTo(DateUtil.formatToDateTimeWithZone(gen,""));
+
+        // Test DateTime adjusts for milliseconds
+        gen = "20110613122406.637";
+        assertThat(Hl7RelatedGeneralUtils.dateTimeWithZoneId(gen,"")).isNotNull();
+        assertThat(Hl7RelatedGeneralUtils.dateTimeWithZoneId(gen,"")).isEqualTo(DateUtil.formatToDateTimeWithZone(gen,""));
+    }
+
+    @Test
+    void get_datetime_value_null() {
+        assertThat(Hl7RelatedGeneralUtils.dateTimeWithZoneId(null,null)).isNull();
+    }
+
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/data/InputTimeZoneIdTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/InputTimeZoneIdTest.java
@@ -1,0 +1,122 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Duration;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.junit.jupiter.api.Test;
+
+import io.github.linuxforhealth.hl7.ConverterOptions;
+import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
+/**
+ * Tests key changes in ZoneId input through context
+ */
+class InputTimeZoneIdTest {
+
+    @Test
+    void validateTimeZoneIdSettingViaOption() {
+
+        // NOTE: This simple Condition (PRB) segment is used for testing time because it has both 
+        // standard DateTime conversions (abatementDateTime, recordedDate) and value conversions (extension).
+        String hl7message = "MSH|^~\\&|||||20040629164652|1|PPR^PC1|331|P|2.3.1||\r"
+                + "PID||||||||||||||||||||||||||||||\r"
+                + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
+                // PRB.1 to PRB.4 required
+                // PRB.2 to recordedDateTime (check time ZoneId) (Note winter date)
+                // PRB.7 to Extension "condition-assertedDate" DateTime (check time ZoneId)
+                // PRB.9 to abatementDateTime (check time ZoneId)
+                // PRB.16 to onsetDateTime (check time ZoneId)
+                + "PRB|AD|20020202020000|K80.00^Cholelithiasis^I10|53956|||20070707070000||20090909090000|||||||20160616160000\r";
+
+        // FIRST test with city based ZoneId passed through options  
+        ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint()
+                .withZoneIdText("America/Chicago").build();
+        // "America/Chicago" will become -06:00 in winter (CST) -05:00 in spring/summer/fall (CDT).  This is expected. 
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message,
+                customOptionsWithTenant);
+        // Find the condition from the FHIR bundle.
+        List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
+        assertThat(conditionResource).hasSize(1);
+        Condition condition = (Condition) conditionResource.get(0);
+        assert (condition.getRecordedDateElement().getValueAsString()).contains("2002-02-02T02:00:00-06:00"); // PRB.2 Chicago Central STANDARD Time
+        assert (condition.getAbatementDateTimeType().getValueAsString()).contains("2009-09-09T09:00:00-05:00"); // PRB.9 Chicago Central DAYLIGHT Time
+        assert (condition.getOnsetDateTimeType().getValueAsString()).contains("2016-06-16T16:00:00-05:00"); // PRB.16 Chicago CDT
+        assert (condition.getExtensionByUrl("http://hl7.org/fhir/StructureDefinition/condition-assertedDate")
+                .getValueAsPrimitive().getValueAsString()).contains("2007-07-07T07:00:00-05:00"); // PRB.7 Chicago CDT
+
+        // SECOND test with fixed ZoneId passed through options      
+        customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint().withZoneIdText("+03:00")
+                .build();
+        e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message,
+                customOptionsWithTenant);
+        // Find the condition from the FHIR bundle.
+        conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
+        assertThat(conditionResource).hasSize(1);
+        condition = (Condition) conditionResource.get(0);
+        assert (condition.getRecordedDateElement().getValueAsString()).contains("2002-02-02T02:00:00+03:00"); // PRB.2 fixed ZoneId
+        assert (condition.getAbatementDateTimeType().getValueAsString()).contains("2009-09-09T09:00:00+03:00"); // PRB.9
+        assert (condition.getOnsetDateTimeType().getValueAsString()).contains("2016-06-16T16:00:00+03:00"); // PRB.16
+        assert (condition.getExtensionByUrl("http://hl7.org/fhir/StructureDefinition/condition-assertedDate")
+                .getValueAsPrimitive().getValueAsString()).contains("2007-07-07T07:00:00+03:00"); // PRB.7    
+
+        // THIRD test with no ZoneId passed through options, so it uses the config.properties ZoneId       
+        customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint().build();
+        e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message,
+                customOptionsWithTenant);
+        // Find the condition from the FHIR bundle.
+        conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
+        assertThat(conditionResource).hasSize(1);
+        condition = (Condition) conditionResource.get(0);
+        assert (condition.getRecordedDateElement().getValueAsString()).contains("2002-02-02T02:00:00+08:00"); // PRB.2 config.properties ZoneId
+        assert (condition.getAbatementDateTimeType().getValueAsString()).contains("2009-09-09T09:00:00+08:00"); // PRB.9
+        assert (condition.getOnsetDateTimeType().getValueAsString()).contains("2016-06-16T16:00:00+08:00"); // PRB.16
+        assert (condition.getExtensionByUrl("http://hl7.org/fhir/StructureDefinition/condition-assertedDate")
+                .getValueAsPrimitive().getValueAsString()).contains("2007-07-07T07:00:00+08:00"); // PRB.7    
+    }
+
+    @Test
+    void testEncounterLengthWithZoneIdContext() {
+        // This is the same as the test for PV1.44 and PV1.45 in Hl7EncounterFHIRConversionTest.testEncounterLength, but 
+        // here we pass in ZoneIdText context to ensure that Hl7RelatedGeneralUtils.pv1DurationLength works correctly with an input ZoneId.
+
+        // Both start PV1.44 and end PV1.45 must be present to use either value as part of length
+        // When both are present, the calculation value is provided in "Minutes"
+        String hl7message = "MSH|^~\\&|PROSOLV||||20151008111200||ADT^A01^ADT_A01|MSGID000001|T|2.6|||||||||\n"
+                + "EVN|A04|20151008111200|||||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                // PV1.44 present; PV1.45 present
+                + "PV1|1|E||||||||||||||||||||||||||||||||||||||||||20161013154626|20161014154634|||||||\n";
+
+        // Test with city based ZoneId passed through options  
+        ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint()
+                .withZoneIdText("Europe/Paris").build();
+        // "Europe/Paris" will become -01:00, but it we don't see because it is internal and relative to other date. 
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message,
+                customOptionsWithTenant);
+        // Find the encounter from the FHIR bundle.
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).hasSize(1);
+        Encounter encounter = (Encounter) encounters.get(0);
+        assertThat(encounter.hasLength()).isTrue();
+        Duration encounterLength = encounter.getLength();
+        assertThat(encounterLength.getValue()).isEqualTo((BigDecimal.valueOf(1440)));
+        assertThat(encounterLength.getUnit()).isEqualTo("minutes");
+        assertThat(encounterLength.getCode()).isEqualTo("min");
+        assertThat(encounterLength.getSystem()).isEqualTo("http://unitsofmeasure.org");
+    }
+
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/data/InputTimeZoneIdTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/InputTimeZoneIdTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021, 2022
+ * (C) Copyright IBM Corp. 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/java/io/github/linuxforhealth/hl7/data/JvmTimeZoneIdTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/JvmTimeZoneIdTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2022
+ * (C) Copyright IBM Corp. 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/test/java/io/github/linuxforhealth/hl7/data/JvmTimeZoneIdTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/JvmTimeZoneIdTest.java
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+
+import io.github.linuxforhealth.core.config.ConverterConfiguration;
+import io.github.linuxforhealth.core.terminology.UrlLookup;
+import io.github.linuxforhealth.hl7.ConverterOptions;
+import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
+import io.github.linuxforhealth.hl7.data.date.DateUtil;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
+// This is a specialized test to see that with no configured time zone, the JVM time zone is used.
+
+class JvmTimeZoneIdTest {
+
+    // These variables and before and after test processing are needed to
+    // Store the original config, set our own config, then restore the original config.
+    
+    private static final String CONF_PROP_HOME = "hl7converter.config.home";
+
+    @TempDir
+    static File folder;
+    static String originalConfigHome;
+
+    @BeforeAll
+    static void saveConfigHomeProperty() {
+        originalConfigHome = System.getProperty(CONF_PROP_HOME);
+    }
+
+    @AfterEach
+    void reset() {
+        System.clearProperty(CONF_PROP_HOME);
+        ConverterConfiguration.reset();
+        UrlLookup.reset();
+    }
+
+    @AfterAll
+    static void reloadPreviousConfigurations() {
+        if (originalConfigHome != null)
+            System.setProperty(CONF_PROP_HOME, originalConfigHome);
+        else
+            System.clearProperty(CONF_PROP_HOME);
+        UrlLookup.reset();
+    }
+
+    @Test
+    void testEmptyDefaultTimeZoneYieldsJVMZoneId() throws IOException {
+        // Create our own properties file
+        File configFile = new File(folder, "config.properties");
+        writeSimpleProperties(configFile);
+        System.setProperty(CONF_PROP_HOME, configFile.getParent());
+        ConverterConfiguration.reset();
+
+        // Prove that we're using our custom properties file with no ZoneId
+        ConverterConfiguration theConvConfig = ConverterConfiguration.getInstance();
+        assertThat(theConvConfig.getSupportedMessageTemplates()).hasSize(13); // Four messages supported.  (Proves we're using our created file, not the default.)
+        assertThat(theConvConfig.getZoneId()).isNull(); // Purposely empty
+
+        // IMPORTANT: TimeZoneId's are different than an offset.  TimeZoneId's are a location.  
+        // The offset of the location changes depending on whether Daylight savings time is in effect.
+        // Because we compare after processing, we can't compare locations, only offsets.
+        // It is critical that when we compare offsets, we start with the same date, so the same daylight savings rules apply!
+        // Otherwise a test might work only half of the year.
+
+        // Calculate the local server zone offset
+        LocalDateTime localDateTime = LocalDateTime.of(2002,Month.FEBRUARY,2,2,0,0);  //20020202020000
+        String defaultLocalZone = TimeZone.getDefault().getID();
+        ZoneId localZoneId = ZoneId.of(defaultLocalZone);
+        ZonedDateTime localZonedDateTime = localDateTime.atZone(localZoneId);
+        ZoneOffset localOffset = localZonedDateTime.getOffset();
+
+        // PART 1
+        // Test the format utility (which will fallback to local server time and zone offset)
+        String testDateTime = DateUtil.formatToDateTimeWithDefaultZone("20020202020000");
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        ZonedDateTime testZonedDateTime = ZonedDateTime.parse(testDateTime, dateTimeFormatter);
+        ZoneOffset testOffset = testZonedDateTime.getOffset();
+
+        // Offset from our function call test should equal offset of the local time
+        assertThat(testOffset).isEqualTo(localOffset);
+
+        // PART 2
+        // Do the same for a date going through the entire conversion
+        String hl7message = "MSH|^~\\&|||||20020202020000|1|PPR^PC1|331|P|2.3.1||\r"
+                + "PID||||||||||||||||||||||||||||||\r"
+                + "PV1||I||||||||||||||||||||||||||||||||||||||||||\r"
+                // PRB.1 to PRB.4 required
+                // PRB.2 to recordedDateTime (check time ZoneId)
+                + "PRB|AD|20020202020000|K80.00^Cholelithiasis^I10|53956||||||||||||\r";
+
+        ConverterOptions customOptionsWithTenant = new Builder().withValidateResource().withPrettyPrint().build();
+        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message,
+                customOptionsWithTenant);
+        // Find the condition from the FHIR bundle.
+        List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
+        assertThat(conditionResource).hasSize(1);
+        Condition condition = (Condition) conditionResource.get(0);
+
+        // Get the recordedDate value; convert it back to a zoned time; get the offset for comparison
+        testDateTime = condition.getRecordedDateElement().getValueAsString();  // PRB.2 
+        testZonedDateTime = ZonedDateTime.parse(testDateTime, dateTimeFormatter);
+        testOffset = testZonedDateTime.getOffset();
+
+        // Offset from our test should equal offset of the local time
+        assertThat(testOffset).isEqualTo(localOffset);
+
+        // After the test, the properties file resets.
+    }
+
+    private void writeSimpleProperties(File configFile) throws FileNotFoundException, IOException {
+        Properties prop = new Properties();
+        prop.put("supported.hl7.messages", "ADT_A01, ADT_A03, DFT_P03, MDM_T02, MDM_T06, OML_O21, ORM_O01, OMP_O09, ORU_R01, PPR_PC1, RDE_O11, RDE_O25, VXU_V04");
+        // default.time.zone purposely not set
+        prop.store(new FileOutputStream(configFile), null);
+    }
+ 
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolverTest.java
@@ -23,11 +23,9 @@ import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
 import ca.uhn.hl7v2.model.v26.datatype.TX;
 import ca.uhn.hl7v2.model.v26.datatype.XCN;
-import ca.uhn.hl7v2.model.v26.group.ORU_R01_PATIENT;
-import ca.uhn.hl7v2.model.v26.group.ORU_R01_PATIENT_RESULT;
-import ca.uhn.hl7v2.model.v26.group.ORU_R01_VISIT;
+
 import ca.uhn.hl7v2.model.v26.message.ORU_R01;
-import ca.uhn.hl7v2.model.v26.segment.PV1;
+
 import io.github.linuxforhealth.core.terminology.SimpleCode;
 import io.github.linuxforhealth.hl7.data.date.DateUtil;
 
@@ -78,35 +76,6 @@ class SimpleDataValueResolverTest {
     void get_date_value_null() {
 
         assertThat(SimpleDataValueResolver.DATE.apply(null)).isNull();
-    }
-
-    @Test
-    void get_datetime_value_valid() {
-        String gen = "20110613122406";
-        assertThat(SimpleDataValueResolver.DATE_TIME.apply(gen)).isNotNull();
-        assertThat(SimpleDataValueResolver.DATE_TIME.apply(gen)).isEqualTo(DateUtil.formatToDateTimeWithZone(gen));
-
-        // Test DateTime adjusts for milliseconds
-        gen = "20110613122406.637";
-        assertThat(SimpleDataValueResolver.DATE_TIME.apply(gen)).isNotNull();
-        assertThat(SimpleDataValueResolver.DATE_TIME.apply(gen)).isEqualTo(DateUtil.formatToDateTimeWithZone(gen));
-    }
-
-    @Test
-    void get_instant_value_null() {
-        assertThat(SimpleDataValueResolver.INSTANT.apply(null)).isNull();
-    }
-
-    @Test
-    void get_instant_value_valid() {
-        String gen = "20091130112038";
-        assertThat(SimpleDataValueResolver.INSTANT.apply(gen)).isNotNull();
-        assertThat(SimpleDataValueResolver.INSTANT.apply(gen)).isEqualTo(DateUtil.formatToZonedDateTime(gen));
-    }
-
-    @Test
-    void get_datetime_value_null() {
-        assertThat(SimpleDataValueResolver.DATE_TIME.apply(null)).isNull();
     }
 
     @Test
@@ -323,41 +292,6 @@ class SimpleDataValueResolverTest {
         assertThat(SimpleDataValueResolver.PERSON_DISPLAY_NAME.apply(cwe)).isNull();
         // String is not a valid input and should return null
         assertThat(SimpleDataValueResolver.PERSON_DISPLAY_NAME.apply("Bogus String")).isNull();
-    }
-
-    @Test
-    void getPV1DurationLength() throws DataTypeException {
-        // Get a PV1
-        ORU_R01 message = new ORU_R01();
-        ORU_R01_PATIENT_RESULT patientResult = message.getPATIENT_RESULT();
-        ORU_R01_PATIENT patient = patientResult.getPATIENT();
-        ORU_R01_VISIT visit = patient.getVISIT();
-        PV1 pv1 = visit.getPV1();
-
-        // Admit and Discharge are not yet set; they are still empty
-        assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply(pv1)).isNull();
-
-        // Admit set, but Discharge not yet set
-        pv1.getAdmitDateTime().setValue("20161013154626");
-        assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply(pv1)).isNull();
-
-        // Admit and Discharge set to valid values
-        pv1.getAdmitDateTime().setValue("20161013154626");
-        pv1.getDischargeDateTime().setValue("20161013164626");
-        assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply(pv1)).isEqualTo("60");
-
-        // Admit and Discharge set to valid values less that one minute apart
-        pv1.getAdmitDateTime().setValue("20161013154626");
-        pv1.getDischargeDateTime().setValue("20161013154628");
-        assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply(pv1)).isEqualTo("0");
-
-        // Admit and Discharge set to insufficient detail values (have no minutes) return null
-        pv1.getAdmitDateTime().setValue("20161013");
-        pv1.getDischargeDateTime().setValue("20161013");
-        assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply(pv1)).isNull();
-
-        // Other input types, such as a string, are not valid and null is returned
-        assertThat(SimpleDataValueResolver.PV1_DURATION_LENGTH.apply("A string")).isNull();
     }
 
     @Test

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7IdentifierFHIRConversionTest.java
@@ -324,7 +324,7 @@ class Hl7IdentifierFHIRConversionTest {
 
     @Test
     void conditionDg1IdentifierTest2() {
-        // Test PV1-19 for visit number; extId with DG1-3.1.
+        // Test PV1-19 for visit number; extID with DG1-3.1.
         // Also test DG1-20 creates additional identifiers.
         String withDG120 = "MSH|^~\\&|||||||ADT^A01^ADT_A01|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6||||||\r"
                 + "PID|||10290^^^WEST^MR||||20040530|M||||||||||||||||||||||N\n"
@@ -523,7 +523,7 @@ class Hl7IdentifierFHIRConversionTest {
         int posPLACER = getIdentifierPositionByValue("PON001", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
 
-        // Identifier 1: extId with MSH-7
+        // Identifier 1: extID with MSH-7
         Identifier identifier = report.getIdentifier().get(posExtId);
         String value = identifier.getValue();
         String system = identifier.getSystem();
@@ -573,7 +573,7 @@ class Hl7IdentifierFHIRConversionTest {
         assertThat(posFILLER).isNotSameAs(-1);
         int posPLACER = getIdentifierPositionByValue("CC_000000", identifiers);
         assertThat(posPLACER).isNotSameAs(-1);
-        // Identifier 1: extId with MSH-7
+        // Identifier 1: extID with MSH-7
         Identifier identifier = report.getIdentifier().get(posExtId);
         String value = identifier.getValue();
         String system = identifier.getSystem();
@@ -836,7 +836,7 @@ class Hl7IdentifierFHIRConversionTest {
 
     @Test
     void documentReferenceIdentifierTest() {
-        // Filler and placer from ORC, extId from MSH-7
+        // Filler and placer from ORC, extID from MSH-7
         String documentReference = "MSH|^~\\&|HL7Soup|Instance1|MCM|Instance2|200911021022|Security|MDM^T02|64322|P|2.6|123|456|ER|AL|USA|ASCII|en|2.6|56789^NID^UID|MCM||||\n"
                 +
                 "PID|1||000054321^^^MRN|||||||||||||M|CAT|||||N\n" +


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Passes context input zoneIdText as ZONEID system variable, which is passed real time to dateTime calculation and formatting routines so they are thread safe.  Updates yaml templates to use new utility and pass in the ZONEID.

Remove DATE_TIME, INSTANT, and PV1_DURATION_LENGTH DataValueResolvers and replaces with thread safe utilities that uses ZONEID.

Updates all tests.  Adds new tests for context zoneIdText.

Updates all documentation.

Some reformatting noise in yaml files.
