### PR TITLE
Fix status from OBX-11 in Obs_serviceProvider

### DIFF
--- a/src/main/resources/hl7/resource/Observation_ImmunizationReaction.yml
+++ b/src/main/resources/hl7/resource/Observation_ImmunizationReaction.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -26,6 +26,7 @@ identifier:
 status:
    type: OBSERVATION_STATUS
    default: unknown
+   valueOf: OBX.11 
    expressionType: HL7Spec
 
 code:


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Fixes Observation.status when created via Observation_ImmunizationReaction.