### PR TITLE
Feat/conditional resource template

### DIFF
--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -15,6 +15,7 @@ A HL7 message template maps one or more HL7 segments to a FHIR resource using th
       repeats:  [DEFAULT false]
       isReferenced: [DEFAULT false]
       ignoreEmpty: [DEFAULT false]
+      condition: [DEFAULT empty]
       additionalSegments: [DEFAULT empty]
 ```
 
@@ -26,6 +27,7 @@ A HL7 message template maps one or more HL7 segments to a FHIR resource using th
 | repeats            | Default: false   | Indicates if a repeating HL7 segment will generate multiple FHIR resources.                                                                                                                          |
 | isReferenced       | Default: false   | Indicates if the FHIR Resource is referenced by other FHIR resources.                                                                                                                                |
 | ignoreEmpty        | Default: false   | Indicates if an empty HL7 segment will NOT generate the matching (almost empty) FHIR resource   |
+| condition          | Default: empty   | Indicates that the segment must satisfy the given condition for it to generate the matching FHIR resource. see [Techniques: Conditional Templates](TECHNIQUES.md#Conditional-Templates) |
 | group | Default: empty   | Base group from which the segment and additionalSegments are specified. 
 | additionalSegments | Default: empty   | List of additional HL7 segment names required to complete the FHIR resource mapping.                                                                                                                 |
 
@@ -66,6 +68,19 @@ resources:
       ignoreEmpty: true   ## Sometimes AL1 segments arrive empty
       additionalSegments:
 
+    - resourceName: AllergyIntolerance
+      segment: ZAL
+      resourcePath: resource/AllergyIntoleranceZAL
+      repeats: true
+      condition: ZAL.2.1 IN [A1, A3, H2, H4]          ## Some of our custom ZAL segments are AllergyIntolerance
+      additionalSegments:
+
+    - resourceName: Flag
+      segment: ZAL
+      resourcePath: resource/FlagZAL
+      repeats: true
+      condition: ZAL.2.1 NOT_IN [A1, A3, H2, H4]      ## The rest of our custom ZAL segments are more general alert Flags
+      additionalSegments:
 
 ```
 
@@ -262,6 +277,7 @@ The specification expression has the following format :
     - SEGMENT
     - SEGMENT.FIELD
     - SEGMENT.FIELD.COMPONENT
+    - SEGMENT.FIELD.COMPONENT.SUBCOMPONENT
     - FIELD
     - FIELD.COMPONENT
     - FIELD.COMPONENT.SUBCOMPONENT<br>

--- a/TEMPLATING.md
+++ b/TEMPLATING.md
@@ -14,6 +14,7 @@ A HL7 message template maps one or more HL7 segments to a FHIR resource using th
       resourcePath: [REQUIRED]
       repeats:  [DEFAULT false]
       isReferenced: [DEFAULT false]
