### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 api 'org.apache.commons:commons-math3:3.6.1'
 
 // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-implementation 'com.google.guava:guava:23.0'
+implementation 'com.google.guava:guava:30.0'
 implementation group: 'commons-io', name: 'commons-io', version: '2.7'
 implementation 'ca.uhn.hapi:hapi-base:2.3'
 
@@ -33,19 +33,19 @@ implementation 'ca.uhn.hapi:hapi-structures-v26:2.3'
 implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.1'
 implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.1'
 
-implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.13.4'
+implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.14.0'
     
 api 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2' 
     // https://mvnrepository.com/artifact/org.apache.commons/commons-text
 implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     
 // https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-structures-r4
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.1.2'
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.1.2'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.4.0'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.4.0'
 // https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-validation
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation', version: '6.1.2'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation', version: '6.4.0'
 // https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-validation
-implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation-resources-r4', version: '6.1.2'
+implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-validation-resources-r4', version: '6.4.0'
 
 implementation group: 'org.apache.commons', name: 'commons-jexl3', version: '3.1'
 implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0'


### PR DESCRIPTION
Upgrade com.google.guava:guava@23.0 to com.google.guava:guava@30.0-android
Upgrade ca.uhn.hapi.fhir:hapi-fhir-validation@6.1.2 to ca.uhn.hapi.fhir:hapi-fhir-validation@6.4.0 
Upgrade ca.uhn.hapi.fhir:hapi-fhir-structures-r4@6.1.2 to ca.uhn.hapi.fhir:hapi-fhir-structures-r4@6.4.0 
Upgrade ca.uhn.hapi.fhir:hapi-fhir-structures-r5@6.1.2 to ca.uhn.hapi.fhir:hapi-fhir-structures-r5@6.4.0 
Upgrade com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.13.4 to com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.0 to mitigate vulnerabilities.