### PR TITLE
Fix statusReason shows for 59784-9 && RXA.20!=RE

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -29,7 +29,6 @@ import ca.uhn.hl7v2.model.Varies;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.hl7.fhir.dstu2.model.Order;
 import org.hl7.fhir.dstu3.model.codesystems.MedicationRequestCategory;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCategory;

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -47,7 +47,8 @@ statusReason_2:
     display: "Patient Refusal"
     system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
 
-statusReason_3:
+# 3a & 3b together make complex $rxa20 NULL || $rxa20 NOT_EQUALS RE
+statusReason_3a:
   valueOf: datatype/CodeableConcept_var
   expressionType: resource
   condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 30945-0
@@ -60,7 +61,21 @@ statusReason_3:
     display: "medical precaution"
     system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
 
-statusReason_4:
+statusReason_3b:
+  valueOf: datatype/CodeableConcept_var
+  expressionType: resource
+  condition: $rxa18 NULL && $rxa20 NOT_EQUALS RE && $obx31 EQUALS 30945-0
+  vars:
+    rxa18: RXA.18
+    rxa20: String, RXA.20
+    obx31: String, OBX.3.1
+  constants:
+    code: "MEDPREC"
+    display: "medical precaution"
+    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"    
+
+# 4a & 4b together make complex $rxa20 NULL || $rxa20 NOT_EQUALS RE
+statusReason_4a:
   valueOf: datatype/CodeableConcept_var
   expressionType: resource
   condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 59784-9
@@ -72,6 +87,19 @@ statusReason_4:
     code: "IMMUNE"
     display: "immunity"
     system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+
+statusReason_4b:
+  valueOf: datatype/CodeableConcept_var
+  expressionType: resource
+  condition: $rxa18 NULL && $rxa20 NOT_EQUALS RE && $obx31 EQUALS 59784-9
+  vars:
+    rxa18: RXA.18
+    rxa20: String, RXA.20
+    obx31: String, OBX.3.1
+  constants:
+    code: "IMMUNE"
+    display: "immunity"
+    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"    
 
 vaccineCode_1:
   valueOf: datatype/CodeableConcept


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

Fixes a problem where OBX.3 59784-9 sometimes was not activated.  The logic required RXA.20 to be NULL, but RXA.20 != RE (such as NA) should also activate.  
Small changes to logic to handle complex case added.
Test added.