### PR TITLE
Add alternative codings for statusReason

### DIFF
--- a/src/main/resources/hl7/datatype/CodeableConcept.yml
+++ b/src/main/resources/hl7/datatype/CodeableConcept.yml
@@ -1,5 +1,5 @@
 #
-# (C) Copyright IBM Corp. 2020, 2021
+# (C) Copyright IBM Corp. 2020, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -58,7 +58,18 @@ coding_6:
    valueOf: $coding
    condition: $coding NOT_NULL
    generateList: true
-   
+
+# Allows alternate coding to be added from hardcoded values
+coding_7:
+    generateList: true
+    valueOf: datatype/Coding  # uses values from vars
+    expressionType: resource
+    condition: $code NOT_NULL
+    vars: 
+      code: $alternateCode
+      display: $alternateDisplay
+      system: $alternateSystem
+  
 # Require available text, and the absense of an identifierCoding
 text:
    condition: $displayText NOT_NULL && $identifierCoding NULL

--- a/src/main/resources/hl7/resource/Immunization.yml
+++ b/src/main/resources/hl7/resource/Immunization.yml
@@ -49,57 +49,61 @@ statusReason_2:
 
 # 3a & 3b together make complex $rxa20 NULL || $rxa20 NOT_EQUALS RE
 statusReason_3a:
-  valueOf: datatype/CodeableConcept_var
+  valueOf: datatype/CodeableConcept
   expressionType: resource
   condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 30945-0
+  specs: OBX.3
   vars:
     rxa18: RXA.18
     rxa20: RXA.20
     obx31: String, OBX.3.1
   constants:
-    code: "MEDPREC"
-    display: "medical precaution"
-    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+    alternateCode: "MEDPREC"
+    alternateDisplay: "medical precaution"
+    alternateSystem: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
 
 statusReason_3b:
-  valueOf: datatype/CodeableConcept_var
+  valueOf: datatype/CodeableConcept
   expressionType: resource
   condition: $rxa18 NULL && $rxa20 NOT_EQUALS RE && $obx31 EQUALS 30945-0
+  specs: OBX.3
   vars:
     rxa18: RXA.18
     rxa20: String, RXA.20
     obx31: String, OBX.3.1
   constants:
-    code: "MEDPREC"
-    display: "medical precaution"
-    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+    alternateCode: "MEDPREC"
+    alternateDisplay: "medical precaution"
+    alternateSystem: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
 
 # 4a & 4b together make complex $rxa20 NULL || $rxa20 NOT_EQUALS RE
 statusReason_4a:
-  valueOf: datatype/CodeableConcept_var
+  valueOf: datatype/CodeableConcept
   expressionType: resource
   condition: $rxa18 NULL && $rxa20 NULL && $obx31 EQUALS 59784-9
+  specs: OBX.3
   vars:
     rxa18: RXA.18
     rxa20: RXA.20
     obx31: String, OBX.3.1
   constants:
-    code: "IMMUNE"
-    display: "immunity"
-    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+    alternateCode: "IMMUNE"
+    alternateDisplay: "immunity"
+    alternateSystem: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
 
 statusReason_4b:
-  valueOf: datatype/CodeableConcept_var
+  valueOf: datatype/CodeableConcept
   expressionType: resource
   condition: $rxa18 NULL && $rxa20 NOT_EQUALS RE && $obx31 EQUALS 59784-9
+  specs: OBX.3
   vars:
     rxa18: RXA.18
     rxa20: String, RXA.20
     obx31: String, OBX.3.1
   constants:
-    code: "IMMUNE"
-    display: "immunity"
-    system: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+    alternateCode: "IMMUNE"
+    alternateDisplay: "immunity"
+    alternateSystem: "http://terminology.hl7.org/CodeSystem/v3-ActReason"
 
 vaccineCode_1:
   valueOf: datatype/CodeableConcept

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -350,10 +350,16 @@ class Hl7ImmunizationFHIRConversionTest {
 
         assertThat(immunization.getStatus().getDisplay()).isEqualTo("completed"); //Status defaults to completed
         assertThat(immunization.hasStatusReason()).isTrue();
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getCode()).isEqualTo("MEDPREC");
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getSystem())
+        assertThat(immunization.getStatusReason().getCoding()).hasSize(2);
+        assertThat(immunization.getStatusReason().getCoding().get(0).getCode()).isEqualTo("MEDPREC");
+        assertThat(immunization.getStatusReason().getCoding().get(0).getSystem())
                 .isEqualTo("http://terminology.hl7.org/CodeSystem/v3-ActReason");
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getDisplay()).isEqualTo("medical precaution");
+        assertThat(immunization.getStatusReason().getCoding().get(0).getDisplay()).isEqualTo("medical precaution");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getCode()).isEqualTo("30945-0");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getSystem())
+                .isEqualTo("http://loinc.org");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getDisplay()).isEqualTo("contraindication");
+        assertThat(immunization.getStatusReason().getText()).isEqualTo("contraindication");
     }
 
     @Test
