### PR TITLE
Issue#463 support for addtl adt msgs and in1/in2

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,6 +32,10 @@ The Official FHIR documentation, provided by the HL7 organization, provides comp
 Each resource page contains field definitions [(Example: Medication Resource)](https://www.hl7.org/fhir/medication.html), and HL7 v2 mappings [(Example: Medication Resource)](https://www.hl7.org/fhir/medication-mappings.html).
 Review the documentation determine which FHIR resource fields to include. The FHIR specification supports numerous resources with a variety of fields. It is likely that a subset of fields are required for a given use-case.
 
+Also, keep in mind the messages, structures, groups, and segments from the HL7 V2.6 messages being parsed.  A good resources is [Health Level Seven® Standard Version 2.6 -
+An Application Protocol for Electronic Data Exchange
+in Healthcare Environments](https://www.vico.org/HL7_V2_6/HL7%20Messaging%20Version%202.6/V2_6_Index.html) at vico.org. Messages have specific structures they are supported by.  For example `ADT^A08` and `ADT^A04` use the `ADT_A01` structure to map groups and segments within groups.
+
 ### Modifying an HL7 Segment Template
 
 Find the associated FHIR resource that maps from the fields in the HL7 Segment. A good example is [src/main/resources/hl7/resource/Patient.yml](src/main/resources/hl7/resource/Patient.yml) which maps for the `PID` segment.  (TEMPLATING)[TEMPLATING.md] explains how the templates work for mappings.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Message parsing and modeling is supported using the "HAPI" libraries for [HL7](h
 The converter supports the following message types/events:
 * ADT_A01 - Patient Administration: Admit/Visit Notification
 * ADT_A03 - Patient Administration: Discharge/End Visit  
+* ADT_A04 - Patient Administration: Register a Patient  
 * ADT_A08 - Patient Administration: Update Patient Information
+* ADT_A28 - Patient Administration: Add Person or Patient Information 
+* ADT_A31 - Patient Administration: Update Person Information
 * ADT_A34 - Patient Administration: Merge Patient Information - Patient ID Only
 * ADT_A40 - Patient Administration: Merge Patient - Patient Identifier List
 * DFT_P03 - Post Detail Financial Transaction (does not convert FT1)

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,5 +1,5 @@
 base.path.resource=
-supported.hl7.messages=ADT_A01, ADT_A03, ADT_A08, ADT_A34, ADT_A40, DFT_P03, MDM_T02, MDM_T06, OML_O21, ORM_O01, OMP_O09, ORU_R01, PPR_PC1, RDE_O11, RDE_O25, VXU_V04
+supported.hl7.messages=ADT_A01, ADT_A03, ADT_A04, ADT_A08, ADT_A28, ADT_A31, ADT_A34, ADT_A40, DFT_P03, MDM_T02, MDM_T06, OML_O21, ORM_O01, OMP_O09, ORU_R01, PPR_PC1, RDE_O11, RDE_O25, VXU_V04
 default.zoneid=+08:00
 additional.conceptmap.file=
 additional.resources.location=

--- a/src/main/resources/hl7/message/ADT_A01.yml
+++ b/src/main/resources/hl7/message/ADT_A01.yml
@@ -6,78 +6,78 @@
 # FHIR Resources to extract from ADT_A01 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-             - EVN
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PD1
-             - MSH
-             - INSURANCE.IN1
-             - INSURANCE.IN2
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
+      - INSURANCE.IN1
+      - INSURANCE.IN2
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PV2
-             - EVN
-             - MSH
-             - DG1
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH
+      - DG1
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
-      isReferenced: true
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Condition
+    segment: DG1
+    resourcePath: resource/Condition
+    isReferenced: true
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: Observation
-      segment: OBX
-      resourcePath: resource/Observation
-      repeats: true
-      isReferenced: true
-      additionalSegments:
-        - MSH
+  - resourceName: Observation
+    segment: OBX
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: AllergyIntolerance
-      segment: AL1
-      resourcePath: resource/AllergyIntolerance
-      repeats: true
-      additionalSegments:
-        - MSH
+  - resourceName: AllergyIntolerance
+    segment: AL1
+    resourcePath: resource/AllergyIntolerance
+    repeats: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: Procedure
-      segment: .PR1
-      group: PROCEDURE
-      resourcePath: resource/Procedure
-      repeats: true
-      additionalSegments:
-        - .ROL
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Procedure
+    segment: .PR1
+    group: PROCEDURE
+    resourcePath: resource/Procedure
+    repeats: true
+    additionalSegments:
+      - .ROL
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: Coverage
-      segment: .IN1
-      group: INSURANCE
-      resourcePath: resource/Coverage
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PV1
-        - .IN2
+  - resourceName: Coverage
+    segment: .IN1
+    group: INSURANCE
+    resourcePath: resource/Coverage
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PV1
+      - .IN2

--- a/src/main/resources/hl7/message/ADT_A02.yml
+++ b/src/main/resources/hl7/message/ADT_A02.yml
@@ -1,34 +1,34 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Copyright IBM Corp. 2021, 2022
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 # FHIR Resources to extract from ADT_A02 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-             - EVN
-   
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PD1
-             - MSH
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PV2
-             - EVN
-             - MSH
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
+
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH

--- a/src/main/resources/hl7/message/ADT_A03.yml
+++ b/src/main/resources/hl7/message/ADT_A03.yml
@@ -6,79 +6,78 @@
 # FHIR Resources to extract from ADT_A03 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-             - EVN
-   
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-             - PD1
-             - MSH
-             - INSURANCE.IN1
-             - INSURANCE.IN2
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
+      - INSURANCE.IN1
+      - INSURANCE.IN2
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-        - PV2
-        - EVN
-        - MSH
-        - DG1
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH
+      - DG1
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
-      isReferenced: true
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Condition
+    segment: DG1
+    resourcePath: resource/Condition
+    isReferenced: true
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: Observation
-      segment: OBX
-      resourcePath: resource/Observation
-      repeats: true
-      isReferenced: true
-      additionalSegments:
-             - MSH
+  - resourceName: Observation
+    segment: OBX
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: AllergyIntolerance
-      segment: AL1
-      resourcePath: resource/AllergyIntolerance
-      repeats: true
-      additionalSegments:
-             - MSH
+  - resourceName: AllergyIntolerance
+    segment: AL1
+    resourcePath: resource/AllergyIntolerance
+    repeats: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: Procedure
-      segment: .PR1
-      group: PROCEDURE
-      resourcePath: resource/Procedure
-      repeats: true
-      additionalSegments:
-        - .ROL
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Procedure
+    segment: .PR1
+    group: PROCEDURE
+    resourcePath: resource/Procedure
+    repeats: true
+    additionalSegments:
+      - .ROL
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: Coverage
-      segment: .IN1
-      group: INSURANCE
-      resourcePath: resource/Coverage
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PV1
-        - .IN2
+  - resourceName: Coverage
+    segment: .IN1
+    group: INSURANCE
+    resourcePath: resource/Coverage
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PV1
+      - .IN2

--- a/src/main/resources/hl7/message/ADT_A04.yml
+++ b/src/main/resources/hl7/message/ADT_A04.yml
@@ -23,8 +23,7 @@ resources:
       - PD1
       - MSH
       - INSURANCE.IN1
-      - INSURANCE.IN2      
-
+      - INSURANCE.IN2
 
   - resourceName: Encounter
     segment: PV1

--- a/src/main/resources/hl7/message/ADT_A08.yml
+++ b/src/main/resources/hl7/message/ADT_A08.yml
@@ -6,68 +6,79 @@
 # FHIR Resources to extract from ADT_A08 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-        - EVN
-   
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-        - PD1
-        - MSH
-        - INSURANCE.IN1
-        - INSURANCE.IN2        
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-        - PV2
-        - EVN
-        - MSH
-        - DG1
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
+      - INSURANCE.IN1
+      - INSURANCE.IN2
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
-      isReferenced: true
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PID
-        - PV1
-             
-    - resourceName: Observation
-      segment: OBX
-      resourcePath: resource/Observation
-      repeats: true
-      isReferenced: true
-      additionalSegments:
-        - MSH
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH
+      - DG1
 
-    - resourceName: AllergyIntolerance
-      segment: AL1
-      resourcePath: resource/AllergyIntolerance
-      repeats: true
-      additionalSegments:
-        - MSH
+  - resourceName: Condition
+    segment: DG1
+    resourcePath: resource/Condition
+    isReferenced: true
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: Procedure
-      segment: .PR1
-      group: PROCEDURE
-      resourcePath: resource/Procedure
-      repeats: true
-      additionalSegments:
-        - .ROL
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Observation
+    segment: OBX
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - MSH
+
+  - resourceName: AllergyIntolerance
+    segment: AL1
+    resourcePath: resource/AllergyIntolerance
+    repeats: true
+    additionalSegments:
+      - MSH
+
+  - resourceName: Procedure
+    segment: .PR1
+    group: PROCEDURE
+    resourcePath: resource/Procedure
+    repeats: true
+    additionalSegments:
+      - .ROL
+      - MSH
+      - PID
+      - PV1
+
+  - resourceName: Coverage
+    segment: .IN1
+    group: INSURANCE
+    resourcePath: resource/Coverage
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
+      - .IN2

--- a/src/main/resources/hl7/message/ADT_A28.yml
+++ b/src/main/resources/hl7/message/ADT_A28.yml
@@ -6,78 +6,78 @@
 # FHIR Resources to extract from ADT_A28 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-             - EVN
-   
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-            - PD1
-            - MSH
-            - INSURANCE.IN1
-            - INSURANCE.IN2             
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-        - PV2
-        - EVN
-        - MSH
-        - DG1
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
+      - INSURANCE.IN1
+      - INSURANCE.IN2
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
-      isReferenced: true
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH
+      - DG1
 
-    - resourceName: Observation
-      segment: OBX
-      resourcePath: resource/Observation
-      repeats: true
-      isReferenced: true
-      additionalSegments:
-        - MSH
+  - resourceName: Condition
+    segment: DG1
+    resourcePath: resource/Condition
+    isReferenced: true
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: AllergyIntolerance
-      segment: AL1
-      resourcePath: resource/AllergyIntolerance
-      repeats: true
-      additionalSegments:
-        - MSH
+  - resourceName: Observation
+    segment: OBX
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: Procedure
-      segment: .PR1
-      group: PROCEDURE
-      resourcePath: resource/Procedure
-      repeats: true
-      additionalSegments:
-        - .ROL
-        - MSH
-        - PID
-        - PV1
+  - resourceName: AllergyIntolerance
+    segment: AL1
+    resourcePath: resource/AllergyIntolerance
+    repeats: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: Coverage
-      segment: .IN1
-      group: INSURANCE
-      resourcePath: resource/Coverage
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PV1
-        - .IN2        
+  - resourceName: Procedure
+    segment: .PR1
+    group: PROCEDURE
+    resourcePath: resource/Procedure
+    repeats: true
+    additionalSegments:
+      - .ROL
+      - MSH
+      - PID
+      - PV1
+
+  - resourceName: Coverage
+    segment: .IN1
+    group: INSURANCE
+    resourcePath: resource/Coverage
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PV1
+      - .IN2

--- a/src/main/resources/hl7/message/ADT_A31.yml
+++ b/src/main/resources/hl7/message/ADT_A31.yml
@@ -6,80 +6,79 @@
 # FHIR Resources to extract from ADT_A31 message
 ---
 resources:
-    - resourceName: MessageHeader
-      segment: MSH
-      resourcePath: resource/MessageHeader
-      repeats: false
-      isReferenced: false
-      additionalSegments: 
-             - EVN
-   
-    - resourceName: Patient
-      segment: PID
-      resourcePath: resource/Patient
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-            - PD1
-            - MSH
-            - INSURANCE.IN1
-            - INSURANCE.IN2 
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: resource/MessageHeader
+    repeats: false
+    isReferenced: false
+    additionalSegments:
+      - EVN
 
-    - resourceName: Encounter
-      segment: PV1
-      resourcePath: resource/Encounter
-      repeats: false
-      isReferenced: true
-      additionalSegments:
-        - PV2
-        - EVN
-        - MSH
-        - DG1
+  - resourceName: Patient
+    segment: PID
+    resourcePath: resource/Patient
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PD1
+      - MSH
+      - INSURANCE.IN1
+      - INSURANCE.IN2
 
-    - resourceName: Condition
-      segment: DG1
-      resourcePath: resource/Condition
-      isReferenced: true
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PID
-        - PV1
+  - resourceName: Encounter
+    segment: PV1
+    resourcePath: resource/Encounter
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - PV2
+      - EVN
+      - MSH
+      - DG1
 
-    - resourceName: Observation
-      segment: OBX
-      resourcePath: resource/Observation
-      repeats: true
-      isReferenced: true
-      additionalSegments:
-        - MSH
+  - resourceName: Condition
+    segment: DG1
+    resourcePath: resource/Condition
+    isReferenced: true
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
 
-    - resourceName: AllergyIntolerance
-      segment: AL1
-      resourcePath: resource/AllergyIntolerance
-      repeats: true
-      additionalSegments:
-        - MSH
+  - resourceName: Observation
+    segment: OBX
+    resourcePath: resource/Observation
+    repeats: true
+    isReferenced: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: Procedure
-      segment: .PR1
-      group: PROCEDURE
-      resourcePath: resource/Procedure
-      repeats: true
-      additionalSegments:
-        - .ROL
-        - MSH
-        - PID
-        - PV1
+  - resourceName: AllergyIntolerance
+    segment: AL1
+    resourcePath: resource/AllergyIntolerance
+    repeats: true
+    additionalSegments:
+      - MSH
 
-    - resourceName: Coverage
-      segment: .IN1
-      group: INSURANCE
-      resourcePath: resource/Coverage
-      repeats: true
-      additionalSegments:
-        - MSH
-        - PID
-        - PV1
-        - .IN2        
+  - resourceName: Procedure
+    segment: .PR1
+    group: PROCEDURE
+    resourcePath: resource/Procedure
+    repeats: true
+    additionalSegments:
+      - .ROL
+      - MSH
+      - PID
+      - PV1
 
+  - resourceName: Coverage
+    segment: .IN1
+    group: INSURANCE
+    resourcePath: resource/Coverage
+    repeats: true
+    additionalSegments:
+      - MSH
+      - PID
+      - PV1
+      - .IN2

--- a/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/HL7ADTMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,7 +24,7 @@ class HL7ADTMessageTest {
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
+    @ValueSource(strings = { "ADT^A01", "ADT^A04", "ADT^A08"/* , "ADT^A13" */ })
     void testAdtA01MinimumSegments(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
@@ -41,13 +41,13 @@ class HL7ADTMessageTest {
         assertThat(encounterResource).hasSize(1); // from EVN, PV1
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(2);
+        assertThat(e).hasSize(2);
 
     }
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
+    @ValueSource(strings = { "ADT^A01", "ADT^A04", "ADT^A08"/* , "ADT^A13" */ })
     void testAdtA01MinimumPlusProcedureGroup(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
@@ -68,13 +68,13 @@ class HL7ADTMessageTest {
         assertThat(procedureResource).hasSize(1); // from PR1
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(3);
+        assertThat(e).hasSize(3);
 
     }
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
+    @ValueSource(strings = { "ADT^A01", "ADT^A04", "ADT^A08"/* , "ADT^A13" */ })
     void testAdtA01FullWithObxTypeTXAndNoGroups(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
@@ -110,13 +110,13 @@ class HL7ADTMessageTest {
         assertThat(documentReferenceResource).isEmpty(); // from OBX of type TX; TODO: this should be 1 when card 855 is implemented
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(5); //TODO: this should be 6 when card 855 is implemented
+        assertThat(e).hasSize(5); //TODO: this should be 6 when card 855 is implemented
 
     }
 
     @ParameterizedTest
     // ADT_A01, ADT_A04, ADT_A08, ADT_A13 all use the same message structure so we can reuse adt_a01 tests for them.
-    @ValueSource(strings = { "ADT^A01"/* , "ADT^A04" */, "ADT^A08"/* , "ADT^A13" */ })
+    @ValueSource(strings = { "ADT^A01", "ADT^A04", "ADT^A08"/* , "ADT^A13" */ })
     void testAdtA01FullPlusMultipleProcedureGroup(String message) throws IOException {
         String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + message
                 + "|controlID|P|2.6\r"
@@ -133,7 +133,12 @@ class HL7ADTMessageTest {
                 + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
                 + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
                 + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
-                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r";
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+                // Minimal Insurance. Minimal Organization for Payor, which is required.
+                + "IN1|1|Value1^^System3^Value4^^System6|IdValue1^^^IdSystem4^^^^|Large Blue Organization|||||||||||\n"
+                // IN2.72 creates a RelatedPerson,
+                + "IN2||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||04|\n";
+
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
@@ -155,8 +160,17 @@ class HL7ADTMessageTest {
         List<Resource> procedureResource = ResourceUtils.getResourceList(e, ResourceType.Procedure);
         assertThat(procedureResource).hasSize(4); //from PROCEDURE.PR1
 
+        List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
+        assertThat(coverages).hasSize(1); //from INSURANCE.IN1
+
+        List<Resource> organizationResource = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizationResource).hasSize(1); //from INSURANCE.IN1
+
+        List<Resource> relatedResource = ResourceUtils.getResourceList(e, ResourceType.RelatedPerson);
+        assertThat(relatedResource).hasSize(1); //from INSURANCE.IN1
+
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(11);
+        assertThat(e).hasSize(14);
 
     }
 
@@ -173,7 +187,7 @@ class HL7ADTMessageTest {
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
         // Expecting 2 total resources
-        assertThat(e.size()).isEqualTo(2);
+        assertThat(e).hasSize(2);
 
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1);
@@ -204,8 +218,8 @@ class HL7ADTMessageTest {
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        // Expecting 9 total resources
-        assertThat(e.size()).isEqualTo(15);
+        // Expecting 15 total resources
+        assertThat(e).hasSize(15);
 
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); // from PID and PD1
@@ -249,8 +263,8 @@ class HL7ADTMessageTest {
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        // Expecting 9 total resources
-        assertThat(e.size()).isEqualTo(7);
+        // Expecting 7 total resources
+        assertThat(e).hasSize(7);
 
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); // from PID and PD1
@@ -285,7 +299,7 @@ class HL7ADTMessageTest {
         assertThat(encounterResource).hasSize(1); // from EVN, PV1
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(2);
+        assertThat(e).hasSize(2);
 
     }
 
@@ -309,7 +323,7 @@ class HL7ADTMessageTest {
         assertThat(procedureResource).hasSize(1); // from PR1
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(3);
+        assertThat(e).hasSize(3);
 
     }
 
@@ -336,53 +350,66 @@ class HL7ADTMessageTest {
         assertThat(organizationResource).hasSize(1); // Reference from IN1
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(4);
+        assertThat(e).hasSize(4);
 
     }
 
-    @Test
-    @Disabled("adt-a28 not yet supported")
-    //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
-    void testAdtA28PatientEncounterPresent() throws IOException {
-        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A28|controlID|P|2.6\n"
+    @ParameterizedTest
+    @ValueSource(strings = { "ADT^A28", "ADT^A31" })
+    // @Test
+    // Test ADT_A28 & ADT_A31 with all currently supported segments.  These use the ADT_A05 structure.
+    void testAdtA28A31AllSegments(String message) throws IOException {
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||"+message+"|controlID|P|2.6\n"
                 + "EVN|A01|20150502090000|\n"
                 + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
+                + "PD1|||||||||||01|N||||A\r"
                 + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n"
+                + "PV2|||||||||||||||||||||||||AI|||||||||||||C|\n"
+                + "OBX|1|NM|111^TotalProtein||7.5|gm/dl|5.9-8.4||||F\r"
+                + "OBX|2|ST|100||Observation content|||||||X\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "AL1|1|DA|1605^acetaminophen^L|MO|Muscle Pain~hair loss\r"
+                + "DG1|1||B45678|||A|\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+                + "PR1|1|ICD10|B45678|Fix break|20210322155008|A|75||V46|80|||32|1|D22|G45|1|G|P98|X|0|0\r"
+                // Minimal Insurance. Minimal Organization for Payor, which is required.
+                + "IN1|1|Value1^^System3^Value4^^System6|IdValue1^^^IdSystem4^^^^|Large Blue Organization|||||||||||\n"
+                // IN2.72 creates a RelatedPerson,
+                + "IN2||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||04|\n";
 
         List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
 
-        // Expecting 2 total resources
-        assertThat(e.size()).isEqualTo(2);
+        // Expecting 14 total resources
+        // Patient, Encounter, Condition, Observation (2), AllergyIntolerance (2), Procedure (2), Coverage, RelatedPerson, Organization
+        assertThat(e).hasSize(12);
 
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
-        assertThat(patientResource).hasSize(1);
+        assertThat(patientResource).hasSize(1); // from PID and PD1
 
         List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
-        assertThat(encounterResource).hasSize(1);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1, and PV2
 
-    }
+        List<Resource> observationResource = ResourceUtils.getResourceList(e, ResourceType.Observation);
+        assertThat(observationResource).hasSize(2); // from OBX x2
 
-    @Test
-    @Disabled("adt-a31 not yet supported")
-    //TODO: When this is supported, note that this should be updated to reflect adt_a05 structure
-    void testAdtA31PatientEncounterPresent() throws IOException {
-        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A31|controlID|P|2.6\n"
-                + "EVN|A01|20150502090000|\n"
-                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\n"
-                + "NK1|1|Kennedy^Joe|FTH|||+44 201 12345678||\n"
-                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\n";
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(2); // from AL1 x2
 
-        List<BundleEntryComponent> e = ResourceUtils.createFHIRBundleFromHL7MessageReturnEntryList(hl7message);
+        List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
+        assertThat(conditionResource).hasSize(1); // from DG1
 
-        // Expecting 2 total resources
-        assertThat(e.size()).isEqualTo(2);
+        List<Resource> procedureResource = ResourceUtils.getResourceList(e, ResourceType.Procedure);
+        assertThat(procedureResource).hasSize(2); //from PROCEDURE.PR1
 
-        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
-        assertThat(patientResource).hasSize(1);
+        List<Resource> coverages = ResourceUtils.getResourceList(e, ResourceType.Coverage);
+        assertThat(coverages).hasSize(1); //from INSURANCE.IN1
 
-        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
-        assertThat(encounterResource).hasSize(1);
+        List<Resource> organizationResource = ResourceUtils.getResourceList(e, ResourceType.Organization);
+        assertThat(organizationResource).hasSize(1); //from INSURANCE.IN1
+
+        List<Resource> relatedResource = ResourceUtils.getResourceList(e, ResourceType.RelatedPerson);
+        assertThat(relatedResource).hasSize(1); //from INSURANCE.IN1
 
     }
 
@@ -409,7 +436,7 @@ class HL7ADTMessageTest {
         // messages, so no Encounter should be created from EVN.
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(2);
+        assertThat(e).hasSize(2);
 
     }
 
@@ -439,7 +466,7 @@ class HL7ADTMessageTest {
         // messages, so no Encounter should be created from EVN.
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(2);
+        assertThat(e).hasSize(2);
 
     }
 
@@ -463,7 +490,7 @@ class HL7ADTMessageTest {
         // so no Encounter should be created from EVN.
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(2);
+        assertThat(e).hasSize(2);
 
     }
 
@@ -491,7 +518,7 @@ class HL7ADTMessageTest {
         // so no Encounter should be created from EVN.
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(6);
+        assertThat(e).hasSize(6);
 
     }
 
@@ -524,7 +551,7 @@ class HL7ADTMessageTest {
         // messages, so no Encounter should be created from EVN and PV1.
 
         // Confirm that there are no extra resources
-        assertThat(e.size()).isEqualTo(7);
+        assertThat(e).hasSize(7);
 
     }
 

--- a/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/segments/Hl7FinancialInsuranceTest.java
@@ -308,12 +308,18 @@ class Hl7FinancialInsuranceTest {
     // Tests IN1 & IN2 for all supported message types. 
     // The breadth of this test is sufficent for multiple message type coverage, so other tests are not parameterized.
     @ValueSource(strings = {
-        "DFT^P03^DFT_P03", "VXU^V04^VXU_V04", "ADT^A01^ADT_A01"
+        "DFT^P03^DFT_P03", 
+        "VXU^V04^VXU_V04", 
+        "ADT^A01^ADT_A01",
+        "ADT^A03^ADT_A03", 
+        "ADT^A04^ADT_A01", // ADT^A04 uses structure ADT_A01
+        "ADT^A08^ADT_A01", // ADT^A08 uses structure ADT_A01 
+        "ADT^A28^ADT_A05", // ADT^A28 uses structure ADT_A05 
+        "ADT^A31^ADT_A05"  // ADT^A31 uses structure ADT_A05 
     })
     // Tests IN1.17 coverage by related person. A related person should be created and cross-referenced.
     // Also tests backup field for coverage.order
     // Also test IN2.2 Social Security number
-
     void testInsuranceCoverageByRelatedFields(String messageType) throws IOException {
         String hl7message = "MSH|^~\\&|||||20151008111200||" + messageType + "|MSGID000001|T|2.6|||||||||\n"
                 + "EVN||20210407191342||||||\n"


### PR DESCRIPTION
This makes official support for ADT^A01, ^A03, ^A04, ^A08, ^A28, ^A31 messages -- segments MSH, EVN, PID, PD1, PV1, PV2, OBX, Al1, DG1, PR1, IN1, IN2.
Extend support for IN1/IN2 to these messages.

Tests extended in HL7ADTMessageTest and Hl7FinancialInsuranceTest for coverage.