### PR TITLE
Move Imm.Peformer text to display

### DIFF
--- a/src/main/resources/hl7/secondary/Performer.yml
+++ b/src/main/resources/hl7/secondary/Performer.yml
@@ -10,7 +10,7 @@ function_v1:
    constants:
     system: 'http://terminology.hl7.org/CodeSystem/v2-0443'
     code: 'OP'
-    text: 'Ordering Provider'
+    display: 'Ordering Provider'
 
 function_v2:
    condition: $administeringProvider NOT_NULL
@@ -19,7 +19,7 @@ function_v2:
    constants:
     system: 'http://terminology.hl7.org/CodeSystem/v2-0443'
     code: AP
-    text: Administering Provider
+    display: Administering Provider
 
 function_v3:
    condition: $administeringProviderOrganization NOT_NULL
@@ -28,7 +28,7 @@ function_v3:
    constants:
     system: 'http://terminology.hl7.org/CodeSystem/v2-0443'
     code: AP
-    text: Administering Provider    
+    display: Administering Provider    
 
 actor_1:
    condition: $orderingProvider NOT_NULL || $administeringProvider NOT_NULL

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -89,10 +89,11 @@ class Hl7ImmunizationFHIRConversionTest {
         String requesterRef1 = resource.getPerformer().get(0).getActor().getReference();
         Practitioner practBundle1 = ResourceUtils.getSpecificPractitionerFromBundleEntriesList(e, requesterRef1);
         assertThat(resource.getPerformer()).hasSize(3);
-        assertThat(resource.getPerformer().get(0).getFunction().getCoding().get(0).getCode())
-                .isEqualTo("OP"); // ORC.12
-        assertThat(resource.getPerformer().get(0).getFunction().getText())
-                .isEqualTo("Ordering Provider"); // ORC.12
+        DatatypeUtils.checkCommonCodingAssertions(resource.getPerformer().get(0).getFunction().getCoding().get(0), "OP",
+                "Ordering Provider",
+                "http://terminology.hl7.org/CodeSystem/v2-0443", null); // ORC.12
+        assertThat(resource.getPerformer().get(0).getFunction().hasText()).isFalse();
+
         assertThat(resource.getPerformer().get(0).getActor().getReference()).isNotEmpty(); // ORC.12
         assertThat(practBundle1.getNameFirstRep().getText()).isEqualTo("MARY Pediatric");
         assertThat(practBundle1.getNameFirstRep().getFamily()).isEqualTo("Pediatric");
@@ -101,20 +102,20 @@ class Hl7ImmunizationFHIRConversionTest {
 
         String requesterRef2 = resource.getPerformer().get(1).getActor().getReference();
         Practitioner practBundle2 = ResourceUtils.getSpecificPractitionerFromBundleEntriesList(e, requesterRef2);
-        assertThat(resource.getPerformer().get(1).getFunction().getCoding().get(0).getCode())
-                .isEqualTo("AP"); // RXA.10
-        assertThat(resource.getPerformer().get(1).getFunction().getText())
-                .isEqualTo("Administering Provider"); // RXA.10
+        DatatypeUtils.checkCommonCodingAssertions(resource.getPerformer().get(1).getFunction().getCoding().get(0), "AP",
+                "Administering Provider",
+                "http://terminology.hl7.org/CodeSystem/v2-0443", null); // RXA.10
+        assertThat(resource.getPerformer().get(1).getFunction().hasText()).isFalse();
         assertThat(resource.getPerformer().get(1).getActor().isEmpty()).isFalse(); // RXA.10
         assertThat(practBundle2.getNameFirstRep().getText()).isEqualTo("Nurse Sticker");
         assertThat(practBundle2.getNameFirstRep().getFamily()).isEqualTo("Sticker");
         assertThat(practBundle2.getNameFirstRep().getGiven().get(0)).hasToString("Nurse");
 
         String requesterRef3 = resource.getPerformer().get(2).getActor().getReference();
-        assertThat(resource.getPerformer().get(2).getFunction().getCoding().get(0).getCode())
-                .isEqualTo("AP"); // RXA.10
-        assertThat(resource.getPerformer().get(2).getFunction().getText())
-                .isEqualTo("Administering Provider"); // RXA.10
+        DatatypeUtils.checkCommonCodingAssertions(resource.getPerformer().get(1).getFunction().getCoding().get(0), "AP",
+                "Administering Provider",
+                "http://terminology.hl7.org/CodeSystem/v2-0443", null); // RXA.11
+        assertThat(resource.getPerformer().get(1).getFunction().hasText()).isFalse();
 
         // Immunization.Reaction Date (OBX.14) and Detail (OBX.5 if OBX 3 is 31044-1)
         assertThat(resource.getReactionFirstRep().getDateElement().toString()).contains("2013-05-31"); //OBX.14

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -112,7 +112,7 @@ class Hl7ImmunizationFHIRConversionTest {
         assertThat(practBundle2.getNameFirstRep().getGiven().get(0)).hasToString("Nurse");
 
         String requesterRef3 = resource.getPerformer().get(2).getActor().getReference();
-        DatatypeUtils.checkCommonCodingAssertions(resource.getPerformer().get(1).getFunction().getCoding().get(0), "AP",
+        DatatypeUtils.checkCommonCodingAssertions(resource.getPerformer().get(2).getFunction().getCoding().get(0), "AP",
                 "Administering Provider",
                 "http://terminology.hl7.org/CodeSystem/v2-0443", null); // RXA.11
         assertThat(resource.getPerformer().get(1).getFunction().hasText()).isFalse();
@@ -172,8 +172,11 @@ class Hl7ImmunizationFHIRConversionTest {
         Immunization immunization = ResourceUtils.getImmunization(hl7VUXmessageRep);
 
         assertThat(immunization.getPerformer()).hasSize(1);
-        assertThat(immunization.getPerformer().get(0).getFunction().getCodingFirstRep().getCode()).isEqualTo("AP");// RXA.10
-        assertThat(immunization.getPerformer().get(0).getFunction().getText()).isEqualTo("Administering Provider"); // RXA.10
+        DatatypeUtils.checkCommonCodingAssertions(immunization.getPerformer().get(0).getFunction().getCodingFirstRep(),
+                "AP",
+                "Administering Provider",
+                "http://terminology.hl7.org/CodeSystem/v2-0443", null); // RXA.10
+        assertThat(immunization.getPerformer().get(0).getFunction().hasText()).isFalse();
         assertThat(immunization.getStatus().getDisplay()).isEqualTo("not-done"); // RXA.18 is not empty which signals that the status is not-done. ORC.5 is here to show precedence
         assertThat(immunization.hasStatusReason()).isTrue(); // if status is "not-done" we show the Status reason
         assertThat(immunization.getStatusReason().getCodingFirstRep().getCode()).isEqualTo("00");


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Small change that moves Immunization.performer.function text to display.  Consistently done for all performers.   Adjusted tests.