### PR TITLE
Fix tbl HL70064 lookup and Imm.programEligibility

### DIFF
--- a/src/main/resources/hl7/codesystem/CodingSystemMapping.yml
+++ b/src/main/resources/hl7/codesystem/CodingSystemMapping.yml
@@ -4490,8 +4490,6 @@
   url: "http://hl7.org/fhir/sid/us-medicare"
   oid: "urn:oid:2.16.840.1.113883.4.572"
 
-
-
 - id: "MBI"
   description: "Medicare Beneficiary Identifier"
   url: "http://hl7.org/fhir/sid/us-mbi"
@@ -4504,10 +4502,16 @@
   description: "languages"
   url: "http://hl7.org/fhir/ValueSet/all-languages"
   oid: "urn:oid:2.16.840.1.113883.4.642.3.21"
+
+  # next two are different id notations for the same table.
 - id: "HL70064"
   description: "Financial Class (HL7)"
   url: "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#"
   oid: "urn:oid:2.16.840.1.113883.12.64"
+- id: "V2-0064"
+  description: "Financial Class (HL7)"
+  url: "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#"
+  oid: "urn:oid:2.16.840.1.113883.12.64"  
 
   # source-record-type-system
 - id: "source-record-type-system"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.Test;
 
+import io.github.linuxforhealth.hl7.segments.util.DatatypeUtils;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
 class Hl7ImmunizationFHIRConversionTest {
@@ -167,13 +168,8 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(immunization.getDoseQuantity().getSystem()).isNull();
         assertThat(immunization.getDoseQuantity().getCode()).isNull();
 
-        assertThat(immunization.getProgramEligibilityFirstRep().getCodingFirstRep().getCode()).isEqualTo("V02");
-        assertThat(immunization.getProgramEligibilityFirstRep().getCodingFirstRep().getSystem())
-                .isEqualTo("urn:id:v2-0064");
-        assertThat(immunization.getProgramEligibilityFirstRep().getCodingFirstRep().getDisplay())
-                .isEqualTo("VFC eligible Medicaid/MedicaidManaged Care");
-        assertThat(immunization.getProgramEligibilityFirstRep().getText())
-                .isEqualTo("VFC eligible Medicaid/MedicaidManaged Care");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(immunization.getProgramEligibilityFirstRep(), "V02", "VFC eligible Medicaid/MedicaidManaged Care",
+        "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#", "VFC eligible Medicaid/MedicaidManaged Care");
 
         assertThat(immunization.hasFundingSource()).isFalse();
         assertThat(immunization.hasReaction()).isFalse();
@@ -213,12 +209,8 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(immunization.getDoseQuantity().getSystem()).isEqualTo("http://unitsofmeasure.org");
 
         // If OBX.3 is 30963-3 the OBX.5 is for funding source
-        assertThat(immunization.getFundingSource().getCodingFirstRep().getCode()).isEqualTo("V02");
-        assertThat(immunization.getFundingSource().getCodingFirstRep().getSystem()).isEqualTo("urn:id:v2-0064");
-        assertThat(immunization.getFundingSource().getCodingFirstRep().getDisplay())
-                .isEqualTo("VFC eligible Medicaid/MedicaidManaged Care");
-        assertThat(immunization.getFundingSource().getText()).isEqualTo("VFC eligible Medicaid/MedicaidManaged Care");
-
+        DatatypeUtils.checkCommonCodeableConceptAssertions(immunization.getFundingSource(), "V02", "VFC eligible Medicaid/MedicaidManaged Care",
+        "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#", "VFC eligible Medicaid/MedicaidManaged Care");
         assertThat(immunization.hasProgramEligibility()).isFalse();
         assertThat(immunization.hasReaction()).isFalse();
 


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Add v2-0064 to the tables list and adjust tests to correctly test for Immunization.programEligibility