### PR TITLE
510: support adding extension to FHIR primitives

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/util/ExpressionUtility.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/util/ExpressionUtility.java
@@ -122,9 +122,12 @@ public class ExpressionUtility {
     }
 
     private static String getKeyName(String key, String suffix) {
+        boolean hasLeadingUnderscore = StringUtils.startsWith(key, "_");
         String[] keyComponents = StringUtils.split(key, "_", 2);
         if (keyComponents.length == 2 && KEY_NAME_SUFFIX.equalsIgnoreCase(keyComponents[1])) {
             return keyComponents[0] + suffix;
+        } else if(hasLeadingUnderscore) {
+            return "_" + keyComponents[0];
         } else {
             return keyComponents[0];
         }

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7CustomMessageTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7CustomMessageTest.java
@@ -17,8 +17,10 @@ import java.util.Properties;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.codesystems.AdministrativeGender;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -96,6 +98,10 @@ class Hl7CustomMessageTest {
         // Check for the expected resources 1 patient, 2 conditions, 2 allergies
         List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
         assertThat(patientResource).hasSize(1); // From PID
+        Patient patient = (Patient) patientResource.get(0);
+        assertThat(patient.getGenderElement().getExtension()).hasSize(1);
+        assertThat(patient.getGenderElement().getExtension().get(0).getUrl()).isEqualTo("gender-extension");
+        assertThat(patient.getGender().getDisplay()).isEqualTo(AdministrativeGender.MALE.getDisplay());
 
         List<Resource> conditionResource = ResourceUtils.getResourceList(e, ResourceType.Condition);
         assertThat(conditionResource).hasSize(2); // From 2x PRB

--- a/src/test/resources/additional_custom_resources/hl7/message/CUSTOM_PAT.yml
+++ b/src/test/resources/additional_custom_resources/hl7/message/CUSTOM_PAT.yml
@@ -20,7 +20,7 @@ resources:
    
     - resourceName: Patient
       segment: PID
-      resourcePath: resource/Patient
+      resourcePath: resource/CustomPatient
       repeats: false
       isReferenced: true
       additionalSegments:

--- a/src/test/resources/additional_custom_resources/hl7/resource/CustomPatient.yml
+++ b/src/test/resources/additional_custom_resources/hl7/resource/CustomPatient.yml
@@ -1,0 +1,421 @@
+#
+# (C) Copyright IBM Corp. 2020, 2022
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+resourceType: Patient
+# Represents data that needs to be extracted for a Patient Resource in FHIR
+# reference: https://www.hl7.org/fhir/patient.html
+id:
+  type: STRING
+  valueOf: "GeneralUtils.generateResourceId()"
+  expressionType: JEXL
+
+identifier_1:
+  valueOf: datatype/Identifier_SystemID
+  generateList: true
+  expressionType: resource
+  specs: PID.3
+  vars:
+    assignerSystem: String, PID.3.4
+
+# When the Coverage.subscriber from IN1.17 is NOT self use PID.19 for SSN identifier
+identifier_2a:
+  condition: $valueIn NOT_NULL && $subscriberValue NOT_EQUALS SEL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: CLEAN_SSN, PID.19 # subscriber SSN
+    subscriberValue: String, IN1.17.1 # subscriber relationship
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: SS
+    display: Social Security number
+# There is no text for PID.19
+
+# When IN1.17 is empty and the Coverage.subscriber from IN2.72 is NOT self use PID.19 for SSN identifier
+identifier_2b:
+  condition: $valueIn NOT_NULL && $valueIN117 NULL && $subscriberValue NOT_EQUALS 01
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: CLEAN_SSN, PID.19 # subscriber SSN
+    subscriberValue: String, IN2.72 # subscriber relationship
+    valueIN117: IN1.17.1
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: SS
+    display: Social Security number
+# There is no text for PID.19
+
+# When IN1.17 and IN2.72 are both empty use PID.19 for SSN identifier
+# (Required edge case because NOT_EQUALS is not the same as NULL)
+identifier_2c:
+  condition: $valueIn NOT_NULL && $valueIN117 NULL && $valueIN272 NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: CLEAN_SSN, PID.19 # subscriber SSN
+    valueIN272: String, IN2.72 # subscriber relationship
+    valueIN117: IN1.17.1
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: SS
+    display: Social Security number
+# There is no text for PID.19
+
+# When the Coverage.subscriber from IN1.17 IS self use PID.19 / IN2.2 for SSN identifier
+identifier_2d:
+  condition: $valueIn NOT_NULL && $subscriberValue EQUALS SEL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: CLEAN_SSN, PID.19 | IN2.2 # subscriber SSN
+    subscriberValue: String, IN1.17 # subscriber relationship
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: SS
+    display: Social Security number
+# There is no text for PID.19
+
+# When IN1.17 is empty and the Coverage.subscriber from IN2.72 IS self use PID.19 / IN2.2 for SSN identifier
+identifier_2e:
+  condition: $valueIn NOT_NULL && $valueIN117 NULL && $subscriberValue EQUALS 01
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: CLEAN_SSN, PID.19 | IN2.2 # subscriber SSN
+    valueIN117: IN1.17.1
+    subscriberValue: String, IN2.72 # subscriber relationship
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: SS
+    display: Social Security number
+# There is no text for PID.19
+
+identifier_3:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  # There is no authority for PID.20
+  expressionType: resource
+  # Gets the Driver's license from PID.20, formats and adds it as an ID
+  vars:
+    valueIn: String, PID.20.1
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+    code: DL
+    display: Driver's license number
+# There is no text for PID.20
+
+identifier_4:
+  condition: $mrgIdentifier NOT_NULL
+  valueOf: datatype/Identifier_SystemID
+  generateList: true
+  expressionType: resource
+  specs: MRG.1
+  constants:
+    use: old
+    mrgIdentifier: MRG.1
+# Add the old MR # from the MRG segment
+
+# identifier_5a and _5b are two parts to complex logic
+# Only include IN1.49 as an identifier when the subscriber is not self AND a relatedPerson is created
+identifier_5a:
+  condition: $valueIn NOT_NULL && $subscriberValue NOT_EQUALS SEL && $createRelatedPerson EQUALS TRUE
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  specs: IN1.49
+  vars:
+    valueIn: String, IN1.49.1
+    systemCX: IN1.49.4
+    code: IN1.49.5
+    subscriberValue: String, IN1.17.1 # subscriber relationship
+    createRelatedPerson: RELATED_PERSON_NEEDED_IN117, IN1.17
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+
+identifier_5b:
+  condition: $valueIn NOT_NULL && $valueIN117 NULL && $subscriberValue NOT_EQUALS 01 && $createRelatedPerson EQUALS TRUE
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  specs: IN1.49
+  vars:
+    valueIn: String, IN1.49.1
+    systemCX: IN1.49.4
+    code: IN1.49.5
+    subscriberValue: String, IN2.72 # subscriber relationship
+    createRelatedPerson: RELATED_PERSON_NEEDED_IN272, IN2.72
+    valueIN117: IN1.17.1
+  constants:
+    system: http://terminology.hl7.org/CodeSystem/v2-0203
+
+# identifier_6a and _6b are two parts to complex logic
+# Only include when the subscriber is self, uses IN1.17
+identifier_6a:
+  condition: $valueIn NOT_NULL && $valueIN117 EQUALS SEL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.61 | IN1.36
+    valueIN117: String, IN1.17.1 # subscriber relationship
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MB"
+    display: "Member Number"
+
+# Only include when the subscriber is self
+# IN2.72 only gets used if IN1.17 priority is empty (see identifier_6a)
+identifier_6b:
+  condition: $valueIn NOT_NULL && $valueIN117 NULL && $valueIN272 EQUALS 01
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.61 | IN1.36
+    valueIN117: IN1.17.1
+    valueIN272: String, IN2.72 # subscriber relationship
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MB"
+    display: "Member Number"
+
+identifier_7:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.8
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MA"
+    display: "Patient Medicaid number"
+
+identifier_8:
+  condition: $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  expressionType: resource
+  vars:
+    valueIn: IN2.6
+    # No systemCX set for this identifier
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "MC"
+    display: "Patient's Medicare number"
+
+name:
+  valueOf: datatype/HumanName
+  generateList: true
+  expressionType: resource
+  specs: PID.5
+
+gender:
+  type: ADMINISTRATIVE_GENDER
+  valueOf: PID.8
+  expressionType: HL7Spec
+
+_gender:
+  expressionType: nested
+  expressionsMap:
+    extension_1:
+      generateList: true
+      expressionType: nested
+      expressionsMap:
+        url:
+          type: STRING
+          value: "gender-extension"
+        valueBoolean:
+          type: STRING
+          valueOf: "true"
+
+address:
+  valueOf: datatype/Address
+  generateList: true
+  expressionType: resource
+  specs: PID.11
+  vars:
+    # Used in Address to create district for patient address
+    # In future, they could be processed in a DataValueResolver.
+    distPatientCounty: String, PID.12
+    distAddressCountyParish: String, PID.11.9
+    distPatient: PID
+
+telecom_1:
+  condition: $pid14 NOT_NULL
+  valueOf: datatype/ContactPoint
+  generateList: true
+  expressionType: resource
+  specs: PID.14
+  vars:
+    pid14: PID.14
+  constants:
+    use: work
+
+telecom_2:
+  condition: $pid13 NOT_NULL
+  valueOf: datatype/ContactPoint
+  generateList: true
+  expressionType: resource
+  specs: PID.13
+  vars:
+    pid13: PID.13
+  constants:
+    use: home
+
+# The yaml is processed in reverse order, therefore
+# Put the PID.13 last in yaml so it is first to be processed
+birthDate:
+  type: DATE
+  valueOf: PID.7
+  expressionType: HL7Spec
+
+multipleBirthBoolean_1:
+  condition: $multBool NOT_NULL && $multInt NULL
+  type: BOOLEAN
+  valueOf: PID.24
+  expressionType: HL7Spec
+  vars:
+    multBool: PID.24
+    multInt: PID.25
+
+multipleBirthBoolean_2:
+  condition: $multBool EQUALS N
+  type: BOOLEAN
+  valueOf: PID.24
+  expressionType: HL7Spec
+  vars:
+    multBool: String, PID.24
+    multInt: PID.25
+
+multipleBirthInteger_1:
+  condition: $multBool NULL && $multInt NOT_NULL
+  type: INTEGER
+  valueOf: PID.25
+  expressionType: HL7Spec
+  vars:
+    multBool: String, PID.24
+    multInt: PID.25
+
+multipleBirthInteger_2:
+  condition: $multBool EQUALS Y && $multInt NOT_NULL
+  type: INTEGER
+  valueOf: PID.25
+  expressionType: HL7Spec
+  vars:
+    multBool: String, PID.24
+    multInt: PID.25
+
+deceasedBoolean:
+  condition: $deceasedBool NOT_NULL && $deceasedDateTime NULL
+  type: BOOLEAN
+  valueOf: PID.30
+  expressionType: HL7Spec
+  vars:
+    deceasedBool: PID.30
+    deceasedDateTime: PID.29
+
+deceasedDateTime:
+  condition: $dateTimeIn NOT_NULL
+  type: STRING
+  valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
+  expressionType: JEXL
+  vars:
+    dateTimeIn: PID.29
+
+maritalStatus:
+  valueOf: datatype/CodeableConcept
+  expressionType: resource
+  condition: $coding NOT_NULL
+  vars:
+    coding: MARITAL_STATUS, PID.16
+    text: String, PID.16.2
+
+generalPractitioner:
+  condition: $practitionerVal NOT_NULL
+  valueOf: resource/Practitioner
+  generateList: true
+  expressionType: reference
+  specs: PD1.4
+  vars:
+    practitionerVal: PD1.4
+
+extension:
+  generateList: true
+  expressionType: nested
+  expressions:
+    - condition: $value NOT_NULL
+      valueOf: extension/Extension
+      expressionType: resource
+      vars:
+        value: String, PID.6.1
+      constants:
+        KEY_NAME_SUFFIX: String
+        urlValue: mothersMaidenName
+
+    - expressionType: nested
+      expressionsMap:
+        url:
+          type: SYSTEM_URL
+          value: "religion"
+        valueCodeableConcept:
+          valueOf: datatype/CodeableConcept
+          expressionType: resource
+          condition: $coding NOT_NULL
+          vars:
+            coding: RELIGIOUS_AFFILIATION_CC, PID.17
+            text: String, PID.17.2
+
+    - expressionType: nested
+      specs: PID.10
+      generateList: true
+      expressionsMap:
+        url:
+          type: SYSTEM_URL
+          value: "race"
+        valueCodeableConcept:
+          valueOf: datatype/CodeableConcept
+          expressionType: resource
+          specs: CWE
+
+communication:
+  condition: $language NOT_NULL
+  valueOf: secondary/Communication
+  expressionType: resource
+  vars:
+    language: PID.15
+
+active:
+  condition: $mrgSegment NOT_NULL
+  type: BOOLEAN
+  valueOf: true
+  vars:
+    mrgSegment: MRG
+
+link:
+  generateList: true
+  evaluateLater: true
+  expressionType: nested
+  condition: $mrgSegment NOT_NULL
+  vars:
+    mrgSegment: MRG
+  expressionsMap:
+    type:
+      type: STRING
+      valueOf: "replaces"
+    other:
+      required: true
+      valueOf: resource/PatientMRG
+      expressionType: reference


### PR DESCRIPTION
Provides a fix for #510 

This PR updates `Expression.getKeyName` to maintain a leading underscore if the key name includes one.  It adds a new `CustomPatient` resource used with the `CUSTOM_PAT` and updates the `HL7CustomMessageTest` to checks that the primitive is converted along with the extension.