### PR TITLE
Fix Immun. only first OBX proccessed; javadoc

### DIFF
--- a/TECHNIQUES.md
+++ b/TECHNIQUES.md
@@ -233,3 +233,31 @@ diagnosis:
           # refconditionId is calculated by pattern matching to find identifier that contains urn:id:extID as the system"
           refconditionId: $BASE_VALUE, GeneralUtils.extractAttribute(refconditionId,"$.identifier[?(@.system==\"urn:id:extID\")].value","String")
 ```
+
+#### Referencing fields of repeating segments
+
+As another example, in Immunization, each of the OBX segments needed processing of OBX.5 fields based on the value of OBX.3.  The following looks like it would work, but it doesn't. On the surface, it appears that `specs: OBX.5` will take each OBX record and process OBX5.  However this only works for the _first_ OBX.5, because `specs: OBX.5` is really specifying to repeat the sub-fields of OBX.5.  
+```yml
+# Wrong way to repeat for all OBX records
+fundingSource:
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  condition: $obx3b EQUALS 30963-3
+  specs: OBX.5
+  vars:
+    obx3b: String, OBX.3.1
+```
+The solution is to repeat on OBX using `spec: OBX`, and nest the OBX.5 processing within the repeat from `spec: OBX` 
+```yml
+# Right way to repeat for all OBX records
+fundingSource:
+   expressionType: nested
+   condition: $obx3b EQUALS 30963-3
+   specs: OBX
+   vars:
+      obx3b: String, OBX.3.1 
+   expressions:
+      - valueOf: datatype/CodeableConcept
+        expressionType: resource
+        specs: OBX.5
+```

--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -201,7 +201,7 @@ The extraction logic for each field can be defined by using expressions. This co
 * type: DEFAULT - Object <br>
   Represents the class type for the final return value extracted for the field.
 * specs: DEFAULT - NONE<br>
-  Represents the base value for a resource, if no spec is provided then parents base value would be used as base value for child resource.
+  Represents the base value for a resource, if no spec is provided then parents base value would be used as base value for child resource.  Spec causes a repeating field or segment to be processed once for each field. 
   Refer to the section on supported formats for [Specification](#specification).<br>
 
 * default: DEFAULT - NULL<br>

--- a/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
+++ b/src/main/java/io/github/linuxforhealth/fhir/FHIRContext.java
@@ -41,6 +41,7 @@ public class FHIRContext {
      * @param isPrettyPrint Should PrettyPrint be applied to output formatting
      * @param validateResource Should the output be FHIR validated
      * @param properties Run-time properties in a Map of Key / Value String pairs
+     * @param zoneIdText Country/city zoneId text or offset
      * 
      */
     public FHIRContext(boolean isPrettyPrint, boolean validateResource, Map<String,String> properties, String zoneIdText) {

--- a/src/main/java/io/github/linuxforhealth/hl7/ConverterOptions.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/ConverterOptions.java
@@ -102,7 +102,7 @@ public class ConverterOptions {
     /**
      * getProperty looks up the value for a property of key
      * 
-     * @key isPrettyPrint Should PrettyPrint be applied to output formatting
+     * @param key Property key to look up
      * 
      * @return the value associated with the key or NULL if the key is not found
      * 

--- a/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
+++ b/src/main/resources/hl7/codesystem/v2ToFhirMapping.yml
@@ -144,7 +144,7 @@ DocumentReferenceStatus: #DocumenReference Status
   S: current
   X: entered-in-error
 
-CompositionStatus: #DocumenReference docStatus
+CompositionStatus: #DocumentReference docStatus
   #TXA.17
   AU: final
   DI: preliminary

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -209,10 +209,10 @@ isSubpotent:
 
 programEligibility: 
     expressionType: nested
-    condition: $obx3b EQUALS 64994-7
+    condition: $obx3 EQUALS 64994-7
     specs: OBX # Repeat for all OBX records
     vars:
-      obx3b: String, OBX.3.1
+      obx3: String, OBX.3.1
     expressions:
       - valueOf: datatype/CodeableConcept
         expressionType: resource
@@ -220,10 +220,10 @@ programEligibility:
 
 fundingSource:
   expressionType: nested
-  condition: $obx3b EQUALS 30963-3
+  condition: $obx3 EQUALS 30963-3
   specs: OBX # Repeat for all OBX records
   vars:
-    obx3b: String, OBX.3.1
+    obx3: String, OBX.3.1
   expressions:
     - valueOf: datatype/CodeableConcept
       expressionType: resource

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -81,13 +81,16 @@ vaccineCode_1:
     code: RXA.5
 
 vaccineCode_2:
+  expressionType: nested
   condition: $obx31 EQUALS 30956-7 && $rxa5 NULL
-  valueOf: datatype/CodeableConcept
-  expressionType: resource
-  specs: OBX.5
+  specs: OBX # Repeat for all OBX records
   vars:
     rxa5: RXA.5
     obx31: String, OBX.3.1
+  expressions:
+    - valueOf: datatype/CodeableConcept
+      expressionType: resource
+      specs: OBX.5
 
 patient:
   valueOf: datatype/Reference
@@ -204,21 +207,27 @@ isSubpotent:
   vars:
     rxa20: String, RXA.20
 
-programEligibility:
-  valueOf: datatype/CodeableConcept
-  expressionType: resource
-  condition: $obx3 EQUALS 64994-7
-  specs: OBX.5
-  vars:
-    obx3: String, OBX.3.1
-    
+programEligibility: 
+    expressionType: nested
+    condition: $obx3b EQUALS 64994-7
+    specs: OBX # Repeat for all OBX records
+    vars:
+      obx3b: String, OBX.3.1
+    expressions:
+      - valueOf: datatype/CodeableConcept
+        expressionType: resource
+        specs: OBX.5
+
 fundingSource:
-  valueOf: datatype/CodeableConcept
-  expressionType: resource
-  condition: $obx3 EQUALS 30963-3
-  specs: OBX.5
+  expressionType: nested
+  condition: $obx3b EQUALS 30963-3
+  specs: OBX # Repeat for all OBX records
   vars:
-    obx3: String, OBX.3.1
+    obx3b: String, OBX.3.1
+  expressions:
+    - valueOf: datatype/CodeableConcept
+      expressionType: resource
+      specs: OBX.5
 
 reasonCode:
   valueOf: datatype/CodeableConcept


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>


Fixes a bug where Immunization.fundingSource, Immunization.programEligibility worked by themselves, but not when they were together.  Applied the fix to similar Immunization elements.  Added test which checks for success when all are together.

Fixed some JavaDoc problems.