+      ignoreEmpty: [DEFAULT false]
       additionalSegments: [DEFAULT empty]
 ```
 
@@ -24,6 +25,7 @@ A HL7 message template maps one or more HL7 segments to a FHIR resource using th
 | resourcePath       | Required         | Relative path to the resource template. Example: resource/Patient                                                                                                                                    |
 | repeats            | Default: false   | Indicates if a repeating HL7 segment will generate multiple FHIR resources.                                                                                                                          |
 | isReferenced       | Default: false   | Indicates if the FHIR Resource is referenced by other FHIR resources.                                                                                                                                |
+| ignoreEmpty        | Default: false   | Indicates if an empty HL7 segment will NOT generate the matching (almost empty) FHIR resource   |
 | group | Default: empty   | Base group from which the segment and additionalSegments are specified. 
 | additionalSegments | Default: empty   | List of additional HL7 segment names required to complete the FHIR resource mapping.                                                                                                                 |
 
@@ -61,6 +63,7 @@ resources:
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
+      ignoreEmpty: true   ## Sometimes AL1 segments arrive empty
       additionalSegments:
 
 

--- a/src/main/java/io/github/linuxforhealth/api/FHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/api/FHIRResourceTemplate.java
@@ -49,6 +49,10 @@ public interface FHIRResourceTemplate {
    */
   boolean isReferenced();
 
-
-
+ /**
+  * If this resource is to ignore empty source segments
+  * 
+  * @return True/False
+  */
+  boolean ignoreEmpty();
 }

--- a/src/main/java/io/github/linuxforhealth/api/FHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/api/FHIRResourceTemplate.java
@@ -55,4 +55,11 @@ public interface FHIRResourceTemplate {
   * @return True/False
   */
   boolean ignoreEmpty();
+
+ /**
+  *  If this resource is only to be applied sometimes
+  *  
+  * @return Simple condition expression which must be True for the template to be applied;  e.g.  ZAL.1 IN [A3, A4, H1, H3]
+  */
+  String conditionExpression();
 }

--- a/src/main/java/io/github/linuxforhealth/api/ResourceCondition.java
+++ b/src/main/java/io/github/linuxforhealth/api/ResourceCondition.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright Te Whatu Ora, Health New Zealand, 2023
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.api;
+
+/**
+ * Resource Condition allows for conditional application of ResourceTemplate to a particular message
+ * 
+ * @author Stuart McGrigor
+ */
+public interface ResourceCondition {
+
+
+    /**
+     * Evaluates the condition against the HL7 Message
+     * 
+     * @param context {@link EvaluationResult} representing the HL7 Segment being evaluated
+     * @return true if condition is satisfied by the HL7 Segment being evaluated, otherwise returns false;
+     */
+    default boolean isConditionSatisfied(InputDataExtractor ide, EvaluationResult context) {
+      return true;
+    }
+}

--- a/src/main/java/io/github/linuxforhealth/core/message/AbstractFHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/core/message/AbstractFHIRResourceTemplate.java
@@ -17,22 +17,25 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
   private boolean repeats;
   private String resourcePath;
   private boolean isReferenced;
+  private boolean ignoreEmpty;
 
 
   @JsonCreator
   public AbstractFHIRResourceTemplate(@JsonProperty("resourceName") String resourceName,
       @JsonProperty("resourcePath") String resourcePath,
       @JsonProperty("isReferenced") boolean isReferenced,
-      @JsonProperty("repeats") boolean repeats) {
+      @JsonProperty("repeats") boolean repeats,
+      @JsonProperty("ignoreEmpty") boolean ignoreEmpty) {
     this.resourceName = resourceName;
     this.resourcePath = resourcePath;
     this.repeats = repeats;
     this.isReferenced = isReferenced;
+    this.ignoreEmpty = ignoreEmpty;
   }
 
 
   public AbstractFHIRResourceTemplate(String resourceName, String resourcePath) {
-    this(resourceName, resourcePath, false, false);
+    this(resourceName, resourcePath, false, false, false);
   }
 
   @Override
@@ -62,6 +65,11 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
   @Override
   public boolean isReferenced() {
     return isReferenced;
+  }
+
+  @Override
+  public boolean ignoreEmpty() {
+    return ignoreEmpty;
   }
 
 

--- a/src/main/java/io/github/linuxforhealth/core/message/AbstractFHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/core/message/AbstractFHIRResourceTemplate.java
@@ -18,6 +18,7 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
   private String resourcePath;
   private boolean isReferenced;
   private boolean ignoreEmpty;
+  private String condition;
 
 
   @JsonCreator
@@ -25,17 +26,19 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
       @JsonProperty("resourcePath") String resourcePath,
       @JsonProperty("isReferenced") boolean isReferenced,
       @JsonProperty("repeats") boolean repeats,
-      @JsonProperty("ignoreEmpty") boolean ignoreEmpty) {
+      @JsonProperty("ignoreEmpty") boolean ignoreEmpty,
+      @JsonProperty("condition") String conditionExpression) {
     this.resourceName = resourceName;
     this.resourcePath = resourcePath;
     this.repeats = repeats;
     this.isReferenced = isReferenced;
     this.ignoreEmpty = ignoreEmpty;
+    this.condition = conditionExpression;
   }
 
 
   public AbstractFHIRResourceTemplate(String resourceName, String resourcePath) {
-    this(resourceName, resourcePath, false, false, false);
+    this(resourceName, resourcePath, false, false, false, null);
   }
 
   @Override
@@ -72,7 +75,8 @@ public abstract class AbstractFHIRResourceTemplate implements FHIRResourceTempla
     return ignoreEmpty;
   }
 
-
-
-
+  @Override
+  public String conditionExpression() {
+    return condition;
+  }
 }

--- a/src/main/java/io/github/linuxforhealth/hl7/expression/specification/SpecificationParser.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/expression/specification/SpecificationParser.java
@@ -33,13 +33,20 @@ public class SpecificationParser {
     if (stk.hasNext()) {
       String tok = stk.next();
 
-      if (SupportedSegments.contains(tok)) {
+      // tokens that start with Z are also valid SEGMENTS
+      if (SupportedSegments.contains(tok) || tok.startsWith("Z")) {
         segment = tok;
         if (stk.hasNext()) {
           field = stk.nextToken();
         }
         if (stk.hasNext()) {
           component = NumberUtils.toInt(stk.nextToken());
+        }
+
+        // Don't forget the SubComponents - PID.5.1.2 & PID.5.1.3, can be quite useful
+        //   - allowing us to separate the 'van' and 'van der' prefixes from names like Ludwig van Beethoven, and Cornelius van der Westhuizen
+        if (stk.hasNext()) {
+          subComponent = NumberUtils.toInt(stk.nextToken());
         }
       } else {
         field = tok;

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceCondition.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceCondition.java
@@ -1,0 +1,208 @@
+/*
+ * (c) Copyright Te Whatu Ora, Health New Zealand, 2023
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ */
+package io.github.linuxforhealth.hl7.message;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.GenericPrimitive;
+import ca.uhn.hl7v2.model.Segment;
+import ca.uhn.hl7v2.model.Varies;
+
+import io.github.linuxforhealth.api.EvaluationResult;
+import io.github.linuxforhealth.api.InputDataExtractor;
+import io.github.linuxforhealth.api.ResourceCondition;
+import io.github.linuxforhealth.hl7.expression.specification.HL7Specification;
+import io.github.linuxforhealth.hl7.expression.specification.SpecificationParser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+  * Allows us to conditionally apply a ResourceTemplate depending upon particular values being present in the HL7 message.
+  * 
+  *   <expression>  EQUALS | NOT_EQUALS | IN | NOT_IN | IS_NULL | NOT_NULL   value | [ ... ]
+  *
+  *   eg:  ZSC.2.1.3 NOT_NULL
+  *        ZCR.2(1).1 IS_NULL
+  *        ZCP.3.1 IN [A3, A4, H1, H3, FA, DA]
+  *        ZCP.3.1 NOT_IN [A2, F3, DA]
+  *        ZFD.2 EQUALS A4
+  *        ZSG NOT_EQUALS H2
+  *        
+  *
+  *  Note:  Condition cannot be much more complex, as there are no context variables available at evaluation time.
+  */
+public class HL7FHIRResourceCondition implements ResourceCondition {
+  public enum Operator {
+    EQUALS, NOT_EQUALS, IN, NOT_IN, IS_NULL, NOT_NULL
+  }
+
+  public HL7Specification fieldSpec;       //  expression for the field to be checked
+  public Operator op;                      //  Which comparison?
+  public ArrayList<String> values = new ArrayList<String>();
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HL7FHIRResourceCondition.class);
+
+  public HL7FHIRResourceCondition(String condition) {
+    Preconditions.checkArgument(condition != null && ! condition.isEmpty() && ! condition.isBlank(),
+        "HL7FHIRResourceCondition (if present) cannot be null, empty or blank");
+
+    //  Chop the condition up into pieces - using a non-trivial regexp
+    String regexp="([A-Z][A-Z0-9]+(?:\\.\\d+)?(?:\\(\\d\\))?(?:\\.\\d+)?(?:\\.\\d+)?)\\s+(IN|NOT_IN|EQUALS|NOT_EQUALS|IS_NULL|NOT_NULL)(?:\\s+(?:(\\w+)|\\[([\\s\\w,]+)\\])?)?";
+    Pattern pattern = Pattern.compile(regexp);
+    Matcher matcher = pattern.matcher(condition);
+
+    // Make sure the expression matched
+    if(! matcher.matches())
+      throw new IllegalArgumentException(String.format("Can't parse %s - regexp 'fieldSpec EQUALS|NOT_EQUALS|IN|NOT_IN values' doesn't match", condition));
+
+    // populate our fields
+    this.fieldSpec = (HL7Specification) SpecificationParser.parse(matcher.group(1), false, false);
+    op = Operator.valueOf(matcher.group(2));
+
+    // group(3) and group(4) are both null for IS_NULL and NOT_NULL
+    if(matcher.group(3) == null && matcher.group(4) == null) {
+
+      // Only on IS_NULL and NOT_NULL
+      if(! op.equals(Operator.IS_NULL) && ! op.equals(Operator.NOT_NULL))
+        throw new IllegalArgumentException(String.format("Can't parse %s - non-value only applies to IS_NULL and NOT_NULL", condition));
+
+      // ... and we're done
+      return;
+    }
+
+
+    // group(3) is a single value and only for EQUALS and NOT_EQUALS
+    if(matcher.group(3) != null) {
+
+       // Only on EQUALS and NOT_EQUALS
+      if(! op.equals(Operator.EQUALS) && ! op.equals(Operator.NOT_EQUALS))
+        throw new IllegalArgumentException(String.format("Can't parse %s - Single value only applies to EQUALS and NOT_EQUALS", condition));
+
+        values.add(matcher.group(3));
+
+      // ...and we're done
+      return;
+    }
+
+    // We're working with multiple values in group(4)
+    if(matcher.group(4) == null) {
+      throw new IllegalArgumentException(String.format("Can't parse %s - Multiple values not found", condition));
+    }
+
+    // Only on IN and NOT_IN
+    if(! op.equals(Operator.IN) && ! op.equals(Operator.NOT_IN))
+      throw new IllegalArgumentException(String.format("Can't parse %s - Multiple values only applies to IN and NOT_IN", condition));
+
+    // group(4) is a single string with multiple values
+    String toks[] = matcher.group(4).split("\\s*,\\s*");
+
+    // Make sure we got at least one token
+    if(toks.length == 0)
+      throw new IllegalArgumentException(String.format("Can't parse %s - no values for IN | NOT_IN found", condition));
+
+    for(int ndx=0; ndx<toks.length; ndx++) {
+      values.add(toks[ndx]);
+    }
+  }
+
+  @Override
+  public boolean isConditionSatisfied(InputDataExtractor ide, EvaluationResult context) {
+
+    Preconditions.checkArgument(context != null && (context.getValue() instanceof Segment),
+        String.format("HL7FHIRResourceCondition context must be of type Segment not %s", context.getClass().getName()));
+
+    Segment seg = (Segment) context.getValue();
+    String segName = seg.getName();
+
+    // Have we been given the right context segment ?
+    Preconditions.checkArgument(this.fieldSpec.getSegment() != null && this.fieldSpec.getSegment().equals(segName),
+            String.format("HL7FHIRResourceCondition context Segment %s doesn't match %s", segName, fieldSpec.toString()));
+
+    // We're going to extract a value from the context Segment for testing
+    EvaluationResult evalResult;
+    Object obj;
+
+    try {
+      evalResult = ide.extractValueForSpec(this.fieldSpec, Map.of(seg.getName(), context));
+
+      // Empty result can't succeed
+      if(evalResult.isEmpty()) {
+        LOGGER.warn(String.format("extract field %s was empty", this.fieldSpec.toString()));
+        return false;
+      }
+
+      // We actually just want the value (but it could be anything)
+      obj = evalResult.getValue();
+
+    } catch (Exception ex) {
+      LOGGER.warn(String.format("extract field %s", this.fieldSpec.toString()));
+      LOGGER.debug(String.format("extract field %s", this.fieldSpec.toString()), ex);
+      return false;
+    }
+
+
+    // Grab the actual candidateValue from the returned object
+    String candidateVal;
+    try {
+      if(obj instanceof Segment) {
+        //  We got a whole Segment - grab the first field...
+        candidateVal = ((Varies) ((Segment) obj).getField(1, 0)).getData().toString();        
+      }
+      else if(obj instanceof Varies) {
+        candidateVal = ((Varies) obj).getData().toString();        
+      }
+      else if(obj instanceof GenericPrimitive) {
+        candidateVal = ((GenericPrimitive) obj).getValue();
+      }
+      else {
+        LOGGER.warn(String.format("extract segment %s unknown return type %s", this.fieldSpec.toString(), obj.getClass().getName()));
+        return false;
+      }
+
+    } catch (HL7Exception ex) {
+      LOGGER.warn(String.format("extract segment %s", this.fieldSpec.toString()));
+      LOGGER.debug(String.format("extract segment %s", this.fieldSpec.toString()), ex);
+      return false;
+    }
+
+    // Now do the comparison
+    switch(this.op) {
+      case EQUALS:
+        return candidateVal.equals(this.values.get(0));
+
+      case NOT_EQUALS:
+        return ! candidateVal.equals(this.values.get(0));
+
+      case IN:
+        return this.values.contains(candidateVal);
+        
+      case NOT_IN:
+        return ! this.values.contains(candidateVal);
+
+      case NOT_NULL:
+        return candidateVal != null;
+
+      case IS_NULL:
+        return candidateVal == null;
+
+      default:
+        LOGGER.error("Unknown ResourceCondition.Operator %s", this.op.toString());
+        return false;
+    }
+  }
+
+  public String toString() {
+    return String.format("ResourceCondition: %s %s %s", this.fieldSpec.toString(), this.op.toString(), this.values.toString());
+  }
+}

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplate.java
@@ -7,6 +7,7 @@ package io.github.linuxforhealth.hl7.message;
 
 import com.google.common.base.Preconditions;
 import io.github.linuxforhealth.api.FHIRResourceTemplate;
+import io.github.linuxforhealth.api.ResourceCondition;
 import io.github.linuxforhealth.api.ResourceModel;
 
 
@@ -57,5 +58,13 @@ public class HL7FHIRResourceTemplate implements FHIRResourceTemplate {
     return this.attributes.ignoreEmpty();
   }
 
+  @Override
+  public String conditionExpression() {
+    return this.attributes.conditionExpression();
+  }
 
+  // The conditionExpression above gets parsed into a ResourceCondition
+  public ResourceCondition condition() {
+    return this.attributes.condition();
+ }
 }

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplate.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplate.java
@@ -52,6 +52,10 @@ public class HL7FHIRResourceTemplate implements FHIRResourceTemplate {
     return this.attributes.isReferenced();
   }
 
+  @Override
+  public boolean ignoreEmpty() {
+    return this.attributes.ignoreEmpty();
+  }
 
 
 }

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplateAttributes.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplateAttributes.java
@@ -20,11 +20,11 @@ public class HL7FHIRResourceTemplateAttributes {
   private boolean repeats;
   private String resourcePath;
   private boolean isReferenced;
+  private boolean ignoreEmpty;
   private HL7Segment segment;// primary segment
   private List<HL7Segment> additionalSegments;
   private ResourceModel resource;
   private List<String> group;
-
 
 
   public HL7FHIRResourceTemplateAttributes(Builder builder) {
@@ -35,6 +35,7 @@ public class HL7FHIRResourceTemplateAttributes {
     this.resourcePath = builder.resourcePath;
     this.repeats = builder.repeats;
     this.isReferenced = builder.isReferenced;
+    this.ignoreEmpty = builder.ignoreEmpty;
     additionalSegments = new ArrayList<>();
     builder.rawAdditionalSegments
         .forEach(e -> additionalSegments.add(HL7Segment.parse(e, builder.group)));
@@ -85,7 +86,9 @@ public class HL7FHIRResourceTemplateAttributes {
     return isReferenced;
   }
 
-
+  public boolean ignoreEmpty() {
+    return ignoreEmpty;
+  }
 
   private static ResourceModel generateResourceModel(String resourcePath) {
     return ResourceReader.getInstance().generateResourceModel(resourcePath);
@@ -102,6 +105,7 @@ public class HL7FHIRResourceTemplateAttributes {
     private String resourcePath;
     private String group;
     private boolean isReferenced;
+    private boolean ignoreEmpty;
     private boolean repeats;
     private ResourceModel resourceModel;
 
@@ -153,6 +157,11 @@ public class HL7FHIRResourceTemplateAttributes {
 
     public Builder withIsReferenced(boolean isReferenced) {
       this.isReferenced = isReferenced;
+      return this;
+    }
+
+    public Builder withignoreEmpty(boolean ignoreEmpty) {
+      this.ignoreEmpty = ignoreEmpty;
       return this;
     }
 

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplateAttributes.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7FHIRResourceTemplateAttributes.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
+import io.github.linuxforhealth.api.ResourceCondition;
 import io.github.linuxforhealth.api.ResourceModel;
 import io.github.linuxforhealth.hl7.resource.ResourceReader;
 
@@ -21,6 +22,8 @@ public class HL7FHIRResourceTemplateAttributes {
   private String resourcePath;
   private boolean isReferenced;
   private boolean ignoreEmpty;
+  private ResourceCondition condition;
+  private String conditionExpression;
   private HL7Segment segment;// primary segment
   private List<HL7Segment> additionalSegments;
   private ResourceModel resource;
@@ -36,6 +39,8 @@ public class HL7FHIRResourceTemplateAttributes {
     this.repeats = builder.repeats;
     this.isReferenced = builder.isReferenced;
     this.ignoreEmpty = builder.ignoreEmpty;
+    this.condition = builder.condition;
+    this.conditionExpression = builder.conditionExpression;
     additionalSegments = new ArrayList<>();
     builder.rawAdditionalSegments
         .forEach(e -> additionalSegments.add(HL7Segment.parse(e, builder.group)));
@@ -90,6 +95,14 @@ public class HL7FHIRResourceTemplateAttributes {
     return ignoreEmpty;
   }
 
+  public ResourceCondition condition() {
+    return condition;
+  }
+
+  public String conditionExpression() {
+      return conditionExpression;
+  }
+
   private static ResourceModel generateResourceModel(String resourcePath) {
     return ResourceReader.getInstance().generateResourceModel(resourcePath);
   }
@@ -106,6 +119,8 @@ public class HL7FHIRResourceTemplateAttributes {
     private String group;
     private boolean isReferenced;
     private boolean ignoreEmpty;
+    private ResourceCondition condition;
+    private String conditionExpression;
     private boolean repeats;
     private ResourceModel resourceModel;
 
@@ -162,6 +177,12 @@ public class HL7FHIRResourceTemplateAttributes {
 
     public Builder withignoreEmpty(boolean ignoreEmpty) {
       this.ignoreEmpty = ignoreEmpty;
+      return this;
+    }
+
+    public Builder withCondition(String conditionExpr) {
+      this.conditionExpression = conditionExpr;
+      this.condition = new HL7FHIRResourceCondition(conditionExpr);
       return this;
     }
 

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -306,9 +306,11 @@ public class HL7MessageEngine implements MessageEngine {
                     Visitable vs = baseValue.getValue();
                     if((vs != null && ! vs.isEmpty()) || ! ignoreEmpty) {
 
-                        // baseValue is either not empty or we're ignoring empty segments
+                        // baseValue is either not empty or we're not allowed to ignore empty segments
                         ResourceResult result = rs.evaluate(hl7DataInput, ImmutableMap.copyOf(localContextValues),
                                 baseValue);
+
+                        // We can't rely on empty segment giving us an empty resource; as common templates populate Resource.meta fields
                         if (result != null && result.getValue() != null) {
                             resourceResults.add(result);
                             if (!generateMultiple) {

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -27,7 +27,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Structure;
+import ca.uhn.hl7v2.model.Visitable;
 import io.github.linuxforhealth.api.EvaluationResult;
 import io.github.linuxforhealth.api.FHIRResourceTemplate;
 import io.github.linuxforhealth.api.InputDataExtractor;
@@ -189,7 +191,7 @@ public class HL7MessageEngine implements MessageEngine {
         if (!multipleSegments.isEmpty()) {
 
             resourceResults = generateMultipleResources(hl7DataInput, resourceModel, contextValues,
-                    multipleSegments, template.isGenerateMultiple());
+                    multipleSegments, template.isGenerateMultiple(), template.ignoreEmpty());
         }
         return resourceResults;
     }
@@ -284,7 +286,7 @@ public class HL7MessageEngine implements MessageEngine {
 
     private static List<ResourceResult> generateMultipleResources(final HL7MessageData hl7DataInput,
             final ResourceModel rs, final Map<String, EvaluationResult> contextValues,
-            final List<SegmentGroup> multipleSegments, boolean generateMultiple) {
+            final List<SegmentGroup> multipleSegments, boolean generateMultiple, boolean ignoreEmpty) {
         List<ResourceResult> resourceResults = new ArrayList<>();
         for (SegmentGroup currentGroup : multipleSegments) {
 
@@ -300,16 +302,22 @@ public class HL7MessageEngine implements MessageEngine {
 
             for (EvaluationResult baseValue : baseValues) {
                 try {
-                    ResourceResult result = rs.evaluate(hl7DataInput, ImmutableMap.copyOf(localContextValues),
-                            baseValue);
-                    if (result != null && result.getValue() != null) {
-                        resourceResults.add(result);
-                        if (!generateMultiple) {
-                            // If only single resource needs to be generated then return.
-                            return resourceResults;
+                    // We might need to check if the baseValue is empty
+                    Visitable vs = baseValue.getValue();
+                    if((vs != null && ! vs.isEmpty()) || ! ignoreEmpty) {
+
+                        // baseValue is either not empty or we're ignoring empty segments
+                        ResourceResult result = rs.evaluate(hl7DataInput, ImmutableMap.copyOf(localContextValues),
+                                baseValue);
+                        if (result != null && result.getValue() != null) {
+                            resourceResults.add(result);
+                            if (!generateMultiple) {
+                                // If only single resource needs to be generated then return.
+                                return resourceResults;
+                            }
                         }
                     }
-                } catch (RequiredConstraintFailureException | IllegalArgumentException
+                } catch (RequiredConstraintFailureException | IllegalArgumentException | HL7Exception
                         | IllegalStateException e) {
                     LOGGER.warn("generateMultipleResources - Exception encountered");
                     LOGGER.debug("generateMultipleResources - Exception encountered", e);

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ConditionalMappingTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7ConditionalMappingTest.java
@@ -1,0 +1,327 @@
+/*
+ * (c) Te Whatu Ora, Health New Zealand, 2023
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * @author Stuart McGrigor
+ */
+
+package io.github.linuxforhealth.hl7.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.github.linuxforhealth.core.config.ConverterConfiguration;
+import io.github.linuxforhealth.fhir.FHIRContext;
+import io.github.linuxforhealth.hl7.ConverterOptions;
+import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
+import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
+import io.github.linuxforhealth.hl7.resource.ResourceReader;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
+// This class uses the ability to create ADDITIONAL HL7 messages to convert weird HL7 messages
+// that exercise the new conditional Resource Template functionality
+//
+// In these tests, the additional message definitions for (entirely ficticious) ADT^A11 messages
+// are placed in src/test/resources/additional_resources/hl7/message/ADT_A11.yml
+
+class Hl7ConditionalMappingTest {
+
+    // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    // NOTE VALIDATION IS INTENTIONALLY NOT USED BECAUSE WE ARE CREATING RESOURCES THAT ARE NOT STANDARD
+    private static final ConverterOptions OPTIONS = new Builder().withPrettyPrint().build();
+    // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+    private static final String CONF_PROP_HOME = "hl7converter.config.home";
+
+    @TempDir
+    static File folder;
+
+    static String originalConfigHome;
+
+    @BeforeAll
+    static void saveConfigHomeProperty() {
+        originalConfigHome = System.getProperty(CONF_PROP_HOME);
+        ConverterConfiguration.reset();
+        ResourceReader.reset();
+        folder.setWritable(true);
+    }
+
+    @AfterEach
+    void reset() {
+        System.clearProperty(CONF_PROP_HOME);
+        ConverterConfiguration.reset();
+        ResourceReader.reset();
+    }
+
+    @AfterAll
+    static void reloadPreviousConfigurations() {
+        if (originalConfigHome != null)
+            System.setProperty(CONF_PROP_HOME, originalConfigHome);
+        else
+            System.clearProperty(CONF_PROP_HOME);
+        folder.setWritable(true);
+    }
+
+
+    // Conditional Segment test - Custom SEGMENT value   --  ZSG
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZSG|L2\r,1", 
+                 "ADT^A11,ZSG|A3\r,0",
+                 "ADT^A11,ZSG|L2|Two\r,1",                    // L2 is a FIELD value, but SEGMENT comparison will return first field
+                 "ADT^A11,ZSG|L2^Lookup List 2^WebPAS\r,0"    // L2 is a COMPONENT value so SEGMENT comparison will fail
+                })
+    void testConditionalSegmentValueIsSegment(String messageType, String zSegment, int aiCount) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(aiCount);   // How many AllergyIntolerance segments ?
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(2 + aiCount);
+    }
+
+    // Conditional Segment test - Custom FIELD Value  -  ZFD-2
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZFD|1|L2\r,1", 
+                 "ADT^A11,ZFD|1|A3\r,0",
+                 "ADT^A11,ZFD|1|L2|Three|Four\r,1",
+                 "ADT^A11,ZFD|L2\r,0",                         // L2 is a SEGMENT value so FIELD comparison will fail
+                 "ADT^A11,ZFD|1|L2^Lookup List 2^WebPAS\r,0"   // L2 is a COMPONENT value so FIELD comparison will fail
+                })
+    void testConditionalSegmentValueIsField(String messageType, String zSegment, int aiCount) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(aiCount);   // How many AllergyIntolerance segments ?
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(2 + aiCount);
+    }
+
+    // Conditional Segment test - Custom COMPONENT Value  -  ZCP.2.1
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZCP|1|A3^Allergies^WebPAS\r,1", 
+                 "ADT^A11,ZCP|1|H1^Drug Reactions^WebPAS\r,1", 
+                 "ADT^A11,ZCP|1|H3^Other Allergies^WebPAS\r,1", 
+                 "ADT^A11,ZCP|1|H2^Health Conditions^WebPAS\r,0",             // H2 not IN set
+                 "ADT^A11,ZCP|1|H4^Infection Prevention Alerts^WebPAS\r,0",   // H4 not IN set
+                 "ADT^A11,ZCP|1|H3|three|four\r,1"                            // H3 in FIELD, yet COMPONENT comparison succeeds
+                })
+    void testConditionalSegmentValueIsComponent(String messageType, String zSegment, int aiCount) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(aiCount);   // How many AllergyIntolerance segments ?
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(2 + aiCount);
+    }
+
+    // Conditional Segment test - Custom SUB COMPONENT Value  - ZSC-2.1.2
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZSC|1|pre&A3^Allergies^WebPAS\r,1", 
+                 "ADT^A11,ZSC|1|pre&H1^Drug Reactions^WebPAS\r,1", 
+                 "ADT^A11,ZSC|1|pre&H3^Other Allergies^WebPAS\r,1", 
+                 "ADT^A11,ZSC|1|pre&H2^Health Conditions^WebPAS\r,0",             // H2 not IN set
+                 "ADT^A11,ZSC|1|pre&H4^Infection Prevention Alerts^WebPAS\r,0",   // H4 not IN set
+                 "ADT^A11,ZSC|1|H3|three|four\r,0",                               // H3 in FIELD so SUB COMPONENT comparison will fail
+                 "ADT^A11,ZSC|1|H3^Other Allergies^WebPAS|three|four\r,0"         // H3 in COMPONENT, so SUB COMPONENT comparison will fail
+                })
+    void testConditionalSegmentValueIsSubComponent(String messageType, String zSegment, int aiCount) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(aiCount);   // How many AllergyIntolerance segments ?
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(2 + aiCount);
+    }
+
+
+    // Conditional Segment test - repetition -  ZCR.2(1).1    -- repetitions start at Zero
+     @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZCP|1|A3^Allergies^WebPAS~H2^Other Allergies^WebPAS\r,0", 
+                 "ADT^A11,ZCP|1|H1^Drug Reactions^WebPAS~A3^Allergies^WebPAS\r,1" })
+    void testConditionalSegmentRepetitions(String messageType, String zSegment, int aiCount) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + "ZCP|1|A3^Allergies^WebPAS\r"                      // included
+                + "ZCP|2|H1^Drug Reactions^WebPAS\r"                 // included
+                + "ZCP|3|H2^Health Conditions^WebPAS\r"              // dropped
+                + "ZCP|4|H3^Other Allergies^WebPAS\r"                // included
+                + "ZCP|5|H4^Infection Prevention Alerts^WebPAS\r";   // dropped
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(3);   // How many AllergyIntolerance segments ?
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(5);
+    }
+
+    // Conditional Segment test - multiple segments -  make sure we don't get confusion in which segment we're testing
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZCP|1|A3^Allergies^WebPAS\r,1", 
+                 "ADT^A11,ZCP|1|H1^Drug Reactions^WebPAS\r,1", 
+                 "ADT^A11,ZCP|1|H2^Health Conditions^WebPAS\r,0", 
+                 "ADT^A11,ZCP|1|H3^Other Allergies^WebPAS\r,1", 
+                 "ADT^A11,ZCP|1|H4^Infection Prevention Alerts^WebPAS\r,0"})
+    void testConditionalSegmentMultiples(String messageType, String zSegment, int aiCount) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + "ZCP|1|A3^Allergies^WebPAS\r"                      // included
+                + "ZCP|2|H1^Drug Reactions^WebPAS\r"                 // included
+                + "ZCP|3|H2^Health Conditions^WebPAS\r"              // dropped
+                + "ZCP|4|H3^Other Allergies^WebPAS\r"                // included
+                + "ZCP|5|H4^Infection Prevention Alerts^WebPAS\r";   // dropped
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResource).hasSize(3);   // How many AllergyIntolerance segments ?
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(5);
+    }    
+
+    private static void commonConfigFileSetup() throws IOException {
+        File configFile = new File(folder, "config.properties");
+        Properties prop = new Properties();
+        prop.put("base.path.resource", "src/main/resources");
+        prop.put("supported.hl7.messages", "ADT_A11"); // Must need to define our weird ADT message
+        prop.put("default.zoneid", "+08:00");
+        // Location of custom (or merely additional) resources
+        prop.put("additional.resources.location",  "src/test/resources/additional_resources");
+        prop.store(new FileOutputStream(configFile), null);
+        System.setProperty(CONF_PROP_HOME, configFile.getParent());
+    }
+
+    // Need custom convert sequence with options that turn off FHIR validation.
+    private static List<BundleEntryComponent> getBundleEntryFromHL7Message(String hl7message) {
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter(); // Testing loading of config which happens once per instantiation
+        String json = ftv.convert(hl7message, OPTIONS); // Need custom options that turn off FHIR validation.
+        assertThat(json).isNotNull();
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        return b.getEntry();
+    }
+
+}

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7IgnoreEmptyTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7IgnoreEmptyTest.java
@@ -1,7 +1,9 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (c) Te Whatu Ora, Health New Zealand, 2023
  *
  * SPDX-License-Identifier: Apache-2.0
+ * 
+ * @author Stuart McGrigor
  */
 
 package io.github.linuxforhealth.hl7.message;
@@ -15,6 +17,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Resource;
@@ -22,8 +25,9 @@ import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.github.linuxforhealth.core.config.ConverterConfiguration;
 import io.github.linuxforhealth.fhir.FHIRContext;
@@ -33,14 +37,13 @@ import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.resource.ResourceReader;
 import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
 
-// This shows how and tests the ability to create a custom Hl7 class
-// Detailed documentation about how this works is found here: 
-// http://javadox.com/ca.uhn.hapi/hapi-base/2.1/ca/uhn/hl7v2/parser/DefaultModelClassFactory.html#packageList(java.lang.String)
-// In this test, the custom class which HL7 uses for validation is placed in src/test/java/org/foo/hl7/custom/message/CUSTOM_PAT.java
-// The custom message is placed in src/test/resources/additional_custom_resources/hl7/message/CUSTOM_PAT.yml
-// The custom packages class is placed in src/test/java/custom_packages/2.6 and references the custom package /org/foo/hl7/custom/
+// This class uses the ability to create ADDITIONAL HL7 messages to convert weird HL7 messages
+// that exercise the new ignoreEmpty Resource Template functionality
+//
+// In these tests, the additional message definitions for (entirely ficticious) ADT^A09 and ^A10 messages
+// are placed in src/test/resources/additional_resources/hl7/message/ADT_A09.yml and ADT_A10.yml
 
-class Hl7CustomMessageTest {
+class Hl7IgnoreEmptyTest {
 
     // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     // NOTE VALIDATION IS INTENTIONALLY NOT USED BECAUSE WE ARE CREATING RESOURCES THAT ARE NOT STANDARD
@@ -78,42 +81,61 @@ class Hl7CustomMessageTest {
         folder.setWritable(true);
     }
 
-    @Test
-    void testCustomPatMessage() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = { "ADT^A09", "ADT^A10" })   // ADT_A09 has ignoreEmpty = true; ADT_A10 doesn't
+    void testIgnoreEmptySegment(String messageType) throws IOException {
 
+        // ADT^A09 can ignore empty AL1 and ZAL segments;  ADT^A01 can ignore empty AL1, and always ignores ZAL segments
+        int alCount = messageType.equals("ADT^A09") ? 0 : 2;
+
+        // Set up the config file
         commonConfigFileSetup();
 
-        String hl7message = "MSH|^~\\&|||||20211005105125||CUSTOM^PAT|1a3952f1-38fe-4d55-95c6-ce58ebfc7f10|P|2.6\n"
-                + "PID|1|100009^^^FAC^MR|100009^^^FAC^MR||DOE^JANE||195001010000|M|||||5734421788|||U\n"
-                + "PRB|1|20211005|10281^LYMPHOID LEUKEMIA NEC^ICD9||||201208061011||201208061011|||||||201208061011\n"
-                + "PRB|2|20211005|11334^ABNORMALITIES OF HAIR^ICD9||||201208071000||201208071000|||||||201208071000\n"
-                + "AL1|50|DA|penicillin|MO||20210629\n"
-                + "AL1|50|MA|cat dander|SV|hives\\R\\ difficult breathing|20210629\n";
+        // An empty AL1 and ZAL Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + "AL1|\r"
+                + "ZAL|\r";
 
         List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
 
-        // Check for the expected resources 1 patient, 2 conditions, 2 allergies
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
-        assertThat(patientResource).hasSize(1); // From PID
+        assertThat(patientResource).hasSize(1); // from PID
 
-        List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
-        assertThat(conditionResource).hasSize(2); // From 2x PRB
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
 
         List<Resource> allergyIntoleranceResource = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
-        assertThat(allergyIntoleranceResource).hasSize(2); // From 2x AL1
+        assertThat(allergyIntoleranceResource).hasSize(alCount); // empty AL1 and ZAL Segments
 
-        // Confirm that no extra resources are created
-        assertThat(e.size()).isEqualTo(5);
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(2 + alCount);
+
+        // We might be done
+        if(alCount == 0)
+            return;
+
+        // Let's take a peek at the 'empty' AL1 Segment
+        assertThat(allergyIntoleranceResource).allSatisfy(rs -> {
+
+                AllergyIntolerance ai = (AllergyIntolerance) rs;
+                assert(ai.hasId());
+                assert(ai.hasClinicalStatus());
+                assert(ai.hasVerificationStatus());
+            });
     }
+
 
     private static void commonConfigFileSetup() throws IOException {
         File configFile = new File(folder, "config.properties");
         Properties prop = new Properties();
         prop.put("base.path.resource", "src/main/resources");
-        prop.put("supported.hl7.messages", "*"); // Must use wild card so the custom resources are found.
+        prop.put("supported.hl7.messages", "ADT_A09, ADT_A10, ADT_A11"); // We're using weird ADT messages
         prop.put("default.zoneid", "+08:00");
-        // Location of custom (or merely additional) resources
-        prop.put("additional.resources.location",  "src/test/resources/additional_custom_resources");
+        // Location of additional resources
+        prop.put("additional.resources.location",  "src/test/resources/additional_resources");
         prop.store(new FileOutputStream(configFile), null);
         System.setProperty(CONF_PROP_HOME, configFile.getParent());
     }

--- a/src/test/java/io/github/linuxforhealth/hl7/resource/HL7FHIRResourceConditionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/resource/HL7FHIRResourceConditionTest.java
@@ -98,10 +98,10 @@ class HL7FHIRResourceConditionTest {
   @Test
   void testResourceConditionSegmentISNULL() {
 
-    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 IS_NULL");
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 NULL");
 
     assertThat(cond.fieldSpec).hasToString("[ZAL.2.1]");
-    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.IS_NULL);
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.NULL);
     assertThat(cond.values).hasSize(0);
   }
 

--- a/src/test/java/io/github/linuxforhealth/hl7/resource/HL7FHIRResourceConditionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/resource/HL7FHIRResourceConditionTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Te Whatu Ora, Health New Zealand, 2023
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.linuxforhealth.hl7.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.linuxforhealth.hl7.message.HL7FHIRResourceCondition;
+
+class HL7FHIRResourceConditionTest {
+
+
+  // These tests check that we can correctly parse Resource.condition string to make it ready for evaluation
+  @Test
+  void testResourceConditionComponentEQUALS() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("AL1.2.1 EQUALS 12");
+
+    assertThat(cond.fieldSpec).hasToString("[AL1.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.EQUALS);
+    assertThat(cond.values).hasSize(1);
+    assertThat(cond.values.get(0)).isEqualTo("12");
+  }
+
+  @Test
+  void testResourceConditionComponentNOTEQUALS() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 NOT_EQUALS 12");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.NOT_EQUALS);
+    assertThat(cond.values).hasSize(1);
+    assertThat(cond.values.get(0)).isEqualTo("12");
+  }
+
+  @Test
+  void testResourceConditionComponentIN() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 IN [L3, L4, H1, H2]");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.IN);
+    assertThat(cond.values).hasSize(4);
+    assertThat(cond.values.get(0)).isEqualTo("L3");
+    assertThat(cond.values.get(1)).isEqualTo("L4");
+    assertThat(cond.values.get(2)).isEqualTo("H1");
+    assertThat(cond.values.get(3)).isEqualTo("H2");
+  }
+
+  @Test
+  void testResourceConditionComponentNOTIN() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 NOT_IN [L3, L4, H1, H2]");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.NOT_IN);
+    assertThat(cond.values).hasSize(4);
+    assertThat(cond.values.get(0)).isEqualTo("L3");
+    assertThat(cond.values.get(1)).isEqualTo("L4");
+    assertThat(cond.values.get(2)).isEqualTo("H1");
+    assertThat(cond.values.get(3)).isEqualTo("H2");
+  }
+
+  @Test
+  void testResourceConditionSubComponentEQUALS() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.3.2.1 EQUALS 13");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.3.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.EQUALS);
+    assertThat(cond.values).hasSize(1).element(0).hasToString("13");
+  }
+
+  @Test
+  void testResourceConditionFieldEQUALS() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2 EQUALS 13");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.EQUALS);
+    assertThat(cond.values).hasSize(1).element(0).hasToString("13");
+  }
+
+  @Test
+  void testResourceConditionSegmentEQUALS() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL EQUALS 13");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.EQUALS);
+    assertThat(cond.values).hasSize(1).element(0).hasToString("13");
+  }
+
+  @Test
+  void testResourceConditionSegmentISNULL() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 IS_NULL");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.IS_NULL);
+    assertThat(cond.values).hasSize(0);
+  }
+
+  @Test
+  void testResourceConditionSegmentNOTNULL() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2.1 NOT_NULL");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2.1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.NOT_NULL);
+    assertThat(cond.values).hasSize(0);
+  }
+
+  @Test
+  void testResourceConditionSegmentFieldRepetition() {
+
+    HL7FHIRResourceCondition cond = new HL7FHIRResourceCondition("ZAL.2(1).1 NOT_NULL");
+
+    assertThat(cond.fieldSpec).hasToString("[ZAL.2(1).1]");
+    assertThat(cond.op).isEqualTo(HL7FHIRResourceCondition.Operator.NOT_NULL);
+    assertThat(cond.values).hasSize(0);
+  }
+
+}

--- a/src/test/resources/additional_resources/hl7/message/ADT_A10.yml
+++ b/src/test/resources/additional_resources/hl7/message/ADT_A10.yml
@@ -22,7 +22,7 @@ resources:
    
     - resourceName: Patient
       segment: PID
-      resourcePath: resource/customPatient
+      resourcePath: resource/Patient
       repeats: false
       isReferenced: true
       additionalSegments:

--- a/src/test/resources/additional_resources/hl7/message/ADT_A10.yml
+++ b/src/test/resources/additional_resources/hl7/message/ADT_A10.yml
@@ -1,9 +1,9 @@
 #
-# (C) Copyright IBM Corp. 2021
+# (C) Te Whatu Ora, Health New Zealand, 2023
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# FHIR Resources to extract from ADT_A09 message
+# FHIR Resources to extract from (pretend) ADT_A10 message
 #
 
 ########################################################################
@@ -22,7 +22,7 @@ resources:
    
     - resourceName: Patient
       segment: PID
-      resourcePath: resource/Patient
+      resourcePath: resource/customPatient
       repeats: false
       isReferenced: true
       additionalSegments:
@@ -44,7 +44,7 @@ resources:
       segment: AL1
       resourcePath: resource/AllergyIntolerance
       repeats: true
-      ignoreEmpty: true      ## We want to test our new ignoreEmpty flag
+      ignoreEmpty: false      ## We want to test our new ignoreEmpty flag
       additionalSegments:
         - MSH
 
@@ -52,6 +52,6 @@ resources:
       segment: ZAL
       resourcePath: resource/AllergyIntolerance
       repeats: true
-      ignoreEmpty: true      ## We want to test our new ignoreEmpty flag on 'Z' segments
+      ignoreEmpty: false      ## We want to test our new ignoreEmpty flag on 'Z' segments
       additionalSegments:
         - MSH

--- a/src/test/resources/additional_resources/hl7/message/ADT_A11.yml
+++ b/src/test/resources/additional_resources/hl7/message/ADT_A11.yml
@@ -1,0 +1,93 @@
+#
+# (C) Te Whatu Ora, Health New Zealand, 2023
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# FHIR Resources to extract from (pretend) ADT_A11 message
+#
+
+########################################################################
+# Used for testing only. Not used in production.
+########################################################################
+
+---
+resources:
+    - resourceName: MessageHeader
+      segment: MSH
+      resourcePath: resource/MessageHeader
+      repeats: false
+      isReferenced: false
+      additionalSegments: 
+        - EVN
+   
+    - resourceName: Patient
+      segment: PID
+      resourcePath: resource/Patient
+      repeats: false
+      isReferenced: true
+      additionalSegments:
+        - PD1
+        - MSH
+
+    - resourceName: Encounter
+      segment: PV1
+      resourcePath: resource/Encounter
+      repeats: false
+      isReferenced: true
+      additionalSegments:
+        - PV2
+        - EVN
+        - MSH
+        - DG1
+
+    - resourceName: AllergyIntolerance
+      segment: AL1
+      resourcePath: resource/AllergyIntolerance
+      repeats: true
+      additionalSegments:
+        - MSH
+
+    # SEGMENT - based condition
+    - resourceName: AllergyIntolerance
+      segment: ZSG
+      resourcePath: resource/AllergyIntolerance   ## The AllergyIntolerance will be badly filled in
+      condition: ZSG EQUALS L2
+      repeats: true
+      additionalSegments:
+        - MSH
+
+    # FIELD - based condition
+    - resourceName: AllergyIntolerance
+      segment: ZFD
+      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      condition: ZFD.2 EQUALS L2
+      repeats: true
+      additionalSegments:
+        - MSH
+
+    # COMPONENT based condition
+    - resourceName: AllergyIntolerance
+      segment: ZCP
+      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      condition: ZCP.2.1 IN [A3, A4, H1, H3]
+      repeats: true
+      additionalSegments:
+        - MSH
+
+    # COMPONENT based condition (repetition)
+    - resourceName: AllergyIntolerance
+      segment: ZCR
+      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      condition: ZCR.2(1).1 IN [A3, A4, H1, H3]
+      repeats: true
+      additionalSegments:
+        - MSH
+
+    # SUB COMPONENT based condition
+    - resourceName: AllergyIntolerance
+      segment: ZSC
+      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      condition: ZSC.2.1.2 IN [A3, A4, H1, H3]
+      repeats: true
+      additionalSegments:
+        - MSH


### PR DESCRIPTION
Sometimes, when dealing with custom HL7 segments the correct FHIR resource for the segment differs
depending upon some value in the segment. For example, in our ZAL custom Alert segment field `ZAL.2.1` denotes the Alert Category, and when the value is one of `A1`, `A3`, `H2` or `H4` then the correct FHIR resource is `AllergyIntolerance`;  for all other 
alert category values the correct FHIR resource is `Flag`

Two resources template entries with suitable `condition` expressions will direct each `ZAL` segment to its correct resource template.

```yml
resources:
    - resourceName: AllergyIntolerance
      segment: ZAL
      resourcePath: resource/AllergyIntoleranceZAL
      repeats: true
      condition: ZAL.2.1 IN [A1, A3, H2, H4]          ## Some of our custom ZAL segments are AllergyIntolerance
      additionalSegments:

    - resourceName: Flag
      segment: ZAL
      resourcePath: resource/FlagZAL
      repeats: true
      condition: ZAL.2.1 NOT_IN [A1, A3, H2, H4]      ## The rest of our custom ZAL segments are more general alert Flags
      additionalSegments:

