### PR TITLE
Support VXU Immunization.Performer orgs

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
@@ -91,7 +91,7 @@ public class HL7MessageModel implements MessageTemplate<Message> {
         // NOTE: We have seen PHI in these exception messages.
         try {
             bundle = engine.transform(dataSource, this.getResources(), new HashMap<>());
-            bundle = deduplicate(bundle);
+            deduplicate(bundle);  // Bundle is passed by reference and may be modified
             engine.getFHIRContext().validate(bundle);
 
         } catch (Exception e) {
@@ -117,8 +117,8 @@ public class HL7MessageModel implements MessageTemplate<Message> {
     }
 
     // General deduplication utility. Currently only Organizations.
-    // Potentially modifies bundle!
-    private Bundle deduplicate(Bundle bundle) {
+    // Bundle is passed by reference and may be modified
+    private void deduplicate(Bundle bundle) {
         List<BundleEntryComponent> entries = bundle.getEntry();
         Iterator<BundleEntryComponent> i = entries.iterator();
         while (i.hasNext()) {
@@ -128,7 +128,6 @@ public class HL7MessageModel implements MessageTemplate<Message> {
                 i.remove();  // Safe removal
             }
         }
-        return bundle;
     }
 
     // Determine if an entry has duplicates by counting all the entries which have the same Url.

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,10 +8,13 @@ package io.github.linuxforhealth.hl7.message;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
@@ -34,7 +37,7 @@ public class HL7MessageModel implements MessageTemplate<Message> {
 
     @JsonCreator
     public HL7MessageModel(@JsonProperty("messageName") String messageName,
-                           @JsonProperty("resources") List<HL7FHIRResourceTemplate> resources) {
+            @JsonProperty("resources") List<HL7FHIRResourceTemplate> resources) {
         this.messageName = messageName;
         this.resources = new ArrayList<>();
         if (resources != null && !resources.isEmpty()) {
@@ -52,7 +55,6 @@ public class HL7MessageModel implements MessageTemplate<Message> {
         }
         LOGGER.error("Error transforming HL7 message. {}", classAndStack);
     }
-
 
     public String convert(String message, MessageEngine engine) throws IOException {
         Preconditions.checkArgument(StringUtils.isNotBlank(message),
@@ -75,7 +77,6 @@ public class HL7MessageModel implements MessageTemplate<Message> {
 
     }
 
-
     @Override
     public Bundle convert(Message message, MessageEngine engine) {
         Preconditions.checkArgument(message != null, "Input Hl7 message cannot be null");
@@ -90,6 +91,7 @@ public class HL7MessageModel implements MessageTemplate<Message> {
         // NOTE: We have seen PHI in these exception messages.
         try {
             bundle = engine.transform(dataSource, this.getResources(), new HashMap<>());
+            bundle = deduplicate(bundle);
             engine.getFHIRContext().validate(bundle);
 
         } catch (Exception e) {
@@ -98,9 +100,7 @@ public class HL7MessageModel implements MessageTemplate<Message> {
         }
 
         return bundle;
-
     }
-
 
     @Override
     public String getMessageName() {
@@ -116,5 +116,32 @@ public class HL7MessageModel implements MessageTemplate<Message> {
         return new ArrayList<>(resources);
     }
 
+    // General deduplication utility. Currently only Organizations.
+    // Potentially modifies bundle!
+    private Bundle deduplicate(Bundle bundle) {
+        List<BundleEntryComponent> entries = bundle.getEntry();
+        Iterator<BundleEntryComponent> i = entries.iterator();
+        while (i.hasNext()) {
+            BundleEntryComponent entry = i.next(); // Safe traversal for removal
+            // Currently only looking for duplicate Organizations, because their Urls and Id's are created from org data.
+            if (entry.getFullUrl().startsWith("Organization/") && duplicateFound(entry, entries)) {
+                i.remove();  // Safe removal
+            }
+        }
+        return bundle;
+    }
+
+    // Determine if an entry has duplicates by counting all the entries which have the same Url.
+    // If count > 1 then it has duplicates.  (It will be counted, too, as 1.)
+    private boolean duplicateFound(BundleEntryComponent entry, List<BundleEntryComponent> entries) {
+        String targetUrl = entry.getFullUrl();
+        Integer foundCount = 0;
+        for (BundleEntryComponent component : entries) {
+            if (component.getFullUrl().equals(targetUrl)) {
+                foundCount++;
+            }
+        }
+        return foundCount > 1;
+    }
 
 }

--- a/src/main/resources/hl7/message/VXU_V04.yml
+++ b/src/main/resources/hl7/message/VXU_V04.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -21,7 +21,7 @@ resources:
       additionalSegments:
              - PD1
              - MSH
-      
+
     - resourceName: Encounter
       segment: .PV1
       resourcePath: resource/Encounter
@@ -45,3 +45,4 @@ resources:
               - .RXR
               - .OBSERVATION.OBX
               - MSH
+              - PATIENT.PV1

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -174,6 +174,14 @@ performer_2:
   vars:
     administeringProvider: RXA.10
 
+# This performer is an organization. One will be created.
+performer_3:
+  valueOf: secondary/Performer
+  generateList: true
+  expressionType: resource
+  vars:
+    administeringProviderOrganization: RXA.27.4 | PV1.3.4.1 | RXA.11.4
+
 note:
   valueOf: datatype/Annotation
   expressionType: resource

--- a/src/main/resources/hl7/secondary/Performer.yml
+++ b/src/main/resources/hl7/secondary/Performer.yml
@@ -34,7 +34,6 @@ actor_1:
    condition: $orderingProvider NOT_NULL || $administeringProvider NOT_NULL
    valueOf: resource/Practitioner
    expressionType: reference
-   generateList: true
    specs: $orderingProvider | $administeringProvider
    required: true
 
@@ -42,7 +41,6 @@ actor_2:
    condition: $administeringProviderOrganization NOT_NULL
    valueOf: resource/Organization
    expressionType: reference
-   generateList: true
    specs: $administeringProviderOrganization
    required: true   
    vars:

--- a/src/main/resources/hl7/secondary/Performer.yml
+++ b/src/main/resources/hl7/secondary/Performer.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,10 +20,34 @@ function_v2:
     system: 'http://terminology.hl7.org/CodeSystem/v2-0443'
     code: AP
     text: Administering Provider
-actor:
+
+function_v3:
+   condition: $administeringProviderOrganization NOT_NULL
+   valueOf: datatype/CodeableConcept_var
+   expressionType: resource
+   constants:
+    system: 'http://terminology.hl7.org/CodeSystem/v2-0443'
+    code: AP
+    text: Administering Provider    
+
+actor_1:
    condition: $orderingProvider NOT_NULL || $administeringProvider NOT_NULL
    valueOf: resource/Practitioner
    expressionType: reference
    generateList: true
    specs: $orderingProvider | $administeringProvider
    required: true
+
+actor_2:
+   condition: $administeringProviderOrganization NOT_NULL
+   valueOf: resource/Organization
+   expressionType: reference
+   generateList: true
+   specs: $administeringProviderOrganization
+   required: true   
+   vars:
+     idValue: $administeringProviderOrganization 
+     orgName: String, $administeringProviderOrganization
+     orgIdValue: String, $administeringProviderOrganization # used for Id and Identifier
+   constants:   
+     orgIdSystem: 'extID'  # 'urn:id:' added by SystemCX processing

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Immunization;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Observation;
@@ -37,6 +38,7 @@ class Hl7ImmunizationFHIRConversionTest {
         String hl7VUXmessageRep = "MSH|^~\\&|EHR|12345^SiteName|MIIS|99990|20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
                 + "ORC|RE||197027||ER||||20130905041038|||MD67895^Pediatric^MARY^^^^MD^^RIA|||||\r"
+                // RXA.11 to Performer Organization
                 + "RXA|||20130531||48^HIB PRP-T^CVX|0.5|ML^^ISO+||00^new immunization record^NIP001|^Sticker^Nurse|^^^RI2050||||33k2a|20131210|PMC^sanofi^MVX|00^Patient refusal^NIP002||PA|A|20120901041038\r"
                 + "OBX|1|CWE|31044-1^Reaction^LN|1|VXC9^Persistent, inconsolable crying lasting > 3 hours within 48 hours of dose^CDCPHINVS||||||F|||20130531|||VXC40^per imm^CDCPHINVS\r";
 
@@ -83,7 +85,7 @@ class Hl7ImmunizationFHIRConversionTest {
 
         String requesterRef1 = resource.getPerformer().get(0).getActor().getReference();
         Practitioner practBundle1 = ResourceUtils.getSpecificPractitionerFromBundleEntriesList(e, requesterRef1);
-        assertThat(resource.getPerformer()).hasSize(2);
+        assertThat(resource.getPerformer()).hasSize(3);
         assertThat(resource.getPerformer().get(0).getFunction().getCoding().get(0).getCode())
                 .isEqualTo("OP"); // ORC.12
         assertThat(resource.getPerformer().get(0).getFunction().getText())
@@ -105,6 +107,12 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(practBundle2.getNameFirstRep().getFamily()).isEqualTo("Sticker");
         assertThat(practBundle2.getNameFirstRep().getGiven().get(0)).hasToString("Nurse");
 
+        String requesterRef3 = resource.getPerformer().get(2).getActor().getReference();
+        assertThat(resource.getPerformer().get(2).getFunction().getCoding().get(0).getCode())
+                .isEqualTo("AP"); // RXA.10
+        assertThat(resource.getPerformer().get(2).getFunction().getText())
+                .isEqualTo("Administering Provider"); // RXA.10
+
         // Immunization.Reaction Date (OBX.14) and Detail (OBX.5 if OBX 3 is 31044-1)
         assertThat(resource.getReactionFirstRep().getDateElement().toString()).contains("2013-05-31"); //OBX.14
         assertThat(resource.getReactionFirstRep().getDetail().hasReference()).isTrue(); //OBX.5
@@ -114,17 +122,23 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(observations).hasSize(1);
         Observation obs = ResourceUtils.getResourceObservation(observations.get(0), ResourceUtils.context);
         assertThat(obs.getId()).isEqualTo(reactionDetail);
-        assertThat(obs.getCode().getCodingFirstRep().getDisplay()).isEqualTo("Persistent, inconsolable crying lasting > 3 hours within 48 hours of dose");
+        assertThat(obs.getCode().getCodingFirstRep().getDisplay())
+                .isEqualTo("Persistent, inconsolable crying lasting > 3 hours within 48 hours of dose");
         assertThat(obs.getCode().getCodingFirstRep().getCode()).isEqualTo("VXC9");
         assertThat(obs.getCode().getCodingFirstRep().getSystem()).isEqualTo("urn:id:CDCPHINVS");
-        assertThat(obs.getCode().getText()).isEqualTo("Persistent, inconsolable crying lasting > 3 hours within 48 hours of dose");
+        assertThat(obs.getCode().getText())
+                .isEqualTo("Persistent, inconsolable crying lasting > 3 hours within 48 hours of dose");
         assertThat(obs.getIdentifierFirstRep().getValue()).isEqualTo("197027-VXC9-CDCPHINVS");
         assertThat(obs.getIdentifierFirstRep().getSystem()).isEqualTo("urn:id:extID");
 
-        // Looking for one Organization that matches the manufacturer reference
+        // Looking for two Organizations: one for the manufacturer reference and one for the Immunization.performer
         List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
-        assertThat(organizations).hasSize(1);
+        assertThat(organizations).hasSize(2);
         Organization org = ResourceUtils.getResourceOrganization(organizations.get(0), ResourceUtils.context);
+        assertThat(org.getName()).isEqualTo("RI2050");
+        assertThat(org.getId()).isEqualTo(requesterRef3);
+        assertThat(org.hasContact()).isFalse();
+        org = ResourceUtils.getResourceOrganization(organizations.get(1), ResourceUtils.context);
         assertThat(org.getName()).isEqualTo("sanofi");
         assertThat(org.getId()).isEqualTo(manufacturerRef);
         assertThat(org.hasContact()).isFalse();
@@ -133,6 +147,9 @@ class Hl7ImmunizationFHIRConversionTest {
         List<Resource> serviceRequestList = ResourceUtils.getResourceList(e, ResourceType.ServiceRequest);
         // Confirm that a serviceRequest was not created.
         assertThat(serviceRequestList).isEmpty();
+
+        // Check for expected resources: Organizations (2), Immunization, Patient, Observation, Practitioner (2)
+        assertThat(e).hasSize(7);
     }
 
     @Test
@@ -168,8 +185,10 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(immunization.getDoseQuantity().getSystem()).isNull();
         assertThat(immunization.getDoseQuantity().getCode()).isNull();
 
-        DatatypeUtils.checkCommonCodeableConceptAssertions(immunization.getProgramEligibilityFirstRep(), "V02", "VFC eligible Medicaid/MedicaidManaged Care",
-        "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#", "VFC eligible Medicaid/MedicaidManaged Care");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(immunization.getProgramEligibilityFirstRep(), "V02",
+                "VFC eligible Medicaid/MedicaidManaged Care",
+                "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#",
+                "VFC eligible Medicaid/MedicaidManaged Care");
 
         assertThat(immunization.hasFundingSource()).isFalse();
         assertThat(immunization.hasReaction()).isFalse();
@@ -209,8 +228,10 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(immunization.getDoseQuantity().getSystem()).isEqualTo("http://unitsofmeasure.org");
 
         // If OBX.3 is 30963-3 the OBX.5 is for funding source
-        DatatypeUtils.checkCommonCodeableConceptAssertions(immunization.getFundingSource(), "V02", "VFC eligible Medicaid/MedicaidManaged Care",
-        "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#", "VFC eligible Medicaid/MedicaidManaged Care");
+        DatatypeUtils.checkCommonCodeableConceptAssertions(immunization.getFundingSource(), "V02",
+                "VFC eligible Medicaid/MedicaidManaged Care",
+                "https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.64#",
+                "VFC eligible Medicaid/MedicaidManaged Care");
         assertThat(immunization.hasProgramEligibility()).isFalse();
         assertThat(immunization.hasReaction()).isFalse();
 
@@ -316,9 +337,9 @@ class Hl7ImmunizationFHIRConversionTest {
                 // First Immunization, also create manufacturer reference to Organization sanofi 
                 + "ORC|RE||197027||ER||||||||||||RI2050\r" //ORC.5 is here to prove RXA.20 is taking precedence
                 + "RXA|0|1|20130531|20130531|48^HIB PRP-T^CVX|0.5|ML^^ISO+||||||||33k2a|20131210|PMC^sanofi^MVX|||CP|A|\r"
-                // Second Immunization.  No manufacturer or Organization created.
+                // Second Immunization.  No manufacturer or Organization created. No RXA.11 nor RXA.27
                 + "ORC|RE||IZ-783278^NDA||||||||||||||\r"
-                + "RXA|0|1|20170513|20170513|62^HPV quadrivalent^CVX|999|||||^^^MIICSHORTCODE|||||||00^Parental Refusal^NIP002||RE\r"
+                + "RXA|0|1|20170513|20170513|62^HPV quadrivalent^CVX|999||||||||||||00^Parental Refusal^NIP002||RE\r"
                 // Third Immunization, also create manufacturer reference to Organization merck 
                 + "ORC|RE||IZ-783279^NDA||||||||||||||\r"
                 + "RXA|0|1|20170513|20170513|136^MCV4-CRM^CVX^90734^MCV4-CRM^CPT|1|mL||||||||MRK1234|20211201|MSD^MERCK^MVX||||CP|A\r";
@@ -350,5 +371,118 @@ class Hl7ImmunizationFHIRConversionTest {
             assertThat(mapDrugNameToMfgRefId.get(mapMfgNameToDrugName.get(org.getName()))).contains(org.getId());
         }
 
+    }
+
+    @Test
+    // Test priority of Immunization Performer sourcing is tested. 
+    void testImmunizationAdministrationPlaceOrg1() throws IOException {
+        String hl7VUXmessageRep = "MSH|^~\\&|||||20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                // PV1.3.4 to Organization place; used by Encounter, but bypassed for Immunization Performer because RXA.27 has priority
+                + "PV1||O|^^^PlacePV1.3.4\r"
+                + "ORC|||197027|||||||^Clerk^Myron|||||||RI2050\r"
+                // RXA.11 present, but should be ignored because RXA.27 has priority
+                // RXA.12 - RXA.26 not used
+                + "RXA|0|1|20130531||48^HIB PRP-T^CVX||||||^^^PlaceRXA11|||||||||||||||"
+                // RXA.27 to Immunization Performer
+                + "|^^^PlaceRXA27\r"
+                + "OBX|1|CE|59784-9^Disease with presumed immunity^LN||\r";
+
+        List<Bundle.BundleEntryComponent> e = ResourceUtils
+                .createFHIRBundleFromHL7MessageReturnEntryList(hl7VUXmessageRep);
+
+        // We expect two different organizations, one for Encounter.serviceProvider, one for Immunization.performer   
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(2);
+        Organization org1 = (Organization) organizations.get(0);
+        Organization org2 = (Organization) organizations.get(1);
+        String orgId1 = org1.getId(); // RXA.27
+        String orgId2 = org2.getId(); // PV1.3.4
+
+        List<Resource> immunizations = ResourceUtils.getResourceList(e, ResourceType.Immunization);
+        assertThat(immunizations).hasSize(1);
+        Immunization imm = (Immunization) immunizations.get(0);
+        assertThat(imm.getPerformer()).hasSize(1); // RXA.27
+        assertThat(imm.getPerformerFirstRep().getActor().getReference()).isEqualTo(orgId1); // RXA.27
+
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).hasSize(1);
+        Encounter enc = (Encounter) encounters.get(0);
+        assertThat(enc.getServiceProvider().getReference()).isEqualTo(orgId2); // PV1.3.4
+
+        // Check for expected resources: Organizations (2), Immunization, Encounter, Patient
+        assertThat(e).hasSize(5);
+    }
+
+    @Test
+    // Second test of priority of Immunization Performer sourcing.
+    // Special case where the Encounter referenced Organization and the Immunization referenced Organization are the same.
+    // There will only be one created organization, because any duplicates are de-duplicated.
+    void testImmunizationAdministrationPlaceOrg2() throws IOException {
+        String hl7VUXmessageRep = "MSH|^~\\&|||||20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                // PV1.3.4 to Organization place id
+                + "PV1||O|^^^PlacePV1.3.4\r"
+                + "ORC|||197027|||||||^Clerk^Myron|||||||RI2050\r"
+                // RXA.11 present but ignored because PV1.3.4 takes priority
+                // RXA.12 - RXA.27 not used
+                + "RXA|0|1|20130531||48^HIB PRP-T^CVX||||||^^^PlaceRXA11||||||||||||||||"
+                + "OBX|1|CE|59784-9^Disease with presumed immunity^LN||\r";
+
+        List<Bundle.BundleEntryComponent> e = ResourceUtils
+                .createFHIRBundleFromHL7MessageReturnEntryList(hl7VUXmessageRep);
+
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(1); // Proves that deduplication worked
+        Organization org = (Organization) organizations.get(0);
+        String orgId = org.getId(); // PV1.3.4
+
+        List<Resource> immunizations = ResourceUtils.getResourceList(e, ResourceType.Immunization);
+        assertThat(immunizations).hasSize(1);
+        Immunization imm = (Immunization) immunizations.get(0);
+        assertThat(imm.getPerformer()).hasSize(1); // PV1.3.4
+        assertThat(imm.getPerformerFirstRep().getActor().getReference()).isEqualTo(orgId);
+
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).hasSize(1);
+        Encounter enc = (Encounter) encounters.get(0);
+        assertThat(enc.getServiceProvider().getReference()).isEqualTo(orgId); // PV1.3.4
+
+        // Check for expected resources: Organization, Immunization, Encounter, Patient
+        assertThat(e).hasSize(4);
+    }
+
+    @Test
+    // Third test of priority of Immunization Performer sourcing.
+    void testImmunizationAdministrationPlaceOrg3() throws IOException {
+        String hl7VUXmessageRep = "MSH|^~\\&|||||20140701041038||VXU^V04^VXU_V04|MSG.Valid_01|P|2.6|||\n"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                // PV1 purposely missing
+                + "ORC|||197027|||||||^Clerk^Myron|||||||RI2050\r"
+                // RXA.6 - RXA6.26 not used
+                // RXA.11 present and takes priority because there is no RXA.27 nor PV1.3.4
+                + "RXA|0|1|20130531||48^HIB PRP-T^CVX||||||^^^PlaceRXA11|||||||||||||||"
+                + "OBX|1|CE|59784-9^Disease with presumed immunity^LN||\r";
+
+        List<Bundle.BundleEntryComponent> e = ResourceUtils
+                .createFHIRBundleFromHL7MessageReturnEntryList(hl7VUXmessageRep);
+
+        // We expect two different organizations, one for Encounter.serviceProvider, one for Immunization.performer   
+        List<Resource> organizations = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizations).hasSize(1);
+        Organization org = (Organization) organizations.get(0);
+        String orgId = org.getId(); // RXA.11
+
+        List<Resource> immunizations = ResourceUtils.getResourceList(e, ResourceType.Immunization);
+        assertThat(immunizations).hasSize(1);
+        Immunization imm = (Immunization) immunizations.get(0);
+        assertThat(imm.getPerformer()).hasSize(1); // RXA.11
+        assertThat(imm.getPerformerFirstRep().getActor().getReference()).isEqualTo(orgId); // RXA.11
+
+        List<Resource> encounters = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounters).isEmpty();
+
+        // Check for expected resources: Organizations, Immunization,  Patient
+        assertThat(e).hasSize(3);
     }
 }


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

This supports the creation of Organizations as Immunization Performers based on `RXA.27.4 | PV1.3.4.1 | RXA.11.4`

Implements deduplication of Organizations.