### PR TITLE
Fix for issue: StringIndexOutOfBoundsException is thrown while converting NTE segments with additional dash

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java
@@ -185,7 +185,9 @@ public class HL7ToFHIRConverter {
                         output.append(line);
                     } else {
                         int firstDash = line.indexOf("-");
-                        output.append(line.substring(0, firstDash + 5));
+                        // Added fail-safe check if the content after "-" is less than 5 characters
+                        int lastContentIndex = Math.min(firstDash + 5, line.length());
+                        output.append(line.substring(0, lastContentIndex));
                     }
                     output.append("\n");
                 }

--- a/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
+++ b/src/test/java/io/github/linuxforhealth/FHIRConverterTest.java
@@ -324,6 +324,25 @@ class FHIRConverterTest {
         assertThat(coding.getSystem()).isEqualTo("http://terminology.hl7.org/CodeSystem/v2-0163");
     }
 
+    @Test
+    void test_nte_split_print_structure_on_dash(){
+        String hl7message = "MSH|^~\\&|Lab|Lab|GeneralHosp|MySys|202408160605-1000||ORU^R01|218374717|P|2.3|\n" +
+                "PID|1||||||||123|\n" +
+                "ORC|RE||123|\n" +
+                "OBR|1||123|456||||||||||||||||||202408160605-1000|||F|||||\n" +
+                "OBX|1|NM|1894^Non-HDL Cholesterol, calc^43396-1^1894||180|mg/dL|<130 optimal|H|||F|||202408160605-1000|12D0620420^General's Hospital|%AUTO^%AUTO^2|\n" +
+                "NTE|1|#9151E| |\n" +
+                "NTE|2|#9151E|LDL and Non-HDL Cholesterol goals based on level of risk:|\n" +
+                "NTE|3|#9151E| |\n" +
+                "NTE|4|#9151E|                                          LDL           NON-HDL|\n" +
+                "NTE|5|#9151E|                                          ------------------------|\n" +
+                "SPM|1|YF123321||123456^Specimen (specimen)^SCT|||||||||||||202408180502-1000|202408180531-1000|";
+
+        Bundle b = ftv.convertToBundle(hl7message, OPTIONS, null);
+
+        assertThat(b.getType()).isEqualTo(BundleType.COLLECTION);
+    }
+
     private void verifyResult(String json, BundleType expectedBundleType) {
         verifyResult(json, expectedBundleType, true);
     }


### PR DESCRIPTION
Fix for issue: StringIndexOutOfBoundsException is thrown while converting NTE segments with additional dash
[https://github.com/LinuxForHealth/hl7v2-fhir-converter/issues/512](url)

In HL7ToFHIRConverter class, Method 'getHl7Message' has code for logging HL7 message structure. In order to optimize the content. It takes subset of each line based on first occurrence of "-" and 5 chars more. Issue occurs when there are multiple repeating segments like NTE and HL7Message.printStructure does not follow {Segment} - start prefix on these repeating segments. and these sgement has "-" in content.

For now added fail-safe check if indexof Dash + 5 chars is more then length of line then take line length as input.