### PR TITLE
Fix TS and DTM type times in OBX edu segs

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import ca.uhn.hl7v2.model.v26.datatype.CE;
 import ca.uhn.hl7v2.model.v26.datatype.CWE;
 import ca.uhn.hl7v2.model.v26.datatype.DT;
+import ca.uhn.hl7v2.model.v26.datatype.DTM;
 import ca.uhn.hl7v2.model.v26.datatype.PPN;
 import ca.uhn.hl7v2.model.v26.datatype.TS;
 import ca.uhn.hl7v2.model.v26.datatype.XCN;
@@ -24,8 +25,6 @@ import ca.uhn.hl7v2.model.v26.group.VXU_V04_OBSERVATION;
 import ca.uhn.hl7v2.model.v26.group.VXU_V04_ORDER;
 import ca.uhn.hl7v2.model.v26.segment.OBX;
 import ca.uhn.hl7v2.HL7Exception;
-import ca.uhn.hl7v2.Location;
-import ca.uhn.hl7v2.model.Group;
 import ca.uhn.hl7v2.model.Varies;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -237,7 +236,10 @@ public class SimpleDataValueResolver {
             return DateUtil.formatToDate(((DT)obj).getValue());
         }
         if (obj instanceof TS) {
-            return DateUtil.formatToDate(((TS)obj).toString());
+            return DateUtil.formatToDate(((TS)obj).getTime().toString());
+        }
+        if (obj instanceof DTM) {
+            return DateUtil.formatToDate(((DTM)obj).getValue());
         }
         return null;
     }

--- a/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/data/SimpleDataValueResolver.java
@@ -25,6 +25,7 @@ import ca.uhn.hl7v2.model.v26.group.VXU_V04_OBSERVATION;
 import ca.uhn.hl7v2.model.v26.group.VXU_V04_ORDER;
 import ca.uhn.hl7v2.model.v26.segment.OBX;
 import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.Varies;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -239,7 +240,9 @@ public class SimpleDataValueResolver {
             return DateUtil.formatToDate(((TS)obj).getTime().toString());
         }
         if (obj instanceof DTM) {
-            return DateUtil.formatToDate(((DTM)obj).getValue());
+            String dateString = ((DTM)obj).getValue();
+            // DTMs potentially have more information than we need.  Truncate after day, or return null.
+            return dateString.length() > 7 ? DateUtil.formatToDate(dateString.substring(0,8)) : null;
         }
         return null;
     }

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -707,15 +707,17 @@ class Hl7ImmunizationFHIRConversionTest {
                 + "RXR|C28161^Intramuscular^NCIT|LD^Left Deltoid^HL70163|\n"
                 // Immunization 3: education group 1. Has both DocumentType and Reference records.  
                 // DocumentType will be used as DocumentType.
+                // OBX times have type TS to prove that works
                 + "OBX|8|CE|69764-9^Vaccine Type^LN|4|45^Hep B, CC3a UF^CVX||||||F\n"
                 + "OBX|9|CE|30956-7^Vaccine Type^LN|4|45^Hep B, CC3b UF^CVX||||||F\n"
-                + "OBX|10|DT|29768-9^Date Vaccine Information Statement Published^LN|4|20170303||||||F\n"
-                + "OBX|11|DT|29769-7^Date Vaccine Information Statement Presented^LN|4|20170305||||||F\n"
+                + "OBX|10|TS|29768-9^Date Vaccine Information Statement Published^LN|4|20170303||||||F\n"
+                + "OBX|11|TS|29769-7^Date Vaccine Information Statement Presented^LN|4|20170305||||||F\n"
                 // Immunization 3: education group 2. Has both DocumentType but no Reference record. 
                 // DocumentType will be used as DocumentType.
+                // OBX times have type DTM to prove that works
                 + "OBX|21|CE|69764-9^Vaccine Type^LN|5|45^Hep B, CC4 UF^CVX||||||F\n"
-                + "OBX|22|DT|29768-9^Date Vaccine Information Statement Published^LN|5|20170403||||||F\n"
-                + "OBX|23|DT|29769-7^Date Vaccine Information Statement Presented^LN|5|20170405||||||F\n"
+                + "OBX|22|DTM|29768-9^Date Vaccine Information Statement Published^LN|5|20170403||||||F\n"
+                + "OBX|23|DTM|29769-7^Date Vaccine Information Statement Presented^LN|5|20170405||||||F\n"
                 // Immunization 3: education group 3. Has no DocumentType nor Reference record. 
                 // 'unspecified' is used as DocumentType.       
                 + "OBX|43|DT|29769-7^Date Vaccine Information Statement Presented^LN|7|20170605||||||F\n"

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7ImmunizationFHIRConversionTest.java
@@ -716,8 +716,8 @@ class Hl7ImmunizationFHIRConversionTest {
                 // DocumentType will be used as DocumentType.
                 // OBX times have type DTM to prove that works
                 + "OBX|21|CE|69764-9^Vaccine Type^LN|5|45^Hep B, CC4 UF^CVX||||||F\n"
-                + "OBX|22|DTM|29768-9^Date Vaccine Information Statement Published^LN|5|20170403||||||F\n"
-                + "OBX|23|DTM|29769-7^Date Vaccine Information Statement Presented^LN|5|20170405||||||F\n"
+                + "OBX|22|DTM|29768-9^Date Vaccine Information Statement Published^LN|5|20170403011212000+0000||||||F\n"
+                + "OBX|23|DTM|29769-7^Date Vaccine Information Statement Presented^LN|5|20170405011212000+0000||||||F\n"
                 // Immunization 3: education group 3. Has no DocumentType nor Reference record. 
                 // 'unspecified' is used as DocumentType.       
                 + "OBX|43|DT|29769-7^Date Vaccine Information Statement Presented^LN|7|20170605||||||F\n"


### PR DESCRIPTION
Signed-off-by: Brian Cragun <cragun@us.ibm.com>

TS and DTM type times were not correctly handled.  This fixes the problem and adds tests to validate.