### PR TITLE
Feature:  Ignore Empty HL7 Segments

### DIFF
--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -14,6 +14,7 @@ A HL7 message template maps one or more HL7 segments to a FHIR resource using th
       resourcePath: [REQUIRED]
       repeats:  [DEFAULT false]
       isReferenced: [DEFAULT false]
+      ignoreEmpty: [DEFAULT false]
       additionalSegments: [DEFAULT empty]
 ```
 
@@ -24,6 +25,7 @@ A HL7 message template maps one or more HL7 segments to a FHIR resource using th
 | resourcePath       | Required         | Relative path to the resource template. Example: resource/Patient                                                                                                                                    |
 | repeats            | Default: false   | Indicates if a repeating HL7 segment will generate multiple FHIR resources.                                                                                                                          |
 | isReferenced       | Default: false   | Indicates if the FHIR Resource is referenced by other FHIR resources.                                                                                                                                |
+| ignoreEmpty        | Default: false   | Indicates if an empty HL7 segment will NOT generate the matching (almost empty) FHIR resource   |
 | group | Default: empty   | Base group from which the segment and additionalSegments are specified. 
 | additionalSegments | Default: empty   | List of additional HL7 segment names required to complete the FHIR resource mapping.                                                                                                                 |
 
@@ -61,6 +63,7 @@ resources:
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
+      ignoreEmpty: true   ## Sometimes AL1 segments arrive empty
       additionalSegments:
 
 

--- a/src/main/java/io/github/linuxforhealth/api/FHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/api/FHIRResourceTemplate.java
@@ -49,6 +49,10 @@ public interface FHIRResourceTemplate {
    */
   boolean isReferenced();
 
-
-
+ /**
+  * If this resource is to ignore empty source segments
+  * 
+  * @return True/False
+  */
+  boolean ignoreEmpty();
 }

--- a/src/main/java/io/github/linuxforhealth/core/message/AbstractFHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/core/message/AbstractFHIRResourceTemplate.java
@@ -17,22 +17,25 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
   private boolean repeats;
   private String resourcePath;
   private boolean isReferenced;
+  private boolean ignoreEmpty;
 
 
   @JsonCreator
   public AbstractFHIRResourceTemplate(@JsonProperty("resourceName") String resourceName,
       @JsonProperty("resourcePath") String resourcePath,
       @JsonProperty("isReferenced") boolean isReferenced,
-      @JsonProperty("repeats") boolean repeats) {
+      @JsonProperty("repeats") boolean repeats,
+      @JsonProperty("ignoreEmpty") boolean ignoreEmpty) {
     this.resourceName = resourceName;
     this.resourcePath = resourcePath;
     this.repeats = repeats;
     this.isReferenced = isReferenced;
+    this.ignoreEmpty = ignoreEmpty;
   }
 
 
   public AbstractFHIRResourceTemplate(String resourceName, String resourcePath) {
-    this(resourceName, resourcePath, false, false);
+    this(resourceName, resourcePath, false, false, false);
   }
 
   @Override
@@ -62,6 +65,11 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
   @Override
   public boolean isReferenced() {
     return isReferenced;
+  }
+
+  @Override
+  public boolean ignoreEmpty() {
+    return ignoreEmpty;
   }
 
 

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplate.java
@@ -52,6 +52,10 @@ public class HL7FHIRResourceTemplate implements FHIRResourceTemplate {
     return this.attributes.isReferenced();
   }
 
+  @Override
+  public boolean ignoreEmpty() {
+    return this.attributes.ignoreEmpty();
+  }
 
 
 }

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplateAttributes.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplateAttributes.java
@@ -20,11 +20,11 @@ public class HL7FHIRResourceTemplateAttributes {
   private boolean repeats;
   private String resourcePath;
   private boolean isReferenced;
+  private boolean ignoreEmpty;
   private HL7Segment segment;// primary segment
   private List<HL7Segment> additionalSegments;
   private ResourceModel resource;
   private List<String> group;
-
 
 
   public HL7FHIRResourceTemplateAttributes(Builder builder) {
@@ -35,6 +35,7 @@ public class HL7FHIRResourceTemplateAttributes {
     this.resourcePath = builder.resourcePath;
     this.repeats = builder.repeats;
     this.isReferenced = builder.isReferenced;
+    this.ignoreEmpty = builder.ignoreEmpty;
     additionalSegments = new ArrayList<>();
     builder.rawAdditionalSegments
         .forEach(e -> additionalSegments.add(HL7Segment.parse(e, builder.group)));
@@ -85,7 +86,9 @@ public class HL7FHIRResourceTemplateAttributes {
     return isReferenced;
   }
 
-
+  public boolean ignoreEmpty() {
+    return ignoreEmpty;
+  }
 
   private static ResourceModel generateResourceModel(String resourcePath) {
     return ResourceReader.getInstance().generateResourceModel(resourcePath);
@@ -102,6 +105,7 @@ public class HL7FHIRResourceTemplateAttributes {
     private String resourcePath;
     private String group;
     private boolean isReferenced;
+    private boolean ignoreEmpty;
     private boolean repeats;
     private ResourceModel resourceModel;
 
@@ -153,6 +157,11 @@ public class HL7FHIRResourceTemplateAttributes {
 
     public Builder withIsReferenced(boolean isReferenced) {
       this.isReferenced = isReferenced;
+      return this;
+    }
+
+    public Builder withignoreEmpty(boolean ignoreEmpty) {
+      this.ignoreEmpty = ignoreEmpty;
       return this;
     }
 

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -306,9 +306,11 @@ public class HL7MessageEngine implements MessageEngine {
                     Visitable vs = baseValue.getValue();
                     if((vs != null && ! vs.isEmpty()) || ! ignoreEmpty) {
 
-                        // baseValue is either not empty or we're ignoring empty segments
+                        // baseValue is either not empty or we're not allowed to ignore empty segments
                         ResourceResult result = rs.evaluate(hl7DataInput, ImmutableMap.copyOf(localContextValues),
                                 baseValue);
+
+                        // We can't rely on empty segment giving us an empty resource; as common templates populate Resource.meta fields
                         if (result != null && result.getValue() != null) {
                             resourceResults.add(result);
                             if (!generateMultiple) {

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -27,7 +27,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Structure;
+import ca.uhn.hl7v2.model.Visitable;
 import io.github.linuxforhealth.api.EvaluationResult;
 import io.github.linuxforhealth.api.FHIRResourceTemplate;
 import io.github.linuxforhealth.api.InputDataExtractor;
@@ -189,7 +191,7 @@ public class HL7MessageEngine implements MessageEngine {
         if (!multipleSegments.isEmpty()) {
 
             resourceResults = generateMultipleResources(hl7DataInput, resourceModel, contextValues,
-                    multipleSegments, template.isGenerateMultiple());
+                    multipleSegments, template.isGenerateMultiple(), template.ignoreEmpty());
         }
         return resourceResults;
     }
@@ -284,7 +286,7 @@ public class HL7MessageEngine implements MessageEngine {
 
     private static List<ResourceResult> generateMultipleResources(final HL7MessageData hl7DataInput,
             final ResourceModel rs, final Map<String, EvaluationResult> contextValues,
-            final List<SegmentGroup> multipleSegments, boolean generateMultiple) {
+            final List<SegmentGroup> multipleSegments, boolean generateMultiple, boolean ignoreEmpty) {
         List<ResourceResult> resourceResults = new ArrayList<>();
         for (SegmentGroup currentGroup : multipleSegments) {
 
@@ -300,16 +302,22 @@ public class HL7MessageEngine implements MessageEngine {
 
             for (EvaluationResult baseValue : baseValues) {
                 try {
-                    ResourceResult result = rs.evaluate(hl7DataInput, ImmutableMap.copyOf(localContextValues),
-                            baseValue);
-                    if (result != null && result.getValue() != null) {
-                        resourceResults.add(result);
-                        if (!generateMultiple) {
-                            // If only single resource needs to be generated then return.
-                            return resourceResults;
+                    // We might need to check if the baseValue is empty
+                    Visitable vs = baseValue.getValue();
+                    if((vs != null && ! vs.isEmpty()) || ! ignoreEmpty) {
+
+                        // baseValue is either not empty or we're ignoring empty segments
+                        ResourceResult result = rs.evaluate(hl7DataInput, ImmutableMap.copyOf(localContextValues),
+                                baseValue);
+                        if (result != null && result.getValue() != null) {
+                            resourceResults.add(result);
+                            if (!generateMultiple) {
+                                // If only single resource needs to be generated then return.
+                                return resourceResults;
+                            }
                         }
                     }
-                } catch (RequiredConstraintFailureException | IllegalArgumentException
+                } catch (RequiredConstraintFailureException | IllegalArgumentException | HL7Exception
                         | IllegalStateException e) {
                     LOGGER.warn("generateMultipleResources - Exception encountered");
                     LOGGER.debug("generateMultipleResources - Exception encountered", e);

--- a/src/test/resources/additional_resources/hl7/message/ADT_A10.yml
+++ b/src/test/resources/additional_resources/hl7/message/ADT_A10.yml
@@ -1,9 +1,9 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Te Whatu Ora, Health New Zealand, 2023
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# FHIR Resources to extract from ADT_A09 message
+# FHIR Resources to extract from (pretend) ADT_A10 message
 #
 
 ########################################################################
@@ -22,7 +22,7 @@ resources:
    
     - resourceName: Patient
       segment: PID
-      resourcePath: resource/Patient
+      resourcePath: resource/customPatient
       repeats: false
       isReferenced: true
       additionalSegments:
@@ -44,7 +44,7 @@ resources:
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
-      ignoreEmpty: true      ## We want to test our new ignoreEmpty flag
+      ignoreEmpty: false      ## We want to test our new ignoreEmpty flag
       additionalSegments:
         - MSH
 
@@ -52,6 +52,6 @@ resources:
       segment: ZAL
       resourcePath: resource/AllergyIntolerance
       repeats: true
-      ignoreEmpty: true      ## We want to test our new ignoreEmpty flag on 'Z' segments
+      ignoreEmpty: false      ## We want to test our new ignoreEmpty flag on 'Z' segments
       additionalSegments:
         - MSH


### PR DESCRIPTION
Sometimes some segments are empty, and due to common templates populating `Resource.meta` field we need a way to ignore these empty segments, and not generate a partially filled in Resource.

This example message:

```
MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||ADT^A09|controlID|P|2.6
EVN|A01|20150502090000|
PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||
PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|
AL1|
```
with resource template setting of:

```yaml
resources:
    - resourceName: AllergyIntolerance
      segment: AL1
      resourcePath: resource/AllergyIntolerance
      repeats: true
      ignoreEmpty: true      ## We want to test our new ignoreEmpty flag
      additionalSegments:
        - MSH
```
Should not generate an `AllergyIntolerance` resource if the `ignoreEmpty` field is set to `true`