### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation-resources-
 implementation group: 'org.apache.commons', name: 'commons-jexl3', version: '3.1'
 implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.5.0'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2
-implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.7'
+implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
 implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 implementation group:'com.ibm.fhir', name:'fhir-registry', version:'4.10.2'

--- a/build.gradle
+++ b/build.gradle
@@ -40,12 +40,12 @@ api 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
 implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
     
 // https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-structures-r4
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '5.7.0'
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '5.7.0'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.1.0'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.1.0'
 // https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-validation
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation', version: '5.7.0'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation', version: '6.1.0'
 // https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-validation
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation-resources-r4', version: '5.7.0'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation-resources-r4', version: '6.1.0'
 
 implementation group: 'org.apache.commons', name: 'commons-jexl3', version: '3.1'
 implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation', version:
 implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation-resources-r4', version: '5.7.0'
 
 implementation group: 'org.apache.commons', name: 'commons-jexl3', version: '3.1'
-implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.5.0'
+implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2
 implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ implementation group:'com.ibm.fhir', name:'fhir-registry', version:'4.10.2'
 implementation group:'com.ibm.fhir', name:'fhir-term', version:'4.10.2'
 implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
 
-testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.0'
 testImplementation 'org.assertj:assertj-core:3.9.0'
 testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"
 testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.2"


### PR DESCRIPTION
- Update org.apache.commons:commons-configuration2 to remediate [vulnerability](https://github.com/advisories/GHSA-xj57-8qj4-c4m6)
- Update com.jayway.jsonpath:json-path to remediate CVE-2021-31684 in dependency json-smart_project:json-smart
- Update hapi-fhir-validation and structures to remediate com.squareup.okhttp3:okhttp and [CVE-2020-36518](https://www.cve.org/CVERecord?id=CVE-2020-36518)
- Update ch.qos.logback:logback-classic to remediate dependency ch.qos.logback:logback-core