@@ -370,10 +376,16 @@ class Hl7ImmunizationFHIRConversionTest {
 
         assertThat(immunization.getStatus().getDisplay()).isEqualTo("not-done"); // RXA-20
         assertThat(immunization.hasStatusReason()).isTrue();
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getCode()).isEqualTo("MEDPREC");
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getSystem())
+        assertThat(immunization.getStatusReason().getCoding()).hasSize(2);
+        assertThat(immunization.getStatusReason().getCoding().get(0).getCode()).isEqualTo("MEDPREC");
+        assertThat(immunization.getStatusReason().getCoding().get(0).getSystem())
                 .isEqualTo("http://terminology.hl7.org/CodeSystem/v3-ActReason");
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getDisplay()).isEqualTo("medical precaution");
+        assertThat(immunization.getStatusReason().getCoding().get(0).getDisplay()).isEqualTo("medical precaution");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getCode()).isEqualTo("30945-0");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getSystem())
+                .isEqualTo("http://loinc.org");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getDisplay()).isEqualTo("contraindication");
+        assertThat(immunization.getStatusReason().getText()).isEqualTo("contraindication");
     }
 
     @Test
@@ -389,10 +401,16 @@ class Hl7ImmunizationFHIRConversionTest {
 
         assertThat(immunization.getStatus().getDisplay()).isEqualTo("completed"); //Status defaults to completed
         assertThat(immunization.hasStatusReason()).isTrue();
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getCode()).isEqualTo("IMMUNE");
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getSystem())
+        assertThat(immunization.getStatusReason().getCoding()).hasSize(2);
+        assertThat(immunization.getStatusReason().getCoding().get(0).getCode()).isEqualTo("IMMUNE"); // From OBX.3==59784-9
+        assertThat(immunization.getStatusReason().getCoding().get(0).getSystem())
                 .isEqualTo("http://terminology.hl7.org/CodeSystem/v3-ActReason");
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getDisplay()).isEqualTo("immunity");
+        assertThat(immunization.getStatusReason().getCoding().get(0).getDisplay()).isEqualTo("immunity");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getCode()).isEqualTo("59784-9");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getSystem())
+                .isEqualTo("http://loinc.org");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getDisplay()).isEqualTo("Disease with presumed immunity");
+        assertThat(immunization.getStatusReason().getText()).isEqualTo("Disease with presumed immunity");        
 
     }
 
@@ -410,9 +428,16 @@ class Hl7ImmunizationFHIRConversionTest {
 
         assertThat(immunization.getStatus().getDisplay()).isEqualTo("not-done"); // RXA.20
         assertThat(immunization.hasStatusReason()).isTrue();
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getCode()).isEqualTo("IMMUNE"); // From OBX.3==59784-9
-        assertThat(immunization.getStatusReason().getCodingFirstRep().getSystem())
+        assertThat(immunization.getStatusReason().getCoding()).hasSize(2);
+        assertThat(immunization.getStatusReason().getCoding().get(0).getCode()).isEqualTo("IMMUNE"); // From OBX.3==59784-9
+        assertThat(immunization.getStatusReason().getCoding().get(0).getSystem())
                 .isEqualTo("http://terminology.hl7.org/CodeSystem/v3-ActReason");
+        assertThat(immunization.getStatusReason().getCoding().get(0).getDisplay()).isEqualTo("immunity");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getCode()).isEqualTo("59784-9");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getSystem())
+                .isEqualTo("http://loinc.org");
+        assertThat(immunization.getStatusReason().getCoding().get(1).getDisplay()).isEqualTo("Disease with presumed immunity");
+        assertThat(immunization.getStatusReason().getText()).isEqualTo("Disease with presumed immunity");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>


Allow statusReason coding to contain both original CWE from OBX.3 and the alternative coding (e.g. MEDPREC or IMMUNE).

With tests.