```
The grammar for the condition field is as follows:

```
   <hl7spec>  EQUALS | NOT_EQUALS | IN | NOT_IN | NULL | NOT_NULL   <value> | [ ... ]
```
**Notes:**
  * hl7spec uses the same dot notation as expression syntax inside templates and can be of the folowing forms:
    - SEGMENT
    - SEGMENT.FIELD
    - SEGMENT.FIELD.COMPONENT
    - SEGMENT.FIELD.COMPONENT.SUBCOMPONENT
    - SEGMENT.FIELD(REPETITION)
    - SEGMENT.FIELD(REPETITION).COMPONENT
    - SEGMENT.FIELD(REPETITION).COMPONENT.SUBCOMPONENT
  
    `ZAL`, `ZAL.2`,  `ZAL.2.1`,  `ZAL.2.1.2`, `PID.14(1).2` & `PID.14(1).2.1` are all valid values for hl7spec.
  
  * The SEGMENT part of hl7spec **MUST** match the value of the `segment` field.

  * EQUALS and NOT_EQUALS expressions only accept a single value on the right-hand side of the expression.
  
  * IN and NOT_IN expressions only accept a list of values, delimited by comma, in square brackets on the right-hand side of the expression.
  
  * NULL and NOT_NULL do not accept any value.

  * The condition expression cannot be much more complex, as there are no context variables available at evaluation time.

**Examples**:
  *  `PID.5.1.2 EQUALS van`
  *  `ZAL.2.1.3 NOT_NULL`
  *  `ZAL.2(1).1 NULL`
  *  `ZAL.3.1 IN [A3, A4, H1, H3, FA, DA]`
  *  `ZAL.3.1 NOT_IN [A2, F3, DA]`
  *  `ZAL.2 EQUALS A4`
  *  `ZAL NOT_EQUALS H2`